### PR TITLE
feat: allow for overriding project asset handling

### DIFF
--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -135,7 +135,8 @@ def _get_transformed_dom(path: str):
     return transform(dom)
 
 
-def _get_dom(path: str) -> lxml.etree.ElementTree:
+# error: Function "lxml.etree.ElementTree" is not valid as a type
+def _get_dom(path: str) -> lxml.etree.ElementTree:  # type: ignore
     try:
         return lxml.etree.parse(path)  # noqa S320
     except OSError as err:

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -74,8 +74,9 @@ def setup_assets(
 
     # Ensure all hooks are executable
     if hooks_dir.is_dir():
-        for hook in hooks_dir.iterdir():
-            _ensure_hook_executable(hook)
+        for hook in hooks_dir.iterdir():  # type: ignore
+            # mypy says we are passing a Hook, but this is indeed a Path
+            _ensure_hook_executable(hook)  # type: ignore
 
     if project.type == "gadget":
         gadget_yaml = project_dir / "gadget.yaml"

--- a/tests/unit/parts/test_setup_assets.py
+++ b/tests/unit/parts/test_setup_assets.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shutil
 import textwrap
 from pathlib import Path
 from typing import Any, Dict
@@ -263,6 +264,93 @@ class TestSetupAssets:
             """
         )
 
+    def test_hooks_default_handler(self, default_project, new_dir):
+        project_dir = new_dir
+        assets_dir = project_dir / "snap"
+        prime_dir = project_dir / "prime"
+
+        # Create a configure hook provided by the project
+        project_configure_hook = assets_dir / "hooks" / "configure"
+        project_configure_hook.parent.mkdir(parents=True)
+        project_configure_hook.write_text("project_configure")
+
+        # Create an install hook built through the project
+        built_install_hook = prime_dir / "snap" / "hooks" / "install"
+        built_install_hook.parent.mkdir(parents=True)
+        built_install_hook.write_text("built_install")
+
+        setup_assets(
+            default_project,
+            assets_dir=assets_dir,
+            project_dir=project_dir,
+            prime_dir=prime_dir,
+        )
+
+        hook_meta_dir = prime_dir / "meta" / "hooks"
+
+        # Assert the project configure hook has its wrapper
+        # to the copied over hook and is executable.
+        meta_configure_hook = hook_meta_dir / "configure"
+        assert meta_configure_hook.exists()
+        assert meta_configure_hook.read_text() == textwrap.dedent(
+            """\
+            #!/bin/sh
+            exec "$SNAP/snap/hooks/configure" "$@"
+        """
+        )
+        assert (
+            prime_dir / "snap" / "hooks" / "configure"
+        ).read_text() == "project_configure"
+        assert oct(meta_configure_hook.stat().st_mode)[-3:] == "755"
+
+        # Assert the project install hook has its wrapper
+        # And is executable
+        meta_install_hook = hook_meta_dir / "install"
+        assert meta_install_hook.exists()
+        assert meta_install_hook.read_text() == textwrap.dedent(
+            """\
+            #!/bin/sh
+            exec "$SNAP/snap/hooks/install" "$@"
+        """
+        )
+        assert built_install_hook.read_text() == "built_install"
+        assert oct(meta_install_hook.stat().st_mode)[-3:] == "755"
+
+    def test_hooks_with_handler(self, default_project, new_dir):
+        project_dir = new_dir
+        assets_dir = project_dir / "snap"
+        prime_dir = project_dir / "prime"
+
+        # Create a configure hook provided by the project
+        project_configure_hook = assets_dir / "hooks" / "configure"
+        project_configure_hook.parent.mkdir(parents=True)
+        project_configure_hook.write_text("project_configure")
+
+        def handler(assets_dir, prime_dir) -> None:
+            hooks_meta_dir = prime_dir / "meta" / "hooks"
+            hooks_meta_dir.mkdir(parents=True)
+            for hook in (assets_dir / "hooks").iterdir():
+                shutil.copy(hook, hooks_meta_dir / hook.name)
+
+        setup_assets(
+            default_project,
+            assets_dir=assets_dir,
+            project_dir=project_dir,
+            prime_dir=prime_dir,
+            meta_directory_handler=handler,
+        )
+
+        hook_meta_dir = prime_dir / "meta" / "hooks"
+
+        # Assert the project configure hook was copied
+        # with no wrapper, is executable and that nothing
+        # was put in prime_dir/snap/hooks
+        meta_configure_hook = hook_meta_dir / "configure"
+        assert meta_configure_hook.exists()
+        assert meta_configure_hook.read_text() == "project_configure"
+        assert not (prime_dir / "snap" / "hooks" / "configure").exists()
+        assert oct(meta_configure_hook.stat().st_mode)[-3:] == "755"
+
     def test_setup_assets_icon_in_assets_dir(self, desktop_file, yaml_data, new_dir):
         desktop_file("prime/test.desktop")
         Path("snap/gui").mkdir(parents=True)
@@ -475,7 +563,6 @@ def test_ensure_hook(new_dir):
 
     assert hook_path.exists()
     assert hook_path.read_text() == "#!/bin/true\n"
-    assert oct(hook_path.stat().st_mode)[-3:] == "755"
 
 
 def test_ensure_hook_does_not_overwrite(new_dir):
@@ -526,10 +613,6 @@ def test_create_hook_wrappers(new_dir):
     for hook_name in ["configure", "install"]:
         hook_wrapper = hooks_meta_dir / hook_name
         assert hook_wrapper.exists()
-        assert oct(hook_wrapper.stat().st_mode)[-3:] == "755"
-
-        # verify generated hook was made executable
-        assert oct((hooks_snap_dir / hook_name).stat().st_mode)[-3:] == "755"
 
 
 def test_write_hook_wrapper(new_dir):
@@ -557,4 +640,3 @@ def test_write_hook_wrapper(new_dir):
         hook_wrapper.read_text()
         == f'#!/bin/sh\nexec "$SNAP/snap/hooks/{hook_name}" "$@"\n'
     )
-    assert oct(hook_wrapper.stat().st_mode)[-3:] == "755"


### PR DESCRIPTION
- Move executable setting to one location
- Test for default behavior in relation to hooks
- Test with new asset handler in relation to hooks

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
