### PR TITLE
Use more specific naming for ROS plugs

### DIFF
--- a/snapcraft/extensions/_ros2_humble_meta.py
+++ b/snapcraft/extensions/_ros2_humble_meta.py
@@ -54,9 +54,9 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
     def get_root_snippet(self) -> Dict[str, Any]:
         root_snippet = super().get_root_snippet()
         root_snippet["plugs"] = {
-            "ros-humble": {
+            self.ros2_humble_snaps.content: {
                 "interface": "content",
-                "content": "ros-humble",
+                "content": self.ros2_humble_snaps.content,
                 "target": "$SNAP/opt/ros/underlay_ws",
                 "default-provider": self.ros2_humble_snaps.content,
             }

--- a/snapcraft_legacy/internal/project_loader/_extensions/_ros1_noetic_meta.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/_ros1_noetic_meta.py
@@ -53,10 +53,10 @@ class RosNoeticMetaBase(RosNoeticExtension):
         self.part_snippet_extra = dict()
 
         self.root_snippet["plugs"] = {
-            "ros-noetic":
+            self.ros_noetic_snaps.content:
                 {
                     "interface": "content",
-                    "content": "ros-noetic",
+                    "content": self.ros_noetic_snaps.content,
                     "target": "$SNAP/opt/ros/underlay_ws",
                     "default-provider": self.ros_noetic_snaps.content,
                 }

--- a/snapcraft_legacy/internal/project_loader/_extensions/_ros2_foxy_meta.py
+++ b/snapcraft_legacy/internal/project_loader/_extensions/_ros2_foxy_meta.py
@@ -61,10 +61,10 @@ class RosFoxyMetaBase(RosFoxyExtension):
         ]
 
         self.root_snippet["plugs"] = {
-            "ros-foxy":
+            self.ros2_foxy_snaps.content:
                 {
                     "interface": "content",
-                    "content": "ros-foxy",
+                    "content": self.ros2_foxy_snaps.content,
                     "target": "$SNAP/opt/ros/underlay_ws",
                     "default-provider": self.ros2_foxy_snaps.content,
                 }

--- a/tests/legacy/unit/project_loader/extensions/test_ros1_noetic_meta.py
+++ b/tests/legacy/unit/project_loader/extensions/test_ros1_noetic_meta.py
@@ -92,9 +92,9 @@ class TestClass:
                 }
             ],
             "plugs": {
-                "ros-noetic": {
+                meta: {
                     "interface": "content",
-                    "content": "ros-noetic",
+                    "content": meta,
                     "target": "$SNAP/opt/ros/underlay_ws",
                     "default-provider": meta,
                 }

--- a/tests/legacy/unit/project_loader/extensions/test_ros2_foxy_meta.py
+++ b/tests/legacy/unit/project_loader/extensions/test_ros2_foxy_meta.py
@@ -72,9 +72,9 @@ class TestClass:
                 }
             ],
             "plugs": {
-                "ros-foxy": {
+                meta: {
                     "interface": "content",
-                    "content": "ros-foxy",
+                    "content": meta,
                     "target": "$SNAP/opt/ros/underlay_ws",
                     "default-provider": meta,
                 }

--- a/tests/spread/extensions/catkin-tools-noetic-meta-hello/task.yaml
+++ b/tests/spread/extensions/catkin-tools-noetic-meta-hello/task.yaml
@@ -9,19 +9,21 @@ environment:
   SNAP: catkin-tools-noetic-hello
   SNAP_DIR: "../../plugins/v2/snaps/$SNAP"
 
-  INTERFACE: ros-noetic
-
   META_SNAP/catkin_noetic_ros_core: ros-noetic-ros-core
   EXTENSION/catkin_noetic_ros_core: ros1-noetic-ros-core
+  INTERFACE/catkin_noetic_ros_core: ros-noetic-ros-core
 
   META_SNAP/catkin_noetic_ros_base: ros-noetic-ros-base
   EXTENSION/catkin_noetic_ros_base: ros1-noetic-ros-base
+  INTERFACE/catkin_noetic_ros_base: ros-noetic-ros-base
 
   META_SNAP/catkin_noetic_robot: ros-noetic-robot
   EXTENSION/catkin_noetic_robot: ros1-noetic-robot
+  INTERFACE/catkin_noetic_robot: ros-noetic-robot
 
   META_SNAP/catkin_noetic_desktop: ros-noetic-desktop
   EXTENSION/catkin_noetic_desktop: ros1-noetic-desktop
+  INTERFACE/catkin_noetic_desktop: ros-noetic-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/extensions/ros-noetic-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros-noetic-meta-hello/task.yaml
@@ -9,19 +9,21 @@ environment:
   SNAP: catkin-noetic-hello
   SNAP_DIR: "../../plugins/v2/snaps/$SNAP"
 
-  INTERFACE: ros-noetic
-
   META_SNAP/catkin_noetic_ros_core: ros-noetic-ros-core
   EXTENSION/catkin_noetic_ros_core: ros1-noetic-ros-core
+  INTERFACE/catkin_noetic_ros_core: ros-noetic-ros-core
 
   META_SNAP/catkin_noetic_ros_base: ros-noetic-ros-base
   EXTENSION/catkin_noetic_ros_base: ros1-noetic-ros-base
+  INTERFACE/catkin_noetic_ros_base: ros-noetic-ros-base
 
   META_SNAP/catkin_noetic_robot: ros-noetic-robot
   EXTENSION/catkin_noetic_robot: ros1-noetic-robot
+  INTERFACE/catkin_noetic_robot: ros-noetic-robot
 
   META_SNAP/catkin_noetic_desktop: ros-noetic-desktop
   EXTENSION/catkin_noetic_desktop: ros1-noetic-desktop
+  INTERFACE/catkin_noetic_desktop: ros-noetic-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/extensions/ros-noetic-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros-noetic-meta-talker-listener/task.yaml
@@ -10,19 +10,21 @@ environment:
 
   SNAP_DIR: "../../plugins/v2/snaps/$SNAP"
 
-  INTERFACE: ros-noetic
-
   META_SNAP/catkin_noetic_ros_core: ros-noetic-ros-core
   EXTENSION/catkin_noetic_ros_core: ros1-noetic-ros-core
+  INTERFACE/catkin_noetic_ros_core: ros-noetic-ros-core
 
   META_SNAP/catkin_noetic_ros_base: ros-noetic-ros-base
   EXTENSION/catkin_noetic_ros_base: ros1-noetic-ros-base
+  INTERFACE/catkin_noetic_ros_base: ros-noetic-ros-base
 
   META_SNAP/catkin_noetic_robot: ros-noetic-robot
   EXTENSION/catkin_noetic_robot: ros1-noetic-robot
+  INTERFACE/catkin_noetic_robot: ros-noetic-robot
 
   META_SNAP/catkin_noetic_desktop: ros-noetic-desktop
   EXTENSION/catkin_noetic_desktop: ros1-noetic-desktop
+  INTERFACE/catkin_noetic_desktop: ros-noetic-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/extensions/ros2-foxy-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros2-foxy-meta-hello/task.yaml
@@ -8,16 +8,17 @@ environment:
   SNAP: colcon-ros2-wrapper
   SNAP_DIR: "../../plugins/v2/snaps/$SNAP"
 
-  INTERFACE: ros-foxy
-
   META_SNAP/colcon_foxy_ros_core: ros-foxy-ros-core
   EXTENSION/colcon_foxy_ros_core: ros2-foxy-ros-core
+  INTERFACE/colcon_foxy_ros_core: ros-foxy-ros-core
 
   META_SNAP/colcon_foxy_ros_base: ros-foxy-ros-base
   EXTENSION/colcon_foxy_ros_base: ros2-foxy-ros-base
+  INTERFACE/colcon_foxy_ros_base: ros-foxy-ros-base
 
   META_SNAP/colcon_foxy_desktop: ros-foxy-desktop
   EXTENSION/colcon_foxy_desktop: ros2-foxy-desktop
+  INTERFACE/colcon_foxy_desktop: ros-foxy-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/extensions/ros2-foxy-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-foxy-meta-talker-listener/task.yaml
@@ -8,16 +8,17 @@ environment:
   SNAP: colcon-ros2-talker-listener
   SNAP_DIR: "../../plugins/v2/snaps/$SNAP"
 
-  INTERFACE: ros-foxy
-
   META_SNAP/colcon_foxy_ros_core: ros-foxy-ros-core
   EXTENSION/colcon_foxy_ros_core: ros2-foxy-ros-core
+  INTERFACE/colcon_foxy_ros_core: ros-foxy-ros-core
 
   META_SNAP/colcon_foxy_ros_base: ros-foxy-ros-base
   EXTENSION/colcon_foxy_ros_base: ros2-foxy-ros-base
+  INTERFACE/colcon_foxy_ros_base: ros-foxy-ros-base
 
   META_SNAP/colcon_foxy_desktop: ros-foxy-desktop
   EXTENSION/colcon_foxy_desktop: ros2-foxy-desktop
+  INTERFACE/colcon_foxy_desktop: ros-foxy-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/extensions/ros2-humble-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros2-humble-meta-hello/task.yaml
@@ -9,16 +9,17 @@ environment:
   SNAP: colcon-ros2-wrapper
   SNAP_DIR: "../../plugins/craft-parts/build-and-run-hello/$SNAP"
 
-  INTERFACE: ros-humble
-
   META_SNAP/colcon_humble_ros_core: ros-humble-ros-core
   EXTENSION/colcon_humble_ros_core: ros2-humble-ros-core
+  INTERFACE/colcon_humble_ros_core: ros-humble-ros-core
 
   META_SNAP/colcon_humble_ros_base: ros-humble-ros-base
   EXTENSION/colcon_humble_ros_base: ros2-humble-ros-base
+  INTERFACE/colcon_humble_ros_base: ros-humble-ros-base
 
   META_SNAP/colcon_humble_desktop: ros-humble-desktop
   EXTENSION/colcon_humble_desktop: ros2-humble-desktop
+  INTERFACE/colcon_humble_desktop: ros-humble-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/extensions/ros2-humble-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-humble-meta-talker-listener/task.yaml
@@ -8,16 +8,17 @@ environment:
   SNAP: colcon-talker-listener
   SNAP_DIR: "../../plugins/craft-parts/$SNAP/$SNAP"
 
-  INTERFACE: ros-humble
-
   META_SNAP/colcon_humble_ros_core: ros-humble-ros-core
   EXTENSION/colcon_humble_ros_core: ros2-humble-ros-core
+  INTERFACE/colcon_humble_ros_core: ros-humble-ros-core
 
   META_SNAP/colcon_humble_ros_base: ros-humble-ros-base
   EXTENSION/colcon_humble_ros_base: ros2-humble-ros-base
+  INTERFACE/colcon_humble_ros_base: ros-humble-ros-base
 
   META_SNAP/colcon_humble_desktop: ros-humble-desktop
   EXTENSION/colcon_humble_desktop: ros2-humble-desktop
+  INTERFACE/colcon_humble_desktop: ros-humble-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed

--- a/tests/spread/plugins/v2/ros1-hello/task.yaml
+++ b/tests/spread/plugins/v2/ros1-hello/task.yaml
@@ -58,7 +58,7 @@ execute: |
     done
 
     # Connect the content sharing snap
-    snap connect "${SNAP}":ros-noetic ros-noetic-ros-core
+    snap connect "${SNAP}":ros-noetic-ros-core ros-noetic-ros-core
   fi
 
   [ "$($SNAP)" = "hello world" ]

--- a/tests/unit/parts/extensions/test_ros2_humble_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_humble_meta.py
@@ -123,8 +123,8 @@ class TestExtensionROS2HumbleMetaExtensions:
                 ]
             },
             "plugs": {
-                "ros-humble": {
-                    "content": "ros-humble",
+                meta: {
+                    "content": meta,
                     "default-provider": meta,
                     "interface": "content",
                     "target": "$SNAP/opt/ros/underlay_ws",


### PR DESCRIPTION
(slot) & plug renaming triggered by the request for autoconnection.

For details see [the request on the forum](https://forum.snapcraft.io/t/request-for-global-autoconnect-of-ros-foundation-snaps/38851/8).

Marking as 'draft' until the associated content snaps are released on the store.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
