### PR TITLE
Enable Snapcraft plugins in craft-application codepath

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -29,6 +29,7 @@ import craft_application.commands as craft_app_commands
 import craft_cli
 from craft_application import Application, AppMetadata, util
 from craft_cli import emit
+from craft_parts.plugins.plugins import PluginType
 from overrides import override
 
 import snapcraft
@@ -41,6 +42,7 @@ from snapcraft.utils import get_host_architecture
 from snapcraft_legacy.cli import legacy
 
 from .legacy_cli import _LIB_NAMES, _ORIGINAL_LIB_NAME_LOG_LEVEL
+from .parts import plugins
 from .parts.yaml_utils import extract_parse_info
 
 APP_METADATA = AppMetadata(
@@ -82,6 +84,9 @@ class Snapcraft(Application):
         for craft_var, snapcraft_var in MAPPED_ENV_VARS.items():
             if env_val := os.getenv(snapcraft_var):
                 os.environ[craft_var] = env_val
+
+    def _get_app_plugins(self) -> dict[str, PluginType]:
+        return plugins.get_plugins(core22=False)
 
     @override
     def _configure_services(self, provider_name: str | None) -> None:

--- a/snapcraft/parts/plugins/__init__.py
+++ b/snapcraft/parts/plugins/__init__.py
@@ -22,7 +22,7 @@ from .conda_plugin import CondaPlugin
 from .flutter_plugin import FlutterPlugin
 from .kernel_plugin import KernelPlugin
 from .python_plugin import PythonPlugin
-from .register import register
+from .register import get_plugins, register
 
 __all__ = [
     "ColconPlugin",
@@ -30,5 +30,6 @@ __all__ = [
     "FlutterPlugin",
     "KernelPlugin",
     "PythonPlugin",
+    "get_plugins",
     "register",
 ]

--- a/snapcraft/parts/plugins/register.py
+++ b/snapcraft/parts/plugins/register.py
@@ -17,6 +17,7 @@
 """Snapcraft provided plugin registration."""
 
 import craft_parts
+from craft_parts.plugins.plugins import PluginType
 
 from .colcon_plugin import ColconPlugin
 from .conda_plugin import CondaPlugin
@@ -25,10 +26,24 @@ from .kernel_plugin import KernelPlugin
 from .python_plugin import PythonPlugin
 
 
+def get_plugins(core22: bool) -> dict[str, PluginType]:
+    """Get the dict of Snapcraft-specific plugins.
+
+    :param core22: Whether core22-only plugins should be included.
+    """
+    plugins = {
+        "colcon": ColconPlugin,
+        "conda": CondaPlugin,
+        "flutter": FlutterPlugin,
+        "python": PythonPlugin,
+    }
+
+    if core22:
+        plugins["kernel"] = KernelPlugin
+
+    return plugins
+
+
 def register() -> None:
-    """Register Snapcraft plugins."""
-    craft_parts.plugins.register({"colcon": ColconPlugin})
-    craft_parts.plugins.register({"conda": CondaPlugin})
-    craft_parts.plugins.register({"flutter": FlutterPlugin})
-    craft_parts.plugins.register({"python": PythonPlugin})
-    craft_parts.plugins.register({"kernel": KernelPlugin})
+    """Register Snapcraft plugins for core22."""
+    craft_parts.plugins.register(get_plugins(core22=True))

--- a/snapcraft/services/lifecycle.py
+++ b/snapcraft/services/lifecycle.py
@@ -65,6 +65,8 @@ class Lifecycle(LifecycleService):
         self._manager_kwargs.update(
             base=project.get_effective_base(),
             extra_build_snaps=project.get_extra_build_snaps(),
+            confinement=project.confinement,
+            project_base=project.base or "",
         )
         super().setup()
 

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -158,3 +158,29 @@ def test_generate_manifest(
     assert lifecycle_service.get_primed_stage_packages.mock_calls == [
         mock.call(part_name=part_name) for part_name in parts
     ]
+
+
+@pytest.mark.parametrize("base", ["core24", None])
+@pytest.mark.parametrize("confinement", ["strict", "devmode", "classic"])
+def test_lifecycle_custom_arguments(
+    lifecycle_service, default_project, base, confinement
+):
+    """Test that the lifecycle project has the correct project base and confinement."""
+
+    # Set the base and confinement on the project. This roundabout way here
+    # is because the validators make it hard to update the base from/to None
+    # without "type" being already correct.
+    new_attrs = {"base": base, "confinement": confinement}
+    if base is None:
+        new_attrs["type"] = "base"
+    default_project.__dict__.update(**new_attrs)
+
+    lifecycle_service.setup()
+
+    info = lifecycle_service.project_info
+
+    expected_confinement = confinement
+    expected_base = base if base is not None else ""
+
+    assert info.project_base == expected_base
+    assert info.confinement == expected_confinement

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -236,3 +236,12 @@ def test_parse_info_integrated(monkeypatch, mocker, new_dir):
     assert snap_yaml["summary"] == "Sample summary"
     assert snap_yaml["description"] == "Sample description"
     assert snap_yaml["version"] == "1.2.3"
+
+
+def test_application_plugins():
+    app = application.create_app()
+    plugins = app._get_app_plugins()
+
+    # Just do some sanity checks.
+    assert "python" in plugins
+    assert "kernel" not in plugins


### PR DESCRIPTION
Two commits: one registers the plugins in the craft-application codepath, and one adds the confinement and base variables to the lifecycle (so that plugins can use it).