### PR TITLE
chore(spread): core22 provider setup cleanup

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -236,6 +236,8 @@ suites:
      - ubuntu-22.04-armhf
      - ubuntu-22.04-s390x
      - ubuntu-22.04-ppc64el
+   environment:
+     SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
  tests/spread/core22/environment/:
    summary: core22 environment tests

--- a/tests/spread/core22/chisel-base/task.yaml
+++ b/tests/spread/core22/chisel-base/task.yaml
@@ -1,8 +1,5 @@
 summary: Build a simple snap
 
-environment:
-  SNAPCRAFT_BUILD_ENVIRONMENT: ""
-
 restore: |
   snapcraft clean
   rm -f ./*.snap

--- a/tests/spread/core22/clean/task.yaml
+++ b/tests/spread/core22/clean/task.yaml
@@ -21,9 +21,6 @@ restore: |
 execute: |
   cd "./snaps/$SNAP"
 
-  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
-
   snapcraft pack
   snapcraft clean part1
   lxc --project=snapcraft list | grep snapcraft-clean

--- a/tests/spread/core22/craftctl/task.yaml
+++ b/tests/spread/core22/craftctl/task.yaml
@@ -14,6 +14,7 @@ restore: |
   cd "$SNAP"
   rm -f ./*.snap
   rm -Rf work
+  snapcraft clean --destructive-mode
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"

--- a/tests/spread/core22/invalid-utf8/task.yaml
+++ b/tests/spread/core22/invalid-utf8/task.yaml
@@ -1,8 +1,8 @@
 summary: Handle invalid utf-8 text during the build
 
 restore: |
-  snapcraft clean
+  snapcraft clean --destructive-mode
   rm -f ./*.snap
 
 execute: |
-  snapcraft pack -v 2>&1 | MATCH ":: hi � bye"
+  snapcraft pack --destructive-mode -v 2>&1 | MATCH ":: hi � bye"

--- a/tests/spread/core22/package-repo-archs/task.yaml
+++ b/tests/spread/core22/package-repo-archs/task.yaml
@@ -3,7 +3,6 @@ summary: Test using package-repositories with different architectures on core22
 environment:
   SNAP_ARCH/i386: i386
   SNAP_ARCH/armhf: armhf
-  SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
 restore: |
   snapcraft clean
@@ -16,4 +15,4 @@ execute: |
   cp "$SNAP_ARCH".yaml snap/snapcraft.yaml
 
   # The part's build script does the checking.
-  snapcraft build --verbose --use-lxd
+  snapcraft build --verbose

--- a/tests/spread/core22/package-repositories/task.yaml
+++ b/tests/spread/core22/package-repositories/task.yaml
@@ -7,7 +7,6 @@ environment:
   SNAP/test_apt_ppa: test-apt-ppa
   SNAP/test_pin: test-pin
   SNAP/test_multi_keys: test-multi-keys
-  SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
 restore: |
   cd "$SNAP"

--- a/tests/spread/core22/packing/task.yaml
+++ b/tests/spread/core22/packing/task.yaml
@@ -17,7 +17,7 @@ prepare: |
   # set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
 restore: |
-  snapcraft clean
+  snapcraft clean --destructive-mode
   rm -Rf subdir ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -26,7 +26,7 @@ restore: |
 
 execute: |
   # shellcheck disable=SC2086
-  snapcraft $CMD
+  snapcraft $CMD --destructive-mode
 
   if echo "$CMD" | grep subdir/output; then
     test -f subdir/output.snap

--- a/tests/spread/core22/remove-hook/task.yaml
+++ b/tests/spread/core22/remove-hook/task.yaml
@@ -16,8 +16,6 @@ restore: |
   install_snapcraft
 
 execute: |
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
-
   # create a base instance by running snapcraft
   snapcraft pull --use-lxd --verbosity=trace
 

--- a/tests/spread/core22/set-version-twice/task.yaml
+++ b/tests/spread/core22/set-version-twice/task.yaml
@@ -5,7 +5,7 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
 
 restore: |
-  snapcraft clean
+  snapcraft clean --destructive-mode
   rm -Rf subdir ./*.snap
   rm -f snap/*.yaml
 
@@ -16,14 +16,14 @@ execute: |
   mkdir -p snap
   cp original-snapcraft.yaml snap/snapcraft.yaml
 
-  snapcraft prime
+  snapcraft prime --destructive-mode
 
   cp modified-snapcraft.yaml snap/snapcraft.yaml
 
   snapcraft build part2
-  snapcraft prime
+  snapcraft prime --destructive-mode
 
   cp original-snapcraft.yaml snap/snapcraft.yaml
 
   snapcraft build part2
-  snapcraft prime
+  snapcraft prime --destructive-mode

--- a/tests/spread/core22/snap-creation/task.yaml
+++ b/tests/spread/core22/snap-creation/task.yaml
@@ -10,6 +10,7 @@ prepare: |
 
 restore: |
   cd "$SNAP"
+  snapcraft clean --destructive-mode
   rm -f ./*.snap
   rm -Rf work
 
@@ -19,5 +20,5 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  snapcraft 2>&1 | tee progress.txt
+  snapcraft --destructive-mode 2>&1 | tee progress.txt
   grep "Created snap package ${SNAP}_1.0_amd64.snap" progress.txt

--- a/tests/spread/core22/try/task.yaml
+++ b/tests/spread/core22/try/task.yaml
@@ -6,11 +6,10 @@ execute: |
   mkdir prime
   chmod a+w prime
   
-  unset SNAPCRAFT_BUILD_ENVIRONMENT
   # Prime first to regression test snapcore/snapcraft#4219
-  snapcraft prime --use-lxd
+  snapcraft prime
   # Followed by the actual try
-  snapcraft try --use-lxd
+  snapcraft try
   
   find prime/meta/snap.yaml
   find prime/usr/bin/hello


### PR DESCRIPTION
Also make the clean actually clean the correct provider

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
