### PR TITLE
feat: adopt more fields from the appstream metadata file

### DIFF
--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -106,7 +106,7 @@ def extract(relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
     issues = _get_urls_from_xml_element(dom.findall("url"), "bugtracker")
     donation = _get_urls_from_xml_element(dom.findall("url"), "donation")
     website = _get_urls_from_xml_element(dom.findall("url"), "homepage")
-    source_code = _get_urls_from_xml_element(dom.findall("url"), "vcs-browser")
+    source_code = _get_urls_from_xml_element(dom.findall("url"), "vcs-browser")[0]
 
     desktop_file_paths = []
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))

--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -102,11 +102,12 @@ def extract(relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
     version = _get_latest_release_from_nodes(dom.findall("releases/release"))
     license = _get_value_from_xml_element(dom, "project_license")
     contact = _get_value_from_xml_element(dom, "update_contact")
-    issues = _get_urls_from_xml_element(dom.findall('url'), "bugtracker")
-    donation = _get_urls_from_xml_element(dom.findall('url'), "donation")
-    website = _get_urls_from_xml_element(dom.findall('url'), "homepage")
-    source_code = _get_urls_from_xml_element(dom.findall('url'), "vcs-browser")
-    
+
+    issues = _get_urls_from_xml_element(dom.findall("url"), "bugtracker")
+    donation = _get_urls_from_xml_element(dom.findall("url"), "donation")
+    website = _get_urls_from_xml_element(dom.findall("url"), "homepage")
+    source_code = _get_urls_from_xml_element(dom.findall("url"), "vcs-browser")
+
     desktop_file_paths = []
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))
     # if there are no launchables, use the appstream id to take into
@@ -172,16 +173,18 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
         return "\n".join([n.strip() for n in node.text.splitlines()]).strip()
     return None
 
+
 def _get_urls_from_xml_element(nodes, type) -> Optional[List[str]]:
     urls = {}
     for url in nodes:
         if url is not None and url.text:
-            url_type = url.get('type')
+            url_type = url.get("type")
             url_value = url.text
             urls.setdefault(url_type, []).append(url_value)
     if type in urls.keys():
         return urls[type]
     return None
+
 
 def _get_latest_release_from_nodes(nodes) -> Optional[str]:
     for node in nodes:

--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -100,7 +100,13 @@ def extract(relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
     description = _get_value_from_xml_element(dom, "description")
     title = _get_value_from_xml_element(dom, "name")
     version = _get_latest_release_from_nodes(dom.findall("releases/release"))
-
+    license = _get_value_from_xml_element(dom, "project_license")
+    contact = _get_value_from_xml_element(dom, "update_contact")
+    issues = _get_urls_from_xml_element(dom.findall('url'), "bugtracker")
+    donation = _get_urls_from_xml_element(dom.findall('url'), "donation")
+    website = _get_urls_from_xml_element(dom.findall('url'), "homepage")
+    source_code = _get_urls_from_xml_element(dom.findall('url'), "vcs-browser")
+    
     desktop_file_paths = []
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))
     # if there are no launchables, use the appstream id to take into
@@ -125,6 +131,12 @@ def extract(relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
         description=description,
         version=version,
         icon=icon,
+        license=license,
+        contact=contact,
+        issues=issues,
+        donation=donation,
+        website=website,
+        source_code=source_code,
         desktop_file_paths=desktop_file_paths,
     )
 
@@ -160,6 +172,16 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
         return "\n".join([n.strip() for n in node.text.splitlines()]).strip()
     return None
 
+def _get_urls_from_xml_element(nodes, type) -> Optional[List[str]]:
+    urls = {}
+    for url in nodes:
+        if url is not None and url.text:
+            url_type = url.get('type')
+            url_value = url.text
+            urls.setdefault(url_type, []).append(url_value)
+    if type in urls.keys():
+        return urls[type]
+    return None
 
 def _get_latest_release_from_nodes(nodes) -> Optional[str]:
     for node in nodes:

--- a/snapcraft/meta/extracted_metadata.py
+++ b/snapcraft/meta/extracted_metadata.py
@@ -47,3 +47,21 @@ class ExtractedMetadata:
 
     desktop_file_paths: List[str] = field(default_factory=list)
     """The extracted application desktop file paths."""
+    
+    license: Optional[str] = None
+    """The extracted package license"""
+    
+    contact: Optional[str] = None
+    """The extracted package contact"""
+    
+    donation: Optional[List[str]] = None
+    """The extracted package donation"""
+    
+    issues: Optional[List[str]] = None
+    """The extracted package issues"""
+    
+    source_code: Optional[str] = None
+    """The extracted package source code"""
+    
+    website: Optional[List[str]] = None
+    """The extracted package website"""

--- a/snapcraft/meta/extracted_metadata.py
+++ b/snapcraft/meta/extracted_metadata.py
@@ -47,21 +47,21 @@ class ExtractedMetadata:
 
     desktop_file_paths: List[str] = field(default_factory=list)
     """The extracted application desktop file paths."""
-    
+
     license: Optional[str] = None
     """The extracted package license"""
-    
+
     contact: Optional[str] = None
     """The extracted package contact"""
-    
+
     donation: Optional[List[str]] = None
     """The extracted package donation"""
-    
+
     issues: Optional[List[str]] = None
     """The extracted package issues"""
-    
+
     source_code: Optional[str] = None
     """The extracted package source code"""
-    
+
     website: Optional[List[str]] = None
     """The extracted package website"""

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -65,7 +65,7 @@ class TestAppstreamData:
                 {"type": "vcs-browser"},
                 "source_code",
                 "test-source",
-                ["test-source"],
+                "test-source",
             ),
         ],
     )
@@ -694,7 +694,7 @@ class TestAppstreamContent:
         assert metadata.website == ["https://johnfactotum.github.io/foliate/"]
         assert metadata.issues == ["https://github.com/johnfactotum/foliate/issues"]
         assert metadata.donation == ["https://www.buymeacoffee.com/johnfactotum"]
-        assert metadata.source_code == ["https://github.com/johnfactotum/foliate"]
+        assert metadata.source_code == "https://github.com/johnfactotum/foliate"
 
     def test_appstream_parse_error(self):
         file_name = "snapcraft_legacy.appdata.xml"

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -690,11 +690,64 @@ class TestAppstreamContent:
         Path(file_name).write_text(content)
 
         metadata = appstream.extract(file_name, workdir=".")
+
         assert metadata is not None
         assert metadata.website == ["https://johnfactotum.github.io/foliate/"]
         assert metadata.issues == ["https://github.com/johnfactotum/foliate/issues"]
         assert metadata.donation == ["https://www.buymeacoffee.com/johnfactotum"]
         assert metadata.source_code == "https://github.com/johnfactotum/foliate"
+
+    def test_appstream_url(self):
+        file_name = "foliate.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+              <component type="desktop">
+              <id>com.github.maoschanz.drawing</id>
+              <metadata_license>CC0-1.0</metadata_license>
+              <project_license>GPL-3.0-or-later</project_license>
+              <content_rating type="oars-1.1"/>
+              <name>Drawing</name>
+              <url type="homepage">https://johnfactotum.github.io/foliate/</url>
+              <url type="vcs-browser">https://github.com/johnfactotum/foliate</url>
+              </component>
+            """
+        )
+        Path(file_name).write_text(content)
+
+        metadata = appstream.extract(file_name, workdir=".")
+        assert metadata is not None
+        assert metadata.source_code == "https://github.com/johnfactotum/foliate"
+
+    def test_appstream_with_multiple_lists(self):
+        file_name = "foliate.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+              <component type="desktop">
+              <id>com.github.maoschanz.drawing</id>
+              <metadata_license>CC0-1.0</metadata_license>
+              <project_license>GPL-3.0-or-later</project_license>
+              <content_rating type="oars-1.1"/>
+              <name>Drawing</name>
+              <url type="homepage">https://johnfactotum.github.io/foliate/</url>
+              <url type="vcs-browser">https://github.com/johnfactotum/foliate</url>
+              <url type="bugtracker">https://github.com/alainm23/planify/issues</url>
+              <url type="bugtracker">https://github.com/johnfactotum/foliate/issues</url>
+              </component>
+        """
+        )
+        Path(file_name).write_text(content)
+
+        metadata = appstream.extract(file_name, workdir=".")
+        assert metadata is not None
+        assert metadata.issues == [
+            "https://github.com/alainm23/planify/issues",
+            "https://github.com/johnfactotum/foliate/issues",
+        ]
+        assert metadata.source_code == "https://github.com/johnfactotum/foliate"
+        assert metadata.website == ["https://johnfactotum.github.io/foliate/"]
+        assert metadata.donation is None
 
     def test_appstream_parse_error(self):
         file_name = "snapcraft_legacy.appdata.xml"

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -49,6 +49,12 @@ class TestAppstreamData:
             ("icon", {"type": "local"}, "icon", "/icon.png", "/icon.png"),
             ("id", {}, "common_id", "test-id", "test-id"),
             ("name", {}, "title", "test-title", "test-title"),
+            ("project_license", {}, "license", "test-license", "test-license"),
+            ("update_contact", {}, "contact", "test-contact", "test-contact"),
+            ("url", {"type": 'homepage'}, "website", "test-website", ["test-website"]),
+            ("url", {"type": 'bugtracker'}, "issues", "test-issues", ["test-issues"]),
+            ("url", {"type": 'donation'}, "donation", "test-donation", ["test-donation"]),
+            ("url", {"type": 'vcs-browser'}, "source_code", "test-source", ["test-source"]),        
         ],
     )
     def test_entries(self, file_extension, key, attributes, param_name, value, expect):
@@ -491,6 +497,7 @@ class TestAppstreamContent:
                   <li xml:lang="es">Publica snaps en la tienda.</li>
                 </ul>
               </description>
+              <update_contact>rrroschan@gmail.com</update_contact>
               </component>
         """
         )
@@ -514,6 +521,8 @@ class TestAppstreamContent:
             - _Build snaps_.
             - Publish snaps to the store."""
         )
+        assert metadata.license == "GPL-3.0-or-later"
+        assert metadata.contact == "rrroschan@gmail.com"
 
     def test_appstream_code_tags_not_swallowed(self):
         file_name = "foliate.appdata.xml"
@@ -626,6 +635,54 @@ class TestAppstreamContent:
             - Build snaps.
             - Publish snaps to the store."""
         )
+
+    def test_appstream_links(self):
+        file_name = "foliate.appdata.xml"
+        content = textwrap.dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+              <component type="desktop">
+              <id>com.github.maoschanz.drawing</id>
+              <metadata_license>CC0-1.0</metadata_license>
+              <project_license>GPL-3.0-or-later</project_license>
+              <content_rating type="oars-1.1"/>
+              <name>Drawing</name>
+              <description>
+                <p>Command Line Utility to <em>create snaps</em> quickly.</p>
+                <p xml:lang="es">Aplicativo de línea de comandos para crear snaps.</p>
+                <p>Ordered Features:</p>
+                <p xml:lang="es">Funciones:</p>
+                <ol>
+                  <li><em>Build snaps</em>.</li>
+                  <li xml:lang="es">Construye snaps.</li>
+                  <li>Publish snaps to the store.</li>
+                  <li xml:lang="es">Publica snaps en la tienda.</li>
+                </ol>
+                <p>Unordered Features:</p>
+                <ul>
+                  <li><em>Build snaps</em>.</li>
+                  <li xml:lang="es">Construye snaps.</li>
+                  <li>Publish snaps to the store.</li>
+                  <li xml:lang="es">Publica snaps en la tienda.</li>
+                </ul>
+              </description>
+              <url type="homepage">https://johnfactotum.github.io/foliate/</url>
+              <url type="vcs-browser">https://github.com/johnfactotum/foliate</url>
+              <url type="bugtracker">https://github.com/johnfactotum/foliate/issues</url>
+              <url type="translate">https://github.com/johnfactotum/foliate/tree/gtk4/po</url>
+              <url type="faq">https://github.com/johnfactotum/foliate/blob/gtk4/docs/faq.md</url>
+              <url type="donation">https://www.buymeacoffee.com/johnfactotum</url>
+              </component>
+        """
+        )
+        Path(file_name).write_text(content)
+
+        metadata = appstream.extract(file_name, workdir=".")
+        assert metadata is not None
+        assert metadata.website == ["https://johnfactotum.github.io/foliate/"]
+        assert metadata.issues == ["https://github.com/johnfactotum/foliate/issues"]
+        assert metadata.donation == ["https://www.buymeacoffee.com/johnfactotum"]
+        assert metadata.source_code == ["https://github.com/johnfactotum/foliate"]
 
     def test_appstream_parse_error(self):
         file_name = "snapcraft_legacy.appdata.xml"

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -51,10 +51,22 @@ class TestAppstreamData:
             ("name", {}, "title", "test-title", "test-title"),
             ("project_license", {}, "license", "test-license", "test-license"),
             ("update_contact", {}, "contact", "test-contact", "test-contact"),
-            ("url", {"type": 'homepage'}, "website", "test-website", ["test-website"]),
-            ("url", {"type": 'bugtracker'}, "issues", "test-issues", ["test-issues"]),
-            ("url", {"type": 'donation'}, "donation", "test-donation", ["test-donation"]),
-            ("url", {"type": 'vcs-browser'}, "source_code", "test-source", ["test-source"]),        
+            ("url", {"type": "homepage"}, "website", "test-website", ["test-website"]),
+            ("url", {"type": "bugtracker"}, "issues", "test-issues", ["test-issues"]),
+            (
+                "url",
+                {"type": "donation"},
+                "donation",
+                "test-donation",
+                ["test-donation"],
+            ),
+            (
+                "url",
+                {"type": "vcs-browser"},
+                "source_code",
+                "test-source",
+                ["test-source"],
+            ),
         ],
     )
     def test_entries(self, file_extension, key, attributes, param_name, value, expect):


### PR DESCRIPTION
This commit adds initial support to adopt more metadata fields from the provided appstream metadata file. Those fields includes,

1. license
2. contact
3. source-code
4. issues
5. website
6. donations

----
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
