### PR TITLE
fix(application): use SNAPCRAFT_MANAGED_MODE everywhere

### DIFF
--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -223,7 +223,7 @@ def get_command_environment(
     :return: Dictionary of environmental variables.
     """
     env = bases.buildd.default_command_environment()
-    env["SNAPCRAFT_MANAGED_MODE"] = "1"
+    env["CRAFT_MANAGED_MODE"] = "1"
 
     # Pass-through host environment that target may need.
     for env_key in [

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -178,7 +178,7 @@ def strtobool(value: str) -> bool:
 
 def is_managed_mode() -> bool:
     """Check if snapcraft is running in a managed environment."""
-    managed_flag = os.getenv("SNAPCRAFT_MANAGED_MODE", "n")
+    managed_flag = os.getenv("CRAFT_MANAGED_MODE", "n")
     return strtobool(managed_flag)
 
 

--- a/tests/spread/providers/use-lxd/task.yaml
+++ b/tests/spread/providers/use-lxd/task.yaml
@@ -19,7 +19,7 @@ execute: |
   fi
 
   unset SNAPCRAFT_BUILD_ENVIRONMENT
-  export SNAPCRAFT_MANAGED_MODE=1
+  export CRAFT_MANAGED_MODE=1
 
   snapcraft pull --use-lxd
 

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -333,7 +333,7 @@ def test_get_command_environment(mocker, mock_default_command_environment):
     """Verify command environment is properly constructed."""
     command_environment = providers.get_command_environment()
 
-    assert command_environment == {"PATH": "test-path", "SNAPCRAFT_MANAGED_MODE": "1"}
+    assert command_environment == {"PATH": "test-path", "CRAFT_MANAGED_MODE": "1"}
 
 
 def test_get_command_environment_passthrough(
@@ -356,7 +356,7 @@ def test_get_command_environment_passthrough(
 
     assert command_environment == {
         "PATH": "test-path",
-        "SNAPCRAFT_MANAGED_MODE": "1",
+        "CRAFT_MANAGED_MODE": "1",
         "http_proxy": "test-http",
         "https_proxy": "test-https",
         "no_proxy": "test-no-proxy",
@@ -378,7 +378,7 @@ def test_get_command_environment_http_https_proxy(
 
     assert command_environment == {
         "PATH": "test-path",
-        "SNAPCRAFT_MANAGED_MODE": "1",
+        "CRAFT_MANAGED_MODE": "1",
         "http_proxy": "test-http",
         "https_proxy": "test-https",
     }
@@ -398,7 +398,7 @@ def test_get_command_environment_http_https_priority(
 
     assert command_environment == {
         "PATH": "test-path",
-        "SNAPCRAFT_MANAGED_MODE": "1",
+        "CRAFT_MANAGED_MODE": "1",
         "http_proxy": "test-http-from-arg",
         "https_proxy": "test-https-from-arg",
     }


### PR DESCRIPTION
`craft-application` uses `CRAFT_MANAGED_MODE` environment variable, while `snapcraft` was still using `SNAPCRAFT_MANAGED_MODE`.  This was causing inner managed instances of snapcraft to not realize they were running in managed mode, and write their logs into an ephemeral location inside the LXD instance, rendering those logs inaccessible from the host.

Note that while this fixes the logging issue, this does not fix the spread tests that @tigarmo was hoping it would.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
(CRAFT-2539)