### PR TITLE
extensions/desktop: don't preload bindtextdomain for wine snaps

### DIFF
--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -79,7 +79,7 @@ export SNAP_LAUNCHER_ARCH_TRIPLET="$ARCH"
 if ! grep -qs "^\s*confinement:\s*classic\s*" "$SNAP/meta/snap.yaml"; then
   if [ -f "$SNAP/lib/$ARCH/bindtextdomain.so" ]; then
     export LD_PRELOAD="$LD_PRELOAD:$SNAP/\$LIB/bindtextdomain.so"
-  elif [ -f "$SNAP/gnome-platform/lib/$ARCH/bindtextdomain.so" ]; then
+  elif [ -f "$SNAP/gnome-platform/lib/$ARCH/bindtextdomain.so" ] && ! grep -qs "^\s*default-provider:\s*wine-platform-runtime*" "$SNAP/meta/snap.yaml"; then
     export LD_PRELOAD="$LD_PRELOAD:$SNAP/gnome-platform/\$LIB/bindtextdomain.so"
   fi
 fi


### PR DESCRIPTION
fixes that #3738 couldn't

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
