### PR TITLE
feat!: deprecate enable-manifest and manifest-image-information

### DIFF
--- a/snapcraft/commands/core22/lifecycle.py
+++ b/snapcraft/commands/core22/lifecycle.py
@@ -53,14 +53,14 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             "--enable-manifest",
             action="store_true",
             default=utils.strtobool(os.getenv("SNAPCRAFT_BUILD_INFO", "n")),
-            help="Generate snap manifest",
+            help="Generate snap manifest (Deprecated)",
         )
         parser.add_argument(
             "--manifest-image-information",
             type=str,
             metavar="image-info",
             default=os.getenv("SNAPCRAFT_IMAGE_INFO"),
-            help="Set snap manifest image-info",
+            help="Set snap manifest image-info (Deprecated)",
         )
         parser.add_argument(
             "--bind-ssh",

--- a/snapcraft/commands/core22/lifecycle.py
+++ b/snapcraft/commands/core22/lifecycle.py
@@ -50,17 +50,17 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             help="Shell into the environment if the build fails",
         )
         parser.add_argument(
-            "--enable-manifest",
+            "--enable-manifest",  # Deprecated and removed in core24
             action="store_true",
             default=utils.strtobool(os.getenv("SNAPCRAFT_BUILD_INFO", "n")),
-            help="Generate snap manifest (Deprecated)",
+            help=argparse.SUPPRESS,
         )
         parser.add_argument(
-            "--manifest-image-information",
+            "--manifest-image-information",  # Deprecated and removed in core24
             type=str,
             metavar="image-info",
             default=os.getenv("SNAPCRAFT_IMAGE_INFO"),
-            help="Set snap manifest image-info (Deprecated)",
+            help=argparse.SUPPRESS,
         )
         parser.add_argument(
             "--bind-ssh",

--- a/snapcraft/commands/core22/lint.py
+++ b/snapcraft/commands/core22/lint.py
@@ -373,9 +373,5 @@ class LintCommand(BaseCommand):
                 "Not loading lint filters from 'snapcraft.yaml' because the file "
                 "does not exist inside the snap file."
             )
-            emit.verbose(
-                "To include 'snapcraft.yaml' in a snap file, use the parameter "
-                "'--enable-manifest' when building the snap. (Deprecated)"
-            )
 
         return lint_config

--- a/snapcraft/commands/core22/lint.py
+++ b/snapcraft/commands/core22/lint.py
@@ -375,7 +375,7 @@ class LintCommand(BaseCommand):
             )
             emit.verbose(
                 "To include 'snapcraft.yaml' in a snap file, use the parameter "
-                "'--enable-manifest' when building the snap."
+                "'--enable-manifest' when building the snap. (Deprecated)"
             )
 
         return lint_config

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -322,6 +322,10 @@ def _generate_metadata(
     emit.progress("Generated snap metadata", permanent=True)
 
     if parsed_args.enable_manifest:
+        emit.progress(
+            "'--enable-manifest' is deprecated, and will be removed in core24.",
+            permanent=True,
+        )
         _generate_manifest(
             project,
             lifecycle=lifecycle,
@@ -414,9 +418,17 @@ def _run_in_provider(  # noqa PLR0915
 
     if getattr(parsed_args, "enable_manifest", False):
         cmd.append("--enable-manifest")
+        emit.progress(
+            "'--enable-manifest' is deprecated, and will be removed in core24.",
+            permanent=True,
+        )
     image_information = getattr(parsed_args, "manifest_image_information", None)
     if image_information:
         cmd.extend(["--manifest-image-information", image_information])
+        emit.progress(
+            "'--manifest-image-information' is deprecated, and will be removed in core24.",
+            permanent=True,
+        )
 
     cmd.append("--build-for")
     cmd.append(project.get_build_for())

--- a/tests/unit/commands/test_lint.py
+++ b/tests/unit/commands/test_lint.py
@@ -478,7 +478,7 @@ def test_lint_managed_mode_without_snapcraft_yaml(
             call(
                 "verbose",
                 "To include 'snapcraft.yaml' in a snap file, use the parameter "
-                "'--enable-manifest' when building the snap.",
+                "'--enable-manifest' when building the snap. (Deprecated)",
             ),
         ]
     )

--- a/tests/unit/commands/test_lint.py
+++ b/tests/unit/commands/test_lint.py
@@ -475,11 +475,6 @@ def test_lint_managed_mode_without_snapcraft_yaml(
                 "Not loading lint filters from 'snapcraft.yaml' because the file does "
                 "not exist inside the snap file.",
             ),
-            call(
-                "verbose",
-                "To include 'snapcraft.yaml' in a snap file, use the parameter "
-                "'--enable-manifest' when building the snap. (Deprecated)",
-            ),
         ]
     )
 


### PR DESCRIPTION
`--enable-manifest` and `--manifest-image-information` no longer supported in core24.
