### PR TITLE
feat(project): add get_archs_list for Architecture model

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -29,6 +29,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
     cast,
@@ -424,6 +425,33 @@ class Architecture(models.CraftBaseModel, extra=pydantic.Extra.forbid):
 
     build_on: Union[str, UniqueStrList]
     build_for: Optional[Union[str, UniqueStrList]]
+
+    def get_archs_list(self) -> List[str]:
+        """Get the unique list of architectures.
+
+        Since `build_on` and `build_for` could be str or list, provide a method
+        to easily get the list of unique architectures to use.
+
+        This will return `build-for` if set, otherwise `build-on`.
+
+        :returns: A list of unique architectures.
+        """
+        archs_set: Set[str] = set()
+
+        if isinstance(self.build_for, str):
+            archs_set.add(self.build_for)
+        elif isinstance(self.build_for, list):
+            for arch in self.build_for:
+                archs_set.add(arch)
+
+        if not archs_set:
+            if isinstance(self.build_on, str):
+                archs_set.add(self.build_on)
+            elif isinstance(self.build_on, list):
+                for arch in self.build_on:
+                    archs_set.add(arch)
+
+        return list(archs_set)
 
 
 class ContentPlug(models.CraftBaseModel):

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -1815,6 +1815,58 @@ class TestArchitecture:
             "Use 'platforms' keyword instead."
         ) in str(raised.value)
 
+    @pytest.mark.parametrize(
+        ("architectures", "expected"),
+        [
+            (Architecture(build_on="amd64", build_for=None), ["amd64"]),
+            (Architecture(build_on="amd64", build_for=UniqueStrList([])), ["amd64"]),
+            (Architecture(build_on="amd64", build_for="i386"), ["i386"]),
+            (
+                Architecture(build_on="amd64", build_for=UniqueStrList(["i386"])),
+                ["i386"],
+            ),
+            (
+                Architecture(
+                    build_on="amd64", build_for=UniqueStrList(["amd64", "i386"])
+                ),
+                ["i386", "amd64"],
+            ),
+            (
+                Architecture(build_on=UniqueStrList(["arm64"]), build_for=None),
+                ["arm64"],
+            ),
+            (
+                Architecture(build_on=UniqueStrList(["arm64"]), build_for="armhf"),
+                ["armhf"],
+            ),
+            (
+                Architecture(
+                    build_on=UniqueStrList(["arm64"]),
+                    build_for=UniqueStrList(["armhf"]),
+                ),
+                ["armhf"],
+            ),
+            (
+                Architecture(
+                    build_on=UniqueStrList(["arm64"]),
+                    build_for=UniqueStrList(["armhf", "arm64"]),
+                ),
+                ["armhf", "arm64"],
+            ),
+            (
+                Architecture(
+                    build_on=UniqueStrList(["amd64", "arm64"]),
+                    build_for=UniqueStrList(["armhf", "riscv"]),
+                ),
+                ["armhf", "riscv"],
+            ),
+        ],
+    )
+    def test_architecture_get_archs_list(self, architectures, expected):
+        """Test `get_archs_list()`."""
+
+        assert set(architectures.get_archs_list()) == set(expected)
+
 
 class TestApplyRootPackages:
     """Test Transform the Project."""


### PR DESCRIPTION
`Architecture.get_archs_list` provides a quick way to get a list of all required build targets