### PR TITLE
feat(app): support parse-info

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -41,6 +41,7 @@ from snapcraft.utils import get_host_architecture
 from snapcraft_legacy.cli import legacy
 
 from .legacy_cli import _LIB_NAMES, _ORIGINAL_LIB_NAME_LOG_LEVEL
+from .parts.yaml_utils import extract_parse_info
 
 APP_METADATA = AppMetadata(
     name="snapcraft",
@@ -61,10 +62,11 @@ MAPPED_ENV_VARS = {
 class Snapcraft(Application):
     """Snapcraft application definition."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Whether we know that we should use the core24-based codepath.
         self._known_core24 = False
+        self._parse_info: dict[str, list[str]] = {}
 
         # Locate the project file. It's used in early execution to determine
         # compatibility with previous versions of the snapcraft codebase, and in
@@ -125,6 +127,7 @@ class Snapcraft(Application):
         arch = build_on
         target_arch = build_for if build_for else get_host_architecture()
         new_yaml_data = apply_extensions(yaml_data, arch=arch, target_arch=target_arch)
+        self._parse_info = extract_parse_info(new_yaml_data)
         return apply_root_packages(new_yaml_data)
 
     @override

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -89,6 +89,7 @@ class Snapcraft(Application):
             "package",
             build_plan=self._build_plan,
             snapcraft_yaml_path=self._snapcraft_yaml_path,
+            parse_info=self._parse_info,
         )
 
         super()._configure_services(provider_name)

--- a/snapcraft/parts/extract_metadata.py
+++ b/snapcraft/parts/extract_metadata.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities to extract project metadata from lifecycle directories."""
+from __future__ import annotations
+
+import pathlib
+
+from craft_cli import emit
+from craft_parts import Part, ProjectDirs
+
+from snapcraft import meta
+
+
+def extract_lifecycle_metadata(
+    adopt_info: str | None, parse_info: dict[str, list[str]], work_dir: pathlib.Path
+) -> list[meta.ExtractedMetadata]:
+    """Obtain metadata information.
+
+    :param adopt_info: the Project's ``adopt-info``
+    :param parse_info: the ``parse-info`` information from the Project, organised
+      as a dict of "part-name" to "list of files providing metadata".
+    :param work_dir: the lifecycle's working directory.
+    """
+    if adopt_info is None or adopt_info not in parse_info:
+        return []
+
+    dirs = ProjectDirs(work_dir=work_dir)
+    part = Part(adopt_info, {}, project_dirs=dirs)
+    locations = (
+        part.part_src_dir,
+        part.part_build_dir,
+        part.part_install_dir,
+    )
+    metadata_list: list[meta.ExtractedMetadata] = []
+
+    for metadata_file in parse_info[adopt_info]:
+        emit.trace(f"extract metadata: parse info from {metadata_file}")
+
+        for location in locations:
+            if pathlib.Path(location, metadata_file.lstrip("/")).is_file():
+                metadata = meta.extract_metadata(metadata_file, workdir=str(location))
+                if metadata:
+                    metadata_list.append(metadata)
+                    break
+
+                emit.progress(
+                    f"No metadata extracted from {metadata_file}", permanent=True
+                )
+
+    return metadata_list

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -24,12 +24,13 @@ from typing import Any, Dict, List, Optional, Set
 import craft_parts
 from craft_archives import repo
 from craft_cli import emit
-from craft_parts import Action, ActionType, Part, ProjectDirs, Step
+from craft_parts import Action, ActionType, Step
 from craft_parts.packages import Repository
 from xdg import BaseDirectory  # type: ignore
 
 from snapcraft import errors
-from snapcraft.meta import ExtractedMetadata, extract_metadata
+from snapcraft.meta import ExtractedMetadata
+from snapcraft.parts.extract_metadata import extract_lifecycle_metadata
 from snapcraft.utils import convert_architecture_deb_to_platform, get_host_architecture
 
 _LIFECYCLE_STEPS = {
@@ -241,33 +242,9 @@ class PartsLifecycle:
 
     def extract_metadata(self) -> List[ExtractedMetadata]:
         """Obtain metadata information."""
-        if self._adopt_info is None or self._adopt_info not in self._parse_info:
-            return []
-
-        dirs = ProjectDirs(work_dir=self._work_dir)
-        part = Part(self._adopt_info, {}, project_dirs=dirs)
-        locations = (
-            part.part_src_dir,
-            part.part_build_dir,
-            part.part_install_dir,
+        return extract_lifecycle_metadata(
+            self._adopt_info, self._parse_info, self._work_dir
         )
-        metadata_list: List[ExtractedMetadata] = []
-
-        for metadata_file in self._parse_info[self._adopt_info]:
-            emit.trace(f"extract metadata: parse info from {metadata_file}")
-
-            for location in locations:
-                if pathlib.Path(location, metadata_file.lstrip("/")).is_file():
-                    metadata = extract_metadata(metadata_file, workdir=str(location))
-                    if metadata:
-                        metadata_list.append(metadata)
-                        break
-
-                    emit.progress(
-                        f"No metadata extracted from {metadata_file}", permanent=True
-                    )
-
-        return metadata_list
 
     def get_primed_stage_packages(self) -> List[str]:
         """Obtain the list of primed stage packages from all parts."""

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -50,6 +50,29 @@ def update_project_metadata(
     """
     _update_project_variables(project, project_vars)
 
+    update_from_extracted_metadata(
+        project, metadata_list=metadata_list, assets_dir=assets_dir, prime_dir=prime_dir
+    )
+
+    # Fields that must not end empty
+    for field in MANDATORY_ADOPTABLE_FIELDS:
+        if not getattr(project, field):
+            raise errors.SnapcraftError(
+                f"Field {field!r} was not adopted from metadata"
+            )
+
+
+def update_from_extracted_metadata(
+    project: Project,
+    *,
+    metadata_list: List[ExtractedMetadata],
+    assets_dir: Path,
+    prime_dir: Path,
+) -> None:
+    """Set project fields from extracted metadata.
+
+    See ``update_project_metadata()`` for the parameters.
+    """
     for metadata in metadata_list:
         # Data specified in the project yaml has precedence over extracted data
         if metadata.title and not project.title:
@@ -76,13 +99,6 @@ def update_project_metadata(
         _update_project_app_desktop_file(
             project, metadata=metadata, assets_dir=assets_dir, prime_dir=prime_dir
         )
-
-    # Fields that must not end empty
-    for field in MANDATORY_ADOPTABLE_FIELDS:
-        if not getattr(project, field):
-            raise errors.SnapcraftError(
-                f"Field {field!r} was not adopted from metadata"
-            )
 
 
 def _update_project_variables(project: Project, project_vars: Dict[str, str]):

--- a/tests/spread/core24/appstream-desktop/desktop/expected_snap.yaml
+++ b/tests/spread/core24/appstream-desktop/desktop/expected_snap.yaml
@@ -1,4 +1,5 @@
 name: appstream-desktop
+title: Appstream Desktop
 version: 1.0.0
 summary: Appstream Desktop test
 description: |-
@@ -12,17 +13,15 @@ description: |-
 
 
   Test me please.
+architectures:
+- amd64
+base: core24
 apps:
   appstream-desktop:
     command: usr/bin/appstream-desktop
     common-id: io.snapcraft.appstream
-    command-chain:
-    - snap/command-chain/snapcraft-runner
-architectures:
-- amd64
-assumes:
-- command-chain
-base: core24
 confinement: strict
 grade: devel
-title: Appstream Desktop
+environment:
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH

--- a/tests/spread/core24/appstream-desktop/icon-desktop/expected_snap.yaml
+++ b/tests/spread/core24/appstream-desktop/icon-desktop/expected_snap.yaml
@@ -1,4 +1,5 @@
 name: appstream-desktop
+title: Appstream Desktop
 version: 1.0.0
 summary: Appstream Desktop test
 description: |-
@@ -12,17 +13,15 @@ description: |-
 
 
   Test me please.
+architectures:
+- amd64
+base: core24
 apps:
   appstream-desktop:
     command: usr/bin/appstream-desktop
     common-id: io.snapcraft.appstream
-    command-chain:
-    - snap/command-chain/snapcraft-runner
-architectures:
-- amd64
-assumes:
-- command-chain
-base: core24
 confinement: strict
 grade: devel
-title: Appstream Desktop
+environment:
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH

--- a/tests/spread/core24/appstream-desktop/icon-desktop/snap/snapcraft.yaml
+++ b/tests/spread/core24/appstream-desktop/icon-desktop/snap/snapcraft.yaml
@@ -20,5 +20,5 @@ parts:
     override-build: |
       install -D -m 0644 io.snapcraft.appstream.desktop $CRAFT_PART_INSTALL/usr/share/applications/io.snapcraft.appstream.desktop
       install -D -m 0644 io.snapcraft.appstream.metainfo.xml $CRAFT_PART_INSTALL/usr/share/metainfo/io.snapcraft.appstream.metainfo.xml
-      install -D -m 0644 snapcraft.svg $PCRAFT_PART_INSTALL/usr/share/icons/hicolor/scalable/apps/snapcraft.svg
+      install -D -m 0644 snapcraft.svg $CRAFT_PART_INSTALL/usr/share/icons/hicolor/scalable/apps/snapcraft.svg
       install -D -m 0755 appstream-desktop $CRAFT_PART_INSTALL/usr/bin/appstream-desktop

--- a/tests/spread/core24/appstream-desktop/task.yaml
+++ b/tests/spread/core24/appstream-desktop/task.yaml
@@ -12,9 +12,8 @@ systems:
 
 restore: |
   cd "${SNAP}"
-  # - extra field 'parse-info' not permitted in 'parts.appstream-desktop' configuration
-  snapcraft clean 2>&1 | MATCH "extra field "; exit 0
-  snapcraft clean --destructive-mode 2>&1 | MATCH "extra field "; exit 0
+  snapcraft clean
+  snapcraft clean --destructive-mode
   rm -f ./*.snap
 
 execute: |

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -481,6 +481,7 @@ def package_service(
         services=default_factory,
         snapcraft_yaml_path=file_path,
         build_plan=default_build_plan,
+        parse_info={},
     )
 
 

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -25,6 +25,9 @@ from craft_application.models import SummaryStr, VersionStr
 
 from snapcraft import __version__, linters, meta, models, pack, services
 from snapcraft.application import APP_METADATA
+from snapcraft.meta import ExtractedMetadata
+from snapcraft.parts import extract_metadata, update_metadata
+from snapcraft.services import Package
 
 
 @pytest.mark.usefixtures("default_factory")
@@ -61,6 +64,7 @@ def test_pack_target_arch(
         services=default_factory,
         build_plan=default_build_plan,
         snapcraft_yaml_path=tmp_path / "snapcraft.yaml",
+        parse_info={},
     )
 
     package_service.pack(prime_dir=tmp_path / "prime", dest=tmp_path)
@@ -330,3 +334,63 @@ def test_write_metadata_with_project_gui(
     assert (meta_dir / "gui" / "default.default.desktop").read_text() == "desktop_file"
     assert (meta_dir / "gui" / "icon.png").exists()
     assert (meta_dir / "gui" / "icon.png").read_text() == "package_png_icon"
+
+
+@pytest.fixture
+def extra_project_params(extra_project_params):
+    #     extra_project_params["version"] = None
+    #     extra_project_params["summary"] = None
+    #     extra_project_params["description"] = None
+    extra_project_params["adopt-info"] = "my-part"
+
+    #     extra_project_params["parts"] = {"my-part": {"plugin": "nil"}}
+    return extra_project_params
+
+
+def test_update_project_parse_info(
+    default_project, default_factory, default_build_plan, new_dir, mocker
+):
+    work_dir = Path("work").resolve()
+
+    default_factory.set_kwargs(
+        "lifecycle",
+        work_dir=work_dir,
+        cache_dir=new_dir,
+        build_plan=default_build_plan,
+    )
+
+    lifecycle = default_factory.lifecycle
+    project_info = lifecycle.project_info
+    project_info.execution_finished = True
+
+    fake_metadata = ExtractedMetadata()
+    mocked_extract = mocker.patch.object(
+        extract_metadata, "extract_lifecycle_metadata", return_value=[fake_metadata]
+    )
+    mocked_update = mocker.patch.object(
+        update_metadata, "update_from_extracted_metadata"
+    )
+
+    parse_info = {"my-part": ["file.metadata.xml"]}
+    package = Package(
+        app=APP_METADATA,
+        project=default_project,
+        services=default_factory,
+        snapcraft_yaml_path=new_dir / "snapcraft.yaml",
+        build_plan=default_build_plan,
+        parse_info=parse_info,
+    )
+
+    package.update_project()
+
+    mocked_extract.assert_called_once_with(
+        default_project.adopt_info,
+        parse_info,
+        work_dir,
+    )
+    mocked_update.assert_called_once_with(
+        default_project,
+        metadata_list=[fake_metadata],
+        assets_dir=new_dir / "snap",
+        prime_dir=work_dir / "prime",
+    )

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -135,3 +135,37 @@ def test_application_managed_core20_fallback(monkeypatch, new_dir, mocker):
 
     mock_create_app.assert_not_called()
     mock_legacy_run.assert_called()
+
+
+PARSE_INFO_PROJECT = dedent(
+    """\
+    name: parse-info-project
+    base: core24
+    build-base: devel
+
+    grade: devel
+    confinement: strict
+    adopt-info: parse-info-part
+
+    parts:
+      parse-info-part:
+        plugin: nil
+        source: .
+        parse-info: [usr/share/metainfo/metainfo.xml]
+"""
+)
+
+
+def test_get_project_parse_info(new_dir):
+    """Test that parse-info data is correctly extracted and stored when loading
+    the project from a YAML file."""
+    snap_dir = new_dir / "snap"
+    snap_dir.mkdir()
+    project_yaml = snap_dir / "snapcraft.yaml"
+    project_yaml.write_text(PARSE_INFO_PROJECT)
+
+    app = application.create_app()
+    assert app._parse_info == {}
+
+    _project = app.get_project()
+    assert app._parse_info == {"parse-info-part": ["usr/share/metainfo/metainfo.xml"]}


### PR DESCRIPTION
This is split over multiple commits. The first (valid) one only extracts and stores the data of which part provides the info to be parsed. This lets the project be loaded successfully as the 'parse-info' entry is removed from the parts, but nothing else. The next commit adds the rest of the implementation, and the final commit updates the spread tests.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
