### PR TITLE
fix: use "devel" bases on build plan

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1139,6 +1139,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
                     build_base=self.build_base,
                     project_type=self.project_type,
                     name=self.name,
+                    translate_devel=False,  # We want actual "devel" if set.
                 )
             )
         ].value

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -847,35 +847,6 @@ class Project(models.Project):
 
         return None
 
-    def get_build_plan(self) -> List[BuildInfo]:
-        """Get the build plan for core22 projects."""
-        build_plan: List[BuildInfo] = []
-
-        architectures = cast(List[Architecture], self.architectures)
-
-        # pylint: disable-next=not-an-iterable
-        for arch in architectures:
-            # build_for will be a single element list
-            build_for = cast(list, arch.build_for)[0]
-
-            # TODO: figure out when to filter `all`
-            if build_for == "all":
-                build_for = get_host_architecture()
-
-            # build on will be a list of archs
-            for build_on in arch.build_on:
-                base = SNAPCRAFT_BASE_TO_PROVIDER_BASE[self.get_effective_base()]
-                build_plan.append(
-                    BuildInfo(
-                        platform=f"ubuntu@{base.value}",
-                        build_on=build_on,
-                        build_for=build_for,
-                        base=bases.BaseName("ubuntu", base.value),
-                    )
-                )
-
-        return build_plan
-
 
 class _GrammarAwareModel(pydantic.BaseModel):
     class Config:

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -213,19 +213,23 @@ def get_effective_base(
     build_base: Optional[str],
     project_type: Optional[str],
     name: Optional[str],
+    translate_devel: bool = True,
 ) -> Optional[str]:
     """Return the base to use to create the snap.
 
     Return the build-base if set.
     Exception:
-    "base" snaps will return name if build-base is not set.
-    "devel" snaps, return the base, where the true base is, except "base" snaps.
+    - "base" snaps will return name if build-base is not set.
+    - For snaps with "devel" "build-base", if the "project_type" is "base",
+      returns "devel". Otherwise:
+        - if "translate_devel" is True, returns the "base";
+        - otherwise, returns "devel".
     """
     if project_type == "base":
         return build_base if build_base else name
 
     if build_base is not None:
-        if build_base == "devel":
+        if build_base == "devel" and translate_devel:
             return base
         return build_base
 

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -1913,6 +1913,28 @@ def test_build_planner_get_build_plan(platforms, expected_build_infos):
     assert actual_build_infos == expected_build_infos
 
 
+def test_get_build_plan_devel():
+    """Test that "devel" build-bases are correctly reflected on the build plan"""
+    planner = snapcraft.models.project.SnapcraftBuildPlanner.parse_obj(
+        {
+            "name": "test-snap",
+            "base": "core24",
+            "build-base": "devel",
+            "platforms": {"amd64": None},
+        }
+    )
+
+    build_plan = planner.get_build_plan()
+    assert build_plan == [
+        BuildInfo(
+            build_on="amd64",
+            build_for="amd64",
+            base=BaseName(name="ubuntu", version="devel"),
+            platform="amd64",
+        )
+    ]
+
+
 def test_platform_default():
     """Default value for platforms is the host architecture."""
     planner = snapcraft.models.project.SnapcraftBuildPlanner.parse_obj(
@@ -1961,6 +1983,7 @@ def test_build_planner_get_build_plan_base(mocker):
         build_base="test-build-base",
         project_type="test-type",
         name="test-snap",
+        translate_devel=False,
     )
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -129,6 +129,21 @@ def test_get_effective_base(base, build_base, project_type, name, expected_base)
     assert result == expected_base
 
 
+def test_get_effective_base_translate_devel():
+    params = {
+        "base": "core24",
+        "build_base": "devel",
+        "project_type": None,
+        "name": "my-project",
+    }
+
+    translate_true = utils.get_effective_base(translate_devel=True, **params)
+    assert translate_true == "core24"
+
+    translate_false = utils.get_effective_base(translate_devel=False, **params)
+    assert translate_false == "devel"
+
+
 def test_get_os_platform_linux(tmp_path, mocker):
     """Utilize an /etc/os-release file to determine platform."""
     # explicitly add commented and empty lines, for parser robustness


### PR DESCRIPTION
For the BuildInfos we want to use "devel" bases, as that is the term that craft-providers expects to create instances based on the development track. We still need to use the regular "base" (e.g. "core24") in other places, so add a customization parameter to get_effective_base() to use either behavior.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
