### PR TITLE
fix(tests): expect the proper caca versions core24 classic linter test

### DIFF
--- a/tests/spread/core24/linters/classic/expected_linter_output.txt
+++ b/tests/spread/core24/linters/classic/expected_linter_output.txt
@@ -7,7 +7,7 @@ Lint warnings:
 - classic: usr/bin/toilet: ELF rpath should be set to '$ORIGIN/../lib/x86_64-linux-gnu:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
 - classic: usr/lib/x86_64-linux-gnu/caca/libgl_plugin.so.0.0.0: ELF rpath should be set to '$ORIGIN/..:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
 - classic: usr/lib/x86_64-linux-gnu/caca/libx11_plugin.so.0.0.0: ELF rpath should be set to '$ORIGIN/..:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
-- classic: usr/lib/x86_64-linux-gnu/libcaca++.so.0.99.19: ELF rpath should be set to '$ORIGIN:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
-- classic: usr/lib/x86_64-linux-gnu/libcaca.so.0.99.19: ELF rpath should be set to '$ORIGIN:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
-- classic: usr/lib/x86_64-linux-gnu/libslang.so.2.3.2: ELF rpath should be set to '/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
+- classic: usr/lib/x86_64-linux-gnu/libcaca++.so.0.99.20: ELF rpath should be set to '$ORIGIN:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
+- classic: usr/lib/x86_64-linux-gnu/libcaca.so.0.99.20: ELF rpath should be set to '$ORIGIN:/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
+- classic: usr/lib/x86_64-linux-gnu/libslang.so.2.3.3: ELF rpath should be set to '/snap/core24/current/lib/x86_64-linux-gnu'. (https://snapcraft.io/docs/linters-classic)
 Creating snap package...


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
