### PR TITLE
fix(project): fix core24/devel validation

### DIFF
--- a/snapcraft/projects.py
+++ b/snapcraft/projects.py
@@ -591,14 +591,14 @@ class Project(ProjectModel):
             raise ValueError("grade must be 'devel' when build-base is 'devel'")
         return values
 
-    @pydantic.validator("base", always=True)
+    @pydantic.root_validator()
     @classmethod
-    def _validate_base(cls, base, values):
+    def _validate_base(cls, values):
         """Not allowed to use unstable base without devel build-base."""
         if values.get("base") == "core24" and values.get("build_base") != "devel":
             raise ValueError("build-base must be 'devel' when base is 'core24'")
 
-        return base
+        return values
 
     @pydantic.validator("build_base", always=True)
     @classmethod

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -612,6 +612,12 @@ class TestProjectValidation:
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(project_yaml_data(build_base="devel", grade="stable"))
 
+    def test_project_development_base_error(self, project_yaml_data):
+        error = "build-base must be 'devel' when base is 'core24'"
+
+        with pytest.raises(errors.ProjectValidationError, match=error):
+            Project.unmarshal(project_yaml_data(base="core24"))
+
     def test_project_global_plugs_warning(self, project_yaml_data, emitter):
         data = project_yaml_data(plugs={"desktop": None, "desktop-legacy": None})
         Project.unmarshal(data)


### PR DESCRIPTION
The regular validator's 'values' parameter contains only the fields that have been validated so far (a bad footgun).

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----


