### PR TITLE
fix(tests): upload a larger snap

### DIFF
--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -3,7 +3,7 @@ summary: Test the store workflow
 manual: true
 
 environment:
-  SNAP: dump-hello
+  SNAP: "/snapcraft/tests/spread/plugins/v2/snaps/autotools-hello"
   SNAPCRAFT_STORE_CREDENTIALS/ubuntu_one: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"
   SNAPCRAFT_STORE_CREDENTIALS/legacy: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_LEGACY})"
   SNAPCRAFT_STORE_CREDENTIALS/candid: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_CANDID})"
@@ -30,16 +30,15 @@ prepare: |
   # notify the store team if you need to use a different value when
   # working with the production store.     
   name="test-snapcraft-$(shuf -i 1-1000000000 -n 1)"
-  set_base "../snaps/$SNAP/snap/snapcraft.yaml"
-  set_name "../snaps/$SNAP/snap/snapcraft.yaml" "${name}"
-  set_grade "../snaps/$SNAP/snap/snapcraft.yaml" stable
+  set_name "$SNAP/snap/snapcraft.yaml" "${name}"
+  set_grade "$SNAP/snap/snapcraft.yaml" stable
 
   # Build what we have and verify the snap runs as expected.
-  cd "../snaps/$SNAP"
+  cd "$SNAP"
   snapcraft
 
 restore: |
-  cd "../snaps/$SNAP"
+  cd "$SNAP"
   snapcraft clean
   rm -f ./*.snap
 
@@ -49,7 +48,7 @@ restore: |
 
 execute: |
   # Get information about our snap.
-  cd "../snaps/$SNAP"
+  cd "$SNAP"
   snap_file=$(ls ./*.snap)
   snap_name=$(grep "name: " snap/snapcraft.yaml | sed -e "s/name: \(.*$\)/\1/")
 


### PR DESCRIPTION
This works around the review-tools issue triggered by the squasfs block size change in snapd.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
