### PR TITLE
chore(spread): enable pkg-repo tests for core24

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -40,6 +40,7 @@ jobs:
         spread-jobs:
           - google:ubuntu-20.04-64
           - google:ubuntu-22.04-64
+          - google:ubuntu-24.04-64
 
     steps:
       - name: Checkout snapcraft

--- a/spread.yaml
+++ b/spread.yaml
@@ -53,7 +53,7 @@ backends:
           storage: 20G
           image: ubuntu-2204-64
       - ubuntu-24.04-64:
-          image: ubuntu-23.04-64
+          image: ubuntu-24.04-64
           storage: 12G
           workers: 6
 
@@ -111,6 +111,10 @@ backends:
           username: root
           password: ubuntu
       - ubuntu-22.04-64:
+          workers: 1
+          username: root
+          password: ubuntu
+      - ubuntu-24.04-64:
           workers: 1
           username: root
           password: ubuntu
@@ -271,7 +275,7 @@ suites:
  tests/spread/core24/:
    summary: core24 specific tests
    systems:
-     - ubuntu-22.04*
+     - ubuntu-24.04*
 
  tests/spread/core24/environment/:
    summary: core24 environment tests

--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -20,9 +20,7 @@ execute: |
   cd "$SNAP"
 
   # Build what we have.
-  # If this next line fails, delete it and replace it with the one following it
-  snapcraft --verbose --use-lxd 2>&1 | MATCH 'unrecognized arguments: --use-lxd'; exit 0
-  # snapcraft --verbose --use-lxd
+  snapcraft --verbose
 
   # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -9,6 +9,15 @@ environment:
   SNAP/test_multi_keys: test-multi-keys
   SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
+prepare: |
+  # Workaround to be able to test the snaps
+  if snap install core24; then
+    echo Remove this workaround
+    exit 1
+  else
+    snap install core24 --edge
+  fi
+
 restore: |
   cd "$SNAP"
   rm -f ./*.snap


### PR DESCRIPTION
This mainly removes the --use-lxd toggle, there is no reason for it as it is the default.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
