### PR TITLE
feat(providers): use core24 buildd daily image for devel

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.1
 craft-parts==1.26.0
-craft-providers==1.20.1
+craft-providers==1.21.0
 craft-store==2.5.0
 Deprecated==1.2.14
 distro==1.8.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.2
 craft-parts==1.26.1
-craft-providers==1.20.1
+craft-providers==1.21.0
 craft-store==2.6.0
 cryptography==41.0.7
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-archives==1.1.3
 craft-cli==2.5.0
 craft-grammar==1.1.2
 craft-parts==1.26.1
-craft-providers==1.20.1
+craft-providers==1.21.0
 craft-store==2.6.0
 cryptography==41.0.7
 Deprecated==1.2.14

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -43,6 +43,7 @@ SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core20": bases.BuilddBaseAlias.FOCAL,
     "core22": bases.BuilddBaseAlias.JAMMY,
     "core24": bases.BuilddBaseAlias.NOBLE,
+    "devel": bases.BuilddBaseAlias.NOBLE,
 }
 
 # TODO: move to a package data file for shellcheck and syntax highlighting

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -42,7 +42,7 @@ SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core18": bases.BuilddBaseAlias.BIONIC,
     "core20": bases.BuilddBaseAlias.FOCAL,
     "core22": bases.BuilddBaseAlias.JAMMY,
-    "devel": bases.BuilddBaseAlias.DEVEL,
+    "devel": bases.BuilddBaseAlias.NOBLE,
 }
 
 # TODO: move to a package data file for shellcheck and syntax highlighting

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -43,7 +43,7 @@ SNAPCRAFT_BASE_TO_PROVIDER_BASE = {
     "core20": bases.BuilddBaseAlias.FOCAL,
     "core22": bases.BuilddBaseAlias.JAMMY,
     "core24": bases.BuilddBaseAlias.NOBLE,
-    "devel": bases.BuilddBaseAlias.NOBLE,
+    "devel": bases.BuilddBaseAlias.DEVEL,
 }
 
 # TODO: move to a package data file for shellcheck and syntax highlighting


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

When using `build-base: devel`, use the `core24` buildd daily image instead of the `devel` daily image.

There is no change in how a user defines their `snapcraft.yaml`.  Once the `core24` base is available in the beta channel, then we can allow users to use `base: core24`.

There are some intermittent problems with launching buildd daily images, see https://github.com/canonical/craft-providers/issues/498.

Fixes #4519
(CRAFT-2390)