### PR TITLE
tests: replace mock methods removed in Py3.12

### DIFF
--- a/tests/unit/remote/test_launchpad.py
+++ b/tests/unit/remote/test_launchpad.py
@@ -236,17 +236,11 @@ def launchpad_client(mock_login_with):
     )
 
 
-def test_login(mock_login_with):
-    lpc = LaunchpadClient(
-        app_name="test-app",
-        build_id="id",
-        project_name="test-project",
-        architectures=[],
-    )
+def test_login(mock_login_with, launchpad_client):
 
-    assert lpc.user == "user"
+    assert launchpad_client.user == "user"
 
-    assert mock_login_with.called_with(
+    mock_login_with.assert_called_once_with(
         "test-app remote-build",
         "production",
         ANY,


### PR DESCRIPTION
`Mock.called_with` was never actually a real mock method in `unittest.mock`. It was returning a Mock object, which is truthy.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
