### PR TITLE
fix(test): do not create 2 snapcraft.yaml and confuse location

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -434,9 +434,7 @@ def default_build_plan():
 
 
 @pytest.fixture()
-def lifecycle_service(
-    default_project, default_factory, default_build_plan, snapcraft_yaml, tmp_path
-):
+def lifecycle_service(default_project, default_factory, default_build_plan, tmp_path):
     from snapcraft.application import APP_METADATA
     from snapcraft.services import Lifecycle
 
@@ -472,7 +470,7 @@ def package_service(
     from snapcraft.application import APP_METADATA
     from snapcraft.services import Package
 
-    file_path = tmp_path / "snapcraft.yaml"
+    file_path = tmp_path / "snap" / "snapcraft.yaml"
     snapcraft_yaml(filename=file_path)
 
     return Package(

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -16,6 +16,7 @@
 
 """Tests for the Snapcraft Package service."""
 import datetime
+import shutil
 from pathlib import Path
 from textwrap import dedent
 
@@ -191,6 +192,11 @@ def project_hooks_dir(new_dir, request):
 def test_write_metadata_with_project_hooks(
     package_service, default_factory, default_build_plan, new_dir, project_hooks_dir
 ):
+    if "build-aux" in str(project_hooks_dir):
+        # /build-aux cannot co-exist with /snap
+        shutil.move(new_dir / "snap" / "snapcraft.yaml", new_dir)
+        shutil.rmtree(new_dir / "snap")
+
     default_factory.set_kwargs(
         "lifecycle",
         work_dir=Path("work"),


### PR DESCRIPTION
There are 2 bugs:

First, the current fixture `snapcraft_yaml` may create 2 `snapcraft.yaml` in `/` and `/snap/` due to it used in different places and it is default to `/snap/snapcraft.yaml`. 

When both `snapcraft.yaml` exists, the `/snapcraft.yaml` is used without any error / warning.

The second bug is when `/snap/snapcraft.yaml` exists,  `/build-aux/snap` will be ignored even if it had hooks in it. This is probably expected behavior since these are two different versions of the structure.

Needs #4661
