### PR TITLE
feat: adopt more fields from the appstream metadata file(part 2) 

### DIFF
--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -182,7 +182,7 @@ def _get_urls_from_xml_element(nodes, url_type) -> Optional[List[str]]:
         if (
             node is not None
             and node.attrib["type"] == url_type
-            and node.text not in urls
+            and node.text.strip() not in urls
         ):
             urls.append(node.text.strip())
     if urls:

--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -101,12 +101,13 @@ def extract(relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
     title = _get_value_from_xml_element(dom, "name")
     version = _get_latest_release_from_nodes(dom.findall("releases/release"))
     project_license = _get_value_from_xml_element(dom, "project_license")
-    contact = _get_value_from_xml_element(dom, "update_contact")
+    update_contact = _get_value_from_xml_element(dom, "update_contact")
+    contact = [update_contact] if update_contact else None
 
     issues = _get_urls_from_xml_element(dom.findall("url"), "bugtracker")
     donation = _get_urls_from_xml_element(dom.findall("url"), "donation")
     website = _get_urls_from_xml_element(dom.findall("url"), "homepage")
-    source_code = _get_source_code_from_xml_element(dom.findall("url"))
+    source_code = _get_urls_from_xml_element(dom.findall("url"), "vcs-browser")
 
     desktop_file_paths = []
     desktop_file_ids = _get_desktop_file_ids_from_nodes(dom.findall("launchable"))
@@ -178,17 +179,14 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
 def _get_urls_from_xml_element(nodes, url_type) -> Optional[List[str]]:
     urls = []  # type: List[str]
     for node in nodes:
-        if node is not None and node.attrib["type"] == url_type:
+        if (
+            node is not None
+            and node.attrib["type"] == url_type
+            and node.text not in urls
+        ):
             urls.append(node.text.strip())
     if urls:
         return urls
-    return None
-
-
-def _get_source_code_from_xml_element(nodes) -> Optional[str]:
-    for node in nodes:
-        if node is not None and node.attrib["type"] == "vcs-browser":
-            return node.text.strip()
     return None
 
 

--- a/snapcraft/meta/extracted_metadata.py
+++ b/snapcraft/meta/extracted_metadata.py
@@ -51,7 +51,7 @@ class ExtractedMetadata:
     license: Optional[str] = None
     """The extracted package license"""
 
-    contact: Optional[str] = None
+    contact: Optional[List[str]] = None
     """The extracted package contact"""
 
     donation: Optional[List[str]] = None
@@ -60,7 +60,7 @@ class ExtractedMetadata:
     issues: Optional[List[str]] = None
     """The extracted package issues"""
 
-    source_code: Optional[str] = None
+    source_code: Optional[List[str]] = None
     """The extracted package source code"""
 
     website: Optional[List[str]] = None

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -608,7 +608,6 @@ class Project(models.Project):
     donation: Optional[UniqueStrList]
     # snapcraft's `source_code` is more general than craft-application
     source_code: Optional[UniqueStrList]
-    license: Optional[str]  # type: ignore[assignment]
     contact: Optional[UniqueStrList]
     issues: Optional[UniqueStrList]
     website: Optional[UniqueStrList]
@@ -860,6 +859,13 @@ class Project(models.Project):
             )
 
         return provenance
+
+    @pydantic.validator("contact", "donation", "issues", "source_code", "website", pre=True)
+    @classmethod
+    def _validate_contact(cls, field_value):
+        if isinstance(field_value, str):
+            field_value = cast(UniqueStrList, [field_value])
+        return field_value
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "Project":

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -606,7 +606,10 @@ class Project(models.Project):
     donation: Optional[Union[str, UniqueStrList]]
     # snapcraft's `source_code` is more general than craft-application
     source_code: Optional[str]  # type: ignore[assignment]
-    website: Optional[str]
+    license: Optional[str]
+    contact: Optional[str]
+    issues: Optional[Union[str, UniqueStrList]]
+    website: Optional[Union[str, UniqueStrList]]
     type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
     confinement: Literal["classic", "devmode", "strict"]

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -602,14 +602,12 @@ class Project(models.Project):
     name: ProjectName  # type: ignore[assignment]
     build_base: Optional[str]
     compression: Literal["lzo", "xz"] = "xz"
-    # TODO: ensure we have a test for version being retrieved using adopt-info
-    # snapcraft's `version` is more general than craft-application
-    version: Optional[ProjectVersion]  # type: ignore[assignment]
+    version: Optional[VersionStr]  # type: ignore[assignment]
     donation: Optional[UniqueStrList]
     # snapcraft's `source_code` is more general than craft-application
-    source_code: Optional[UniqueStrList]
-    contact: Optional[UniqueStrList]
-    issues: Optional[UniqueStrList]
+    source_code: Optional[UniqueStrList]  # type: ignore[assignment]
+    contact: Optional[UniqueStrList]  # type: ignore[assignment]
+    issues: Optional[UniqueStrList]  # type: ignore[assignment]
     website: Optional[UniqueStrList]
     type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
@@ -860,7 +858,9 @@ class Project(models.Project):
 
         return provenance
 
-    @pydantic.validator("contact", "donation", "issues", "source_code", "website", pre=True)
+    @pydantic.validator(
+        "contact", "donation", "issues", "source_code", "website", pre=True
+    )
     @classmethod
     def _validate_contact(cls, field_value):
         if isinstance(field_value, str):

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -602,14 +602,16 @@ class Project(models.Project):
     name: ProjectName  # type: ignore[assignment]
     build_base: Optional[str]
     compression: Literal["lzo", "xz"] = "xz"
-    version: Optional[VersionStr]  # type: ignore[assignment]
-    donation: Optional[Union[str, UniqueStrList]]
+    # TODO: ensure we have a test for version being retrieved using adopt-info
+    # snapcraft's `version` is more general than craft-application
+    version: Optional[ProjectVersion]  # type: ignore[assignment]
+    donation: Optional[UniqueStrList]  # type: ignore[assignment]
     # snapcraft's `source_code` is more general than craft-application
-    source_code: UniqueStrList = cast(UniqueStrList, [])  # type: ignore[assignment]
+    source_code: Optional[UniqueStrList]  # type: ignore[assignment]
     license: Optional[str]  # type: ignore[assignment]
-    contact: UniqueStrList = cast(UniqueStrList, [])  # type: ignore[assignment]
-    issues: UniqueStrList = cast(UniqueStrList, [])  # type: ignore[assignment]
-    website: UniqueStrList = cast(UniqueStrList, [])
+    contact: Optional[UniqueStrList]  # type: ignore[assignment]
+    issues: Optional[UniqueStrList]  # type: ignore[assignment]
+    website: Optional[UniqueStrList]  # type: ignore[assignment]
     type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
     confinement: Literal["classic", "devmode", "strict"]

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -862,7 +862,7 @@ class Project(models.Project):
         "contact", "donation", "issues", "source_code", "website", pre=True
     )
     @classmethod
-    def _validate_contact(cls, field_value):
+    def _validate_urls(cls, field_value):
         if isinstance(field_value, str):
             field_value = cast(UniqueStrList, [field_value])
         return field_value

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -605,13 +605,13 @@ class Project(models.Project):
     # TODO: ensure we have a test for version being retrieved using adopt-info
     # snapcraft's `version` is more general than craft-application
     version: Optional[ProjectVersion]  # type: ignore[assignment]
-    donation: Optional[UniqueStrList]  # type: ignore[assignment]
+    donation: Optional[UniqueStrList]
     # snapcraft's `source_code` is more general than craft-application
-    source_code: Optional[UniqueStrList]  # type: ignore[assignment]
+    source_code: Optional[UniqueStrList]
     license: Optional[str]  # type: ignore[assignment]
-    contact: Optional[UniqueStrList]  # type: ignore[assignment]
-    issues: Optional[UniqueStrList]  # type: ignore[assignment]
-    website: Optional[UniqueStrList]  # type: ignore[assignment]
+    contact: Optional[UniqueStrList]
+    issues: Optional[UniqueStrList]
+    website: Optional[UniqueStrList]
     type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
     confinement: Literal["classic", "devmode", "strict"]

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -605,11 +605,11 @@ class Project(models.Project):
     version: Optional[VersionStr]  # type: ignore[assignment]
     donation: Optional[Union[str, UniqueStrList]]
     # snapcraft's `source_code` is more general than craft-application
-    source_code: Optional[str]  # type: ignore[assignment]
-    license: Optional[str]
-    contact: Optional[str]
-    issues: Optional[Union[str, UniqueStrList]]
-    website: Optional[Union[str, UniqueStrList]]
+    source_code: UniqueStrList = cast(UniqueStrList, [])  # type: ignore[assignment]
+    license: Optional[str]  # type: ignore[assignment]
+    contact: UniqueStrList = cast(UniqueStrList, [])  # type: ignore[assignment]
+    issues: UniqueStrList = cast(UniqueStrList, [])  # type: ignore[assignment]
+    website: UniqueStrList = cast(UniqueStrList, [])
     type: Optional[Literal["app", "base", "gadget", "kernel", "snapd"]]
     icon: Optional[str]
     confinement: Literal["classic", "devmode", "strict"]

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -49,7 +49,6 @@ def update_project_metadata(
     :raises SnapcraftError: If project update failed.
     """
     _update_project_variables(project, project_vars)
-    _update_project_links(project, metadata_list)
 
     update_from_extracted_metadata(
         project, metadata_list=metadata_list, assets_dir=assets_dir, prime_dir=prime_dir
@@ -103,6 +102,8 @@ def update_from_extracted_metadata(
         _update_project_app_desktop_file(
             project, metadata=metadata, assets_dir=assets_dir, prime_dir=prime_dir
         )
+
+        _update_project_links(project, metadata_list)
 
 
 def _update_project_links(

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -109,20 +109,23 @@ def _update_project_links(
     project: Project,
     metadata_list: List[ExtractedMetadata],
 ) -> None:
+    """Update project links from metadata.
+    
+    :param project: The Project model to update.
+    :param metadata_list: A list of parsed information from metadata files.
+    """
     for metadata in metadata_list:
         fields = ["contact", "donation", "source_code", "issues", "website"]
         for field in fields:
-            if (
-                getattr(metadata, field)
-                and getattr(project, field)
-                and getattr(project, field) != getattr(metadata, field)
-            ):
-                project_list = list(getattr(project, field))
-                project_list.extend(set(getattr(metadata, field)) - set(project_list))
+            metadata_field = getattr(metadata, field)
+            project_field = getattr(project, field)
+            if metadata_field and project_field and project_field != metadata_field:
+                project_list = list(project_field)
+                project_list.extend(set(metadata_field) - set(project_list))
                 setattr(project, field, cast(UniqueStrList, project_list))
 
             if not getattr(project, field):
-                setattr(project, field, cast(UniqueStrList, getattr(metadata, field)))
+                setattr(project, field, cast(UniqueStrList, metadata_field))
 
 
 def _update_project_variables(project: Project, project_vars: Dict[str, str]):

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -86,6 +86,33 @@ def update_from_extracted_metadata(
 
         if metadata.version and not project.version:
             project.version = cast(VersionStr, metadata.version)
+            
+        if metadata.license and not project.license:
+            project.license = metadata.license
+            
+        if metadata.contact and not project.contact:
+            project.contact = metadata.contact
+            
+        if metadata.donation and project.donation:
+            project.donation = project.donation + metadata.donation
+            
+        if metadata.donation and not project.donation:
+            project.donation = metadata.donation
+            
+        if metadata.source_code and not project.source_code:
+            project.source_code = metadata.source_code
+            
+        if metadata.issues and project.issues:
+            project.issues = project.issues + metadata.issues
+        
+        if metadata.issues and not project.issues:
+            project.issues = metadata.issues
+        
+        if metadata.website and project.website:
+            project.website = project.website + metadata.website
+            
+        if metadata.website and not project.website:
+            project.website = metadata.website
 
         if metadata.grade and not project.grade:
             project.grade = metadata.grade  # type: ignore

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -115,12 +115,17 @@ def _update_project_links(
             if isinstance(getattr(project, field), str):
                 setattr(project, field, cast(UniqueStrList, [getattr(project, field)]))
 
-            if getattr(metadata, field) and getattr(project, field) != getattr(
-                metadata, field
+            if (
+                getattr(metadata, field)
+                and getattr(project, field)
+                and getattr(project, field) != getattr(metadata, field)
             ):
                 project_list = list(getattr(project, field))
                 project_list.extend(set(getattr(metadata, field)) - set(project_list))
                 setattr(project, field, cast(UniqueStrList, project_list))
+                
+            if not getattr(project, field):
+                setattr(project, field, cast(UniqueStrList, getattr(metadata, field)))
 
 
 def _update_project_variables(project: Project, project_vars: Dict[str, str]):

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -123,7 +123,7 @@ def _update_project_links(
                 project_list = list(getattr(project, field))
                 project_list.extend(set(getattr(metadata, field)) - set(project_list))
                 setattr(project, field, cast(UniqueStrList, project_list))
-                
+
             if not getattr(project, field):
                 setattr(project, field, cast(UniqueStrList, getattr(metadata, field)))
 

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -110,7 +110,7 @@ def _update_project_links(
     metadata_list: List[ExtractedMetadata],
 ) -> None:
     """Update project links from metadata.
-    
+
     :param project: The Project model to update.
     :param metadata_list: A list of parsed information from metadata files.
     """

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -110,85 +110,17 @@ def _update_project_links(
     metadata_list: List[ExtractedMetadata],
 ) -> None:
     for metadata in metadata_list:
-        if metadata.contact and project.contact:
-            for item in metadata.contact:
-                project.contact = cast(
-                    UniqueStrList,
-                    (
-                        [project.contact]
-                        if isinstance(project.contact, str)
-                        else project.contact
-                    ),
-                )
-                if item not in project.contact:
-                    project.contact.extend([item])
+        fields = ["contact", "donation", "source_code", "issues", "website"]
+        for field in fields:
+            if isinstance(getattr(project, field), str):
+                setattr(project, field, cast(UniqueStrList, [getattr(project, field)]))
 
-        if metadata.contact and not project.contact:
-            project.contact = cast(UniqueStrList, metadata.contact)
-
-        if metadata.donation and project.donation:
-            for item in metadata.donation:
-                if item not in project.donation:
-                    project.donation = cast(
-                        UniqueStrList,
-                        (
-                            [project.donation]
-                            if isinstance(project.donation, str)
-                            else project.donation
-                        ),
-                    )
-                    project.donation.extend([item])
-
-        if metadata.donation and not project.donation:
-            project.donation = cast(UniqueStrList, metadata.donation)
-
-        if metadata.source_code and project.source_code:
-            for item in metadata.source_code:
-                if item not in project.source_code:
-                    project.source_code = cast(
-                        UniqueStrList,
-                        (
-                            [project.source_code]
-                            if isinstance(project.source_code, str)
-                            else project.source_code
-                        ),
-                    )
-                    project.source_code.extend([item])
-
-        if metadata.source_code and not project.source_code:
-            project.source_code = cast(UniqueStrList, metadata.source_code)
-
-        if metadata.issues and project.issues:
-            for item in metadata.issues:
-                if item not in project.issues:
-                    project.issues = cast(
-                        UniqueStrList,
-                        (
-                            [project.issues]
-                            if isinstance(project.issues, str)
-                            else project.issues
-                        ),
-                    )
-                    project.issues.extend([item])
-
-        if metadata.issues and not project.issues:
-            project.issues = cast(UniqueStrList, metadata.issues)
-
-        if metadata.website and project.website:
-            for item in metadata.website:
-                if item not in project.website:
-                    project.website = cast(
-                        UniqueStrList,
-                        (
-                            [project.website]
-                            if isinstance(project.website, str)
-                            else project.website
-                        ),
-                    )
-                    project.website.extend([item])
-
-        if metadata.website and not project.website:
-            project.website = cast(UniqueStrList, metadata.website)
+            if getattr(metadata, field) and getattr(project, field) != getattr(
+                metadata, field
+            ):
+                project_list = list(getattr(project, field))
+                project_list.extend(set(getattr(metadata, field)) - set(project_list))
+                setattr(project, field, cast(UniqueStrList, project_list))
 
 
 def _update_project_variables(project: Project, project_vars: Dict[str, str]):

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -112,9 +112,6 @@ def _update_project_links(
     for metadata in metadata_list:
         fields = ["contact", "donation", "source_code", "issues", "website"]
         for field in fields:
-            if isinstance(getattr(project, field), str):
-                setattr(project, field, cast(UniqueStrList, [getattr(project, field)]))
-
             if (
                 getattr(metadata, field)
                 and getattr(project, field)

--- a/tests/spread/core24/appstream-desktop/desktop/expected_snap.yaml
+++ b/tests/spread/core24/appstream-desktop/desktop/expected_snap.yaml
@@ -13,6 +13,7 @@ description: |-
 
 
   Test me please.
+license: GPL-2.0+
 architectures:
 - amd64
 base: core24

--- a/tests/spread/core24/appstream-desktop/desktop/expected_snap.yaml
+++ b/tests/spread/core24/appstream-desktop/desktop/expected_snap.yaml
@@ -26,3 +26,6 @@ grade: devel
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+links:
+  website:
+  - https://snapcraft.io

--- a/tests/spread/core24/appstream-desktop/icon-desktop/expected_snap.yaml
+++ b/tests/spread/core24/appstream-desktop/icon-desktop/expected_snap.yaml
@@ -13,6 +13,7 @@ description: |-
 
 
   Test me please.
+license: GPL-2.0+
 architectures:
 - amd64
 base: core24

--- a/tests/spread/core24/appstream-desktop/icon-desktop/expected_snap.yaml
+++ b/tests/spread/core24/appstream-desktop/icon-desktop/expected_snap.yaml
@@ -26,3 +26,6 @@ grade: devel
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+links:
+  website:
+  - https://snapcraft.io

--- a/tests/spread/general/appstream-desktop/expected_snap_core22.yaml
+++ b/tests/spread/general/appstream-desktop/expected_snap_core22.yaml
@@ -13,6 +13,7 @@ description: |-
 
 
   Test me please.
+license: GPL-2.0+
 architectures:
 - amd64
 base: core22
@@ -25,3 +26,6 @@ grade: devel
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+links:
+  website:
+  - https://snapcraft.io

--- a/tests/spread/general/appstream-icon-from-desktop/expected_snap_core22.yaml
+++ b/tests/spread/general/appstream-icon-from-desktop/expected_snap_core22.yaml
@@ -13,6 +13,7 @@ description: |-
 
 
   Test me please.
+license: GPL-2.0+
 architectures:
 - amd64
 base: core22
@@ -25,3 +26,6 @@ grade: devel
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+links:
+  website:
+  - https://snapcraft.io

--- a/tests/spread/general/appstream-remote-gfx/expected_snap_core22.yaml
+++ b/tests/spread/general/appstream-remote-gfx/expected_snap_core22.yaml
@@ -13,6 +13,7 @@ description: |-
 
 
   Test me please.
+license: GPL-2.0+
 architectures:
 - amd64
 base: core22
@@ -25,3 +26,6 @@ grade: devel
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+links:
+  website:
+  - https://snapcraft.io

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -575,6 +575,7 @@ class TestAppstreamContent:
         metadata = appstream.extract(file_name, workdir=".")
 
         assert metadata is not None
+        assert metadata.license == "GPL-3.0-or-later"
         assert metadata.description == textwrap.dedent(
             """\
             Command Line Utility to create snaps quickly.
@@ -633,6 +634,7 @@ class TestAppstreamContent:
         metadata = appstream.extract(file_name, workdir=".")
 
         assert metadata is not None
+        assert metadata.license == "GPL-3.0-or-later"
         assert metadata.description == textwrap.dedent(
             """\
             Command Line Utility to create snaps quickly.

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -50,7 +50,7 @@ class TestAppstreamData:
             ("id", {}, "common_id", "test-id", "test-id"),
             ("name", {}, "title", "test-title", "test-title"),
             ("project_license", {}, "license", "test-license", "test-license"),
-            ("update_contact", {}, "contact", "test-contact", "test-contact"),
+            ("update_contact", {}, "contact", "test-contact", ["test-contact"]),
             ("url", {"type": "homepage"}, "website", "test-website", ["test-website"]),
             ("url", {"type": "bugtracker"}, "issues", "test-issues", ["test-issues"]),
             (
@@ -65,7 +65,7 @@ class TestAppstreamData:
                 {"type": "vcs-browser"},
                 "source_code",
                 "test-source",
-                "test-source",
+                ["test-source"],
             ),
         ],
     )
@@ -534,7 +534,7 @@ class TestAppstreamContent:
             - Publish snaps to the store."""
         )
         assert metadata.license == "GPL-3.0-or-later"
-        assert metadata.contact == "rrroschan@gmail.com"
+        assert metadata.contact == ["rrroschan@gmail.com"]
 
     def test_appstream_code_tags_not_swallowed(self):
         file_name = "foliate.appdata.xml"
@@ -695,7 +695,7 @@ class TestAppstreamContent:
         assert metadata.website == ["https://johnfactotum.github.io/foliate/"]
         assert metadata.issues == ["https://github.com/johnfactotum/foliate/issues"]
         assert metadata.donation == ["https://www.buymeacoffee.com/johnfactotum"]
-        assert metadata.source_code == "https://github.com/johnfactotum/foliate"
+        assert metadata.source_code == ["https://github.com/johnfactotum/foliate"]
 
     def test_appstream_url(self):
         file_name = "foliate.appdata.xml"
@@ -717,7 +717,7 @@ class TestAppstreamContent:
 
         metadata = appstream.extract(file_name, workdir=".")
         assert metadata is not None
-        assert metadata.source_code == "https://github.com/johnfactotum/foliate"
+        assert metadata.source_code == ["https://github.com/johnfactotum/foliate"]
 
     def test_appstream_with_multiple_lists(self):
         file_name = "foliate.appdata.xml"
@@ -745,7 +745,7 @@ class TestAppstreamContent:
             "https://github.com/alainm23/planify/issues",
             "https://github.com/johnfactotum/foliate/issues",
         ]
-        assert metadata.source_code == "https://github.com/johnfactotum/foliate"
+        assert metadata.source_code == ["https://github.com/johnfactotum/foliate"]
         assert metadata.website == ["https://johnfactotum.github.io/foliate/"]
         assert metadata.donation is None
 

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -194,11 +194,11 @@ def test_build_base_stable(simple_project, new_dir):
 def test_links_scalars(simple_project, new_dir):
     snap_yaml.write(
         simple_project(
-            contact="me@acme.com",
-            issues="https://hubhub.com/issues",
-            donation="https://moneyfornothing.com",
-            source_code="https://closed.acme.com",
-            website="https://acme.com",
+            contact=["me@acme.com"],
+            issues=["https://hubhub.com/issues"],
+            donation=["https://moneyfornothing.com"],
+            source_code=["https://closed.acme.com"],
+            website=["https://acme.com"],
         ),
         prime_dir=Path(new_dir),
         arch="amd64",
@@ -251,8 +251,8 @@ def test_links_lists(simple_project, new_dir):
                 "https://corner.com/issues",
             ],
             donation=["https://moneyfornothing.com", "https://prince.com"],
-            source_code="https://closed.acme.com",
-            website="https://acme.com",
+            source_code=["https://closed.acme.com"],
+            website=["https://acme.com"],
         ),
         prime_dir=Path(new_dir),
         arch="amd64",
@@ -1313,20 +1313,20 @@ def test_architectures_all(simple_project, new_dir):
 
 def test_links_for_scalars(simple_project):
     project = simple_project(
-        contact="me@acme.com",
-        issues="https://hubhub.com/issues",
-        donation="https://moneyfornothing.com",
-        source_code="https://closed.acme.com",
-        website="https://acme.com",
+        contact=["me@acme.com"],
+        issues=["https://hubhub.com/issues"],
+        donation=["https://moneyfornothing.com"],
+        source_code=["https://closed.acme.com"],
+        website=["https://acme.com"],
     )
 
     links = snap_yaml.Links.from_project(project)
 
-    assert links.contact == [project.contact]
-    assert links.issues == [project.issues]
-    assert links.donation == [project.donation]
-    assert links.source_code == [project.source_code]
-    assert links.website == [project.website]
+    assert links.contact == project.contact
+    assert links.issues == project.issues
+    assert links.donation == project.donation
+    assert links.source_code == project.source_code
+    assert links.website == project.website
 
     assert bool(links) is True
 

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -56,6 +56,8 @@ def project_yaml_data():
             "grade": "stable",
             "confinement": "strict",
             "parts": {},
+            "contact": "hello@world",
+            "website": "example.org",
             **kwargs,
         }
 
@@ -90,11 +92,11 @@ class TestProjectDefaults:
 
         assert project.build_base == project.base
         assert project.compression == "xz"
-        assert project.contact is None
+        assert project.contact == ["hello@world"]
         assert project.donation is None
         assert project.issues is None
         assert project.source_code is None
-        assert project.website is None
+        assert project.website == ["example.org"]
         assert project.type is None
         assert project.icon is None
         assert project.layout is None

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -56,8 +56,6 @@ def project_yaml_data():
             "grade": "stable",
             "confinement": "strict",
             "parts": {},
-            "contact": "hello@world",
-            "website": "example.org",
             **kwargs,
         }
 
@@ -92,11 +90,11 @@ class TestProjectDefaults:
 
         assert project.build_base == project.base
         assert project.compression == "xz"
-        assert project.contact == ["hello@world"]
+        assert project.contact is None
         assert project.donation is None
         assert project.issues is None
         assert project.source_code is None
-        assert project.website == ["example.org"]
+        assert project.website is None
         assert project.type is None
         assert project.icon is None
         assert project.layout is None
@@ -627,6 +625,66 @@ class TestProjectValidation:
             "#heading--plugs-and-slots-for-an-entire-snap)"
         )
         emitter.assert_message(expected_message)
+
+    def test_links_scalar(self, project_yaml_data):
+        data = project_yaml_data(
+            contact="https://matrix.to/#/#nickvision:matrix.org",
+            donation="https://github.com/sponsors/nlogozzo",
+            issues="https://github.com/NickvisionApps/Parabolic/issues",
+            source_code="https://github.com/NickvisionApps/Parabolic",
+            website="https://github.com/NickvisionApps/Parabolic",
+        )
+        project = Project.unmarshal(data)
+        assert project.contact == ["https://matrix.to/#/#nickvision:matrix.org"]
+        assert project.donation == ["https://github.com/sponsors/nlogozzo"]
+        assert project.issues == ["https://github.com/NickvisionApps/Parabolic/issues"]
+        assert project.source_code == ["https://github.com/NickvisionApps/Parabolic"]
+        assert project.website == ["https://github.com/NickvisionApps/Parabolic"]
+
+    def test_links_list(self, project_yaml_data):
+        data = project_yaml_data(
+            contact=[
+                "https://matrix.to/#/#nickvision:matrix.org",
+                "hello@example.org",
+            ],
+            donation=[
+                "https://github.com/sponsors/nlogozzo",
+                "https://paypal.me/nlogozzo",
+            ],
+            issues=[
+                "https://github.com/NickvisionApps/Parabolic/issues",
+                "https://github.com/NickvisionApps/Denaro/issues",
+            ],
+            source_code=[
+                "https://github.com/NickvisionApps/Parabolic",
+                "https://github.com/NickvisionApps/Denaro",
+            ],
+            website=[
+                "https://github.com/NickvisionApps/Parabolic",
+                "https://github.com/NickvisionApps/Denaro",
+            ],
+        )
+        project = Project.unmarshal(data)
+        assert project.contact == [
+            "https://matrix.to/#/#nickvision:matrix.org",
+            "hello@example.org",
+        ]
+        assert project.donation == [
+            "https://github.com/sponsors/nlogozzo",
+            "https://paypal.me/nlogozzo",
+        ]
+        assert project.issues == [
+            "https://github.com/NickvisionApps/Parabolic/issues",
+            "https://github.com/NickvisionApps/Denaro/issues",
+        ]
+        assert project.source_code == [
+            "https://github.com/NickvisionApps/Parabolic",
+            "https://github.com/NickvisionApps/Denaro",
+        ]
+        assert project.website == [
+            "https://github.com/NickvisionApps/Parabolic",
+            "https://github.com/NickvisionApps/Denaro",
+        ]
 
 
 class TestHookValidation:

--- a/tests/unit/parts/test_update_metadata.py
+++ b/tests/unit/parts/test_update_metadata.py
@@ -71,6 +71,12 @@ def project_yaml_data():
             "base": "core22",
             "grade": "stable",
             "confinement": "strict",
+            "license" : "license",
+            "contact": "contact",
+            "donation": ["donation1"],
+            "issues": ["issues1"],
+            "website": ["website1"],
+            "source-code": "source-code",
             "parts": {},
             **extra_args,
         }
@@ -89,8 +95,14 @@ def test_update_project_metadata(project_yaml_data, appstream_file, new_dir):
         title="title",
         summary="summary",
         description="description",
+        license="license",
         version="1.2.3",
         icon="assets/icon.png",
+        contact="contact",
+        donation=["donation2"],
+        issues=["issues2"],
+        website=["website2"],
+        source_code="vcs-browser",
         desktop_file_paths=["assets/file.desktop"],
     )
     assets_dir = Path("assets")
@@ -121,6 +133,11 @@ def test_update_project_metadata(project_yaml_data, appstream_file, new_dir):
     assert project.summary == "summary"  # already set in project
     assert project.description == "description"  # already set in project
     assert project.version == "0.1"  # already set in project
+    assert project.contact == "contact" # already set in project
+    assert project.issues == ["issues1", "issues2"]
+    assert project.donation == ["donation1", "donation2"]
+    assert project.website == ["website1", "website2"]
+    assert project.source_code == "source-code" # adopts from project
     assert project.icon == "assets/icon.png"
     assert project.apps["app3"].desktop == "assets/file.desktop"
 
@@ -237,7 +254,7 @@ def test_update_project_metadata_multiple(
     project = Project(**yaml_data)
     metadata1 = ExtractedMetadata(version="4.5.6")
     metadata2 = ExtractedMetadata(
-        summary="metadata summary", description="metadata description"
+        summary="metadata summary", description="metadata description", website=["website1"], source_code="source-code", issues=["issues1"], donation=["donation1"]
     )
     metadata3 = ExtractedMetadata(
         version="7.8.9", title="metadata title", grade="devel"
@@ -245,12 +262,18 @@ def test_update_project_metadata_multiple(
     metadata4 = ExtractedMetadata(
         summary="extra summary", description="extra description"
     )
+    metadata5 = ExtractedMetadata(
+        license="GPL-3.0", contact="test@test.com"
+    )
+    metadata6 = ExtractedMetadata(
+        source_code="source-code", website=["website2"], issues=["issues2"], donation=["donation2"]
+    )
     prj_vars = {"version": "", "grade": ""}
 
     update_project_metadata(
         project,
         project_vars=prj_vars,
-        metadata_list=[metadata1, metadata2, metadata3, metadata4],
+        metadata_list=[metadata1, metadata2, metadata3, metadata4, metadata5, metadata6],
         assets_dir=new_dir,
         prime_dir=new_dir,
     )
@@ -260,6 +283,12 @@ def test_update_project_metadata_multiple(
     assert project.description == expected["description"]
     assert project.title == expected["title"]
     assert project.grade == expected["grade"]
+    assert project.contact == "test@test.com"
+    assert project.license == "GPL-3.0"
+    assert project.donation == ["donation1", "donation2"]
+    assert project.source_code == "source-code"
+    assert project.issues == ["issues1", "issues2"]
+    assert project.website == ["website1", "website2"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/parts/test_update_metadata.py
+++ b/tests/unit/parts/test_update_metadata.py
@@ -72,11 +72,11 @@ def project_yaml_data():
             "grade": "stable",
             "confinement": "strict",
             "license": "license",
-            "contact": {"contact1"},
-            "donation": {"donation1"},
-            "issues": {"issues1"},
-            "website": {"website1"},
-            "source-code": {"source-code"},
+            "contact": "contact1",
+            "donation": "donation1",
+            "issues": "issues1",
+            "website": "website1",
+            "source-code": "source-code",
             "parts": {},
             **extra_args,
         }
@@ -258,8 +258,8 @@ def test_update_project_metadata_multiple(
         description="metadata description",
         website=["website1"],
         source_code=["source-code"],
-        issues=["issues1"],
-        donation=["donation1"],
+        issues=["issues1", "issues3"],
+        donation=["donation1", "donation2"],
     )
     metadata3 = ExtractedMetadata(
         version="7.8.9", title="metadata title", grade="devel"
@@ -269,9 +269,9 @@ def test_update_project_metadata_multiple(
     )
     metadata5 = ExtractedMetadata(license="GPL-3.0", contact=["test@test.com"])
     metadata6 = ExtractedMetadata(
-        source_code=["source-code"],
+        source_code=["source-code", "vcs-browser"],
         website=["website2"],
-        issues=["issues2"],
+        issues=["issues2", "issues3"],
         donation=["donation2"],
     )
     prj_vars = {"version": "", "grade": ""}
@@ -299,8 +299,8 @@ def test_update_project_metadata_multiple(
     assert project.contact == ["test@test.com"]
     assert project.license == "GPL-3.0"
     assert project.donation == ["donation1", "donation2"]
-    assert project.source_code == ["source-code"]
-    assert project.issues == ["issues1", "issues2"]
+    assert project.source_code == ["source-code", "vcs-browser"]
+    assert project.issues == ["issues1", "issues3", "issues2"]
     assert project.website == ["website1", "website2"]
 
 

--- a/tests/unit/parts/test_update_metadata.py
+++ b/tests/unit/parts/test_update_metadata.py
@@ -72,11 +72,11 @@ def project_yaml_data():
             "grade": "stable",
             "confinement": "strict",
             "license": "license",
-            "contact": "contact1",
-            "donation": "donation1",
-            "issues": "issues1",
-            "website": "website1",
-            "source-code": "source-code",
+            "contact": {"contact1"},
+            "donation": {"donation1"},
+            "issues": {"issues1"},
+            "website": {"website1"},
+            "source-code": {"source-code"},
             "parts": {},
             **extra_args,
         }
@@ -299,7 +299,7 @@ def test_update_project_metadata_multiple(
     assert project.contact == ["test@test.com"]
     assert project.license == "GPL-3.0"
     assert project.donation == ["donation1", "donation2"]
-    assert project.source_code == "source-code"
+    assert project.source_code == ["source-code"]
     assert project.issues == ["issues1", "issues2"]
     assert project.website == ["website1", "website2"]
 

--- a/tests/unit/parts/test_update_metadata.py
+++ b/tests/unit/parts/test_update_metadata.py
@@ -71,11 +71,11 @@ def project_yaml_data():
             "base": "core22",
             "grade": "stable",
             "confinement": "strict",
-            "license" : "license",
-            "contact": "contact",
-            "donation": ["donation1"],
-            "issues": ["issues1"],
-            "website": ["website1"],
+            "license": "license",
+            "contact": "contact1",
+            "donation": "donation1",
+            "issues": "issues1",
+            "website": "website1",
             "source-code": "source-code",
             "parts": {},
             **extra_args,
@@ -98,11 +98,11 @@ def test_update_project_metadata(project_yaml_data, appstream_file, new_dir):
         license="license",
         version="1.2.3",
         icon="assets/icon.png",
-        contact="contact",
+        contact=["contact2"],
         donation=["donation2"],
         issues=["issues2"],
         website=["website2"],
-        source_code="vcs-browser",
+        source_code=["vcs-browser"],
         desktop_file_paths=["assets/file.desktop"],
     )
     assets_dir = Path("assets")
@@ -133,11 +133,11 @@ def test_update_project_metadata(project_yaml_data, appstream_file, new_dir):
     assert project.summary == "summary"  # already set in project
     assert project.description == "description"  # already set in project
     assert project.version == "0.1"  # already set in project
-    assert project.contact == "contact" # already set in project
+    assert project.contact == ["contact1", "contact2"]
     assert project.issues == ["issues1", "issues2"]
     assert project.donation == ["donation1", "donation2"]
     assert project.website == ["website1", "website2"]
-    assert project.source_code == "source-code" # adopts from project
+    assert project.source_code == ["source-code", "vcs-browser"]  # adopts from project
     assert project.icon == "assets/icon.png"
     assert project.apps["app3"].desktop == "assets/file.desktop"
 
@@ -254,7 +254,12 @@ def test_update_project_metadata_multiple(
     project = Project(**yaml_data)
     metadata1 = ExtractedMetadata(version="4.5.6")
     metadata2 = ExtractedMetadata(
-        summary="metadata summary", description="metadata description", website=["website1"], source_code="source-code", issues=["issues1"], donation=["donation1"]
+        summary="metadata summary",
+        description="metadata description",
+        website=["website1"],
+        source_code=["source-code"],
+        issues=["issues1"],
+        donation=["donation1"],
     )
     metadata3 = ExtractedMetadata(
         version="7.8.9", title="metadata title", grade="devel"
@@ -262,18 +267,26 @@ def test_update_project_metadata_multiple(
     metadata4 = ExtractedMetadata(
         summary="extra summary", description="extra description"
     )
-    metadata5 = ExtractedMetadata(
-        license="GPL-3.0", contact="test@test.com"
-    )
+    metadata5 = ExtractedMetadata(license="GPL-3.0", contact=["test@test.com"])
     metadata6 = ExtractedMetadata(
-        source_code="source-code", website=["website2"], issues=["issues2"], donation=["donation2"]
+        source_code=["source-code"],
+        website=["website2"],
+        issues=["issues2"],
+        donation=["donation2"],
     )
     prj_vars = {"version": "", "grade": ""}
 
     update_project_metadata(
         project,
         project_vars=prj_vars,
-        metadata_list=[metadata1, metadata2, metadata3, metadata4, metadata5, metadata6],
+        metadata_list=[
+            metadata1,
+            metadata2,
+            metadata3,
+            metadata4,
+            metadata5,
+            metadata6,
+        ],
         assets_dir=new_dir,
         prime_dir=new_dir,
     )
@@ -283,7 +296,7 @@ def test_update_project_metadata_multiple(
     assert project.description == expected["description"]
     assert project.title == expected["title"]
     assert project.grade == expected["grade"]
-    assert project.contact == "test@test.com"
+    assert project.contact == ["test@test.com"]
     assert project.license == "GPL-3.0"
     assert project.donation == ["donation1", "donation2"]
     assert project.source_code == "source-code"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

This is the Part 2 of PR #4613. This adds a new method named `_update_project_links` which is called from the `update_project_metadata` function. It checks if the `project` has that particular metadata and if yes, then it appends the value into it, and else it casts the value onto it from the `extracted_metadata`