### PR TITLE
feat: use craft-application project variables

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -110,6 +110,7 @@ APP_METADATA = AppMetadata(
     ProjectClass=models.Project,
     BuildPlannerClass=SnapcraftBuildPlanner,
     source_ignore_patterns=["*.snap"],
+    project_variables=["version", "grade"],
 )
 
 

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -415,8 +415,6 @@ class Project(models.Project):
     name: ProjectName  # type: ignore[assignment]
     build_base: Optional[str]
     compression: Literal["lzo", "xz"] = "xz"
-    # TODO: ensure we have a test for version being retrieved using adopt-info
-    # snapcraft's `version` is more general than craft-application
     version: Optional[ProjectVersion]  # type: ignore[assignment]
     donation: Optional[Union[str, UniqueStrList]]
     # snapcraft's `source_code` is more general than craft-application


### PR DESCRIPTION
Define `version` and `grade` as craft-application project variables that can
be updated using craftctl.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
