### PR TITLE
fix(tests): expect the proper libpng version in core24 linter test

### DIFF
--- a/tests/spread/core24/linters/library-unused/expected_linter_output.txt
+++ b/tests/spread/core24/linters/library-unused/expected_linter_output.txt
@@ -2,5 +2,5 @@ Running linters...
 Running linter: classic
 Running linter: library
 Lint warnings:
-- library: libpng16.so.16: unused library 'usr/lib/x86_64-linux-gnu/libpng16.so.16.37.0'. (https://snapcraft.io/docs/linters-library)
+- library: libpng16.so.16: unused library 'usr/lib/x86_64-linux-gnu/libpng16.so.16.41.0'. (https://snapcraft.io/docs/linters-library)
 Creating snap package...


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
This fixes `google:ubuntu-22.04-64:tests/spread/core24/linters/library-unused`