### PR TITLE
feat: setup_assets for core24 metadata

### DIFF
--- a/tests/spread/core24/hooks/aux/build-aux/snap/hooks/install
+++ b/tests/spread/core24/hooks/aux/build-aux/snap/hooks/install
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+echo "I am a project install hook!"

--- a/tests/spread/core24/hooks/aux/build-aux/snap/snapcraft.yaml
+++ b/tests/spread/core24/hooks/aux/build-aux/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: hooks
+base: core24
+build-base: devel
+version: '1.0'
+summary: Test conflicting generated and project hooks.
+description: Project hooks in $PROJECT/snap/hooks/ should take priority over conflicting code generated hooks.
+grade: devel
+confinement: strict
+
+parts:
+  hooks:
+    source: src/
+    plugin: go
+    build-snaps: [go/1.20/stable]
+    organize:
+      bin/install: snap/hooks/install
+      bin/configure: snap/hooks/configure
+      

--- a/tests/spread/core24/hooks/aux/src/configure/configure.go
+++ b/tests/spread/core24/hooks/aux/src/configure/configure.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("I am a code generated configure hook!")
+}

--- a/tests/spread/core24/hooks/aux/src/go.mod
+++ b/tests/spread/core24/hooks/aux/src/go.mod
@@ -1,0 +1,3 @@
+module github.com/snapcore/snapcraft/tests/spread/general/hooks/generated-hooks
+
+go 1.20

--- a/tests/spread/core24/hooks/aux/src/install/install.go
+++ b/tests/spread/core24/hooks/aux/src/install/install.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("I am a code generated install hook!")
+}

--- a/tests/spread/core24/hooks/default/snap/hooks/install
+++ b/tests/spread/core24/hooks/default/snap/hooks/install
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+echo "I am a project install hook!"

--- a/tests/spread/core24/hooks/default/snap/snapcraft.yaml
+++ b/tests/spread/core24/hooks/default/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: hooks
+base: core24
+build-base: devel
+version: '1.0'
+summary: Test conflicting generated and project hooks.
+description: Project hooks in $PROJECT/snap/hooks/ should take priority over conflicting code generated hooks.
+grade: devel
+confinement: strict
+
+parts:
+  hooks:
+    source: src/
+    plugin: go
+    build-snaps: [go/1.20/stable]
+    organize:
+      bin/install: snap/hooks/install
+      bin/configure: snap/hooks/configure
+      

--- a/tests/spread/core24/hooks/default/src/configure/configure.go
+++ b/tests/spread/core24/hooks/default/src/configure/configure.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("I am a code generated configure hook!")
+}

--- a/tests/spread/core24/hooks/default/src/go.mod
+++ b/tests/spread/core24/hooks/default/src/go.mod
@@ -1,0 +1,3 @@
+module github.com/snapcore/snapcraft/tests/spread/general/hooks/generated-hooks
+
+go 1.20

--- a/tests/spread/core24/hooks/default/src/install/install.go
+++ b/tests/spread/core24/hooks/default/src/install/install.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("I am a code generated install hook!")
+}

--- a/tests/spread/core24/hooks/task.yaml
+++ b/tests/spread/core24/hooks/task.yaml
@@ -1,0 +1,37 @@
+summary: setup hooks
+
+environment:
+  SNAP/default: default
+  SNAP/build_aux: aux
+  
+restore: |
+  cd "${SNAP}"
+  
+  snapcraft clean --destructive-mode
+  rm -rf hooks_*.snap
+
+execute: |
+  cd "${SNAP}"
+  
+  snapcraft pack --destructive-mode
+
+  # verify hooks were staged
+   if [[ ! -f prime/meta/hooks/configure ]] && [[ ! -f prime/meta/hooks/install ]]; then
+      echo "no hook found in prime/meta/hooks/"
+      exit 1
+  fi
+
+  # Verify both built hooks are in prime/snap/hooks
+  prime/snap/hooks/configure | MATCH "I am a code generated configure hook!"
+  prime/snap/hooks/install | MATCH "I am a code generated install hook!"
+
+  # verify that the built configure hook was provisioned
+  prime/meta/hooks/configure | MATCH "I am a code generated configure hook!"
+
+  # verify that the install hook from the project is provisioned
+  # over the one that was built
+  prime/meta/hooks/install | MATCH "I am a project install hook"
+
+  # verify snap is installable
+  snap install hooks_1.0_*.snap --dangerous
+


### PR DESCRIPTION
The PrimeCommand calls

    self._services.package.write_metadata(self._services.lifecycle.prime_dir)

Which makes it simple to hook up.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
Fixes #4592 