### PR TITLE
feat: add component metadata for hooks

### DIFF
--- a/snapcraft/meta/component_yaml.py
+++ b/snapcraft/meta/component_yaml.py
@@ -25,7 +25,11 @@ from snapcraft.errors import SnapcraftError
 
 
 class ComponentMetadata(BaseMetadata):
-    """The component.yaml model."""
+    """The component.yaml model.
+
+    Component hooks are not included in the component's metadata.
+    Instead, they are included in the snap's metadata.
+    """
 
     component: str
     type: str

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -235,6 +235,7 @@ class ComponentMetadata(SnapcraftMetadata):  # type: ignore # (pydantic plugin i
     summary: SummaryStr
     description: str
     type: str
+    hooks: dict[str, models.Hook] | None
 
     @override
     class Config(BaseMetadata.Config):

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -541,6 +541,7 @@ class Component(models.CraftBaseModel):
     description: str
     type: Literal["test"]
     version: Optional[VersionStr]  # type: ignore[assignment]
+    hooks: dict[str, Hook] | None
 
     @pydantic.validator("version")
     @classmethod

--- a/tests/spread/core22/components/expected-snap.yaml
+++ b/tests/spread/core22/components/expected-snap.yaml
@@ -1,0 +1,20 @@
+name: hello-components
+version: '1.0'
+summary: Build a snap with components
+description: Build a snap with components
+architectures:
+- amd64
+base: core22
+apps:
+  hello:
+    command: bin/hello
+confinement: strict
+grade: devel
+environment:
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+components:
+  share:
+    summary: Hello World
+    description: Hello World
+    type: test

--- a/tests/spread/core22/components/expected-snap.yaml
+++ b/tests/spread/core22/components/expected-snap.yaml
@@ -18,3 +18,8 @@ components:
     summary: Hello World
     description: Hello World
     type: test
+    hooks:
+      install:
+        plugs:
+        - home
+        - network

--- a/tests/spread/core22/components/snapcraft.yaml
+++ b/tests/spread/core22/components/snapcraft.yaml
@@ -16,6 +16,9 @@ components:
     summary: Hello World
     description: Hello World
     version: "1.0"
+    hooks:
+      install:
+        plugs: ["home", "network"]
 
 parts:
   hello:

--- a/tests/spread/core22/components/task.yaml
+++ b/tests/spread/core22/components/task.yaml
@@ -19,7 +19,7 @@ execute: |
   fi
 
   # assert snap metadata
-  if ! diff snap-contents/meta/snap.yaml expected-snap.yaml; then
+  if ! diff -u snap-contents/meta/snap.yaml expected-snap.yaml; then
     echo "Metadata for the snap is incorrect."
     exit 1
   fi
@@ -44,7 +44,7 @@ execute: |
   fi
   
   # assert contents of component metadata
-  if ! diff component-contents/meta/component.yaml expected-component.yaml; then
+  if ! diff -u component-contents/meta/component.yaml expected-component.yaml; then
     echo "Metadata for the share component is incorrect."
     exit 1
   fi

--- a/tests/spread/core22/components/task.yaml
+++ b/tests/spread/core22/components/task.yaml
@@ -11,10 +11,16 @@ restore: |
 execute: |
   snapcraft pack
 
-  # assert contents of default partition
+  # assert snap contents
   unsquashfs -dest "snap-contents" "hello-components_1.0_amd64.snap"
   if [ ! -e "snap-contents/bin/hello" ]; then
     echo "Expected 'bin/hello' in snap contents"
+    exit 1
+  fi
+
+  # assert snap metadata
+  if ! diff snap-contents/meta/snap.yaml expected-snap.yaml; then
+    echo "Metadata for the snap is incorrect."
     exit 1
   fi
 

--- a/tests/spread/core24/components/expected-snap.yaml
+++ b/tests/spread/core24/components/expected-snap.yaml
@@ -18,3 +18,8 @@ components:
     summary: Hello World
     description: Hello World
     type: test
+    hooks:
+      install:
+        plugs:
+        - home
+        - network

--- a/tests/spread/core24/components/expected-snap.yaml
+++ b/tests/spread/core24/components/expected-snap.yaml
@@ -1,0 +1,20 @@
+name: hello-components
+version: '1.0'
+summary: Build a snap with components
+description: Build a snap with components
+architectures:
+- amd64
+base: core24
+apps:
+  hello:
+    command: bin/hello
+confinement: strict
+grade: devel
+environment:
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+components:
+  share:
+    summary: Hello World
+    description: Hello World
+    type: test

--- a/tests/spread/core24/components/snapcraft.yaml
+++ b/tests/spread/core24/components/snapcraft.yaml
@@ -17,6 +17,9 @@ components:
     summary: Hello World
     description: Hello World
     version: "1.0"
+    hooks:
+      install:
+        plugs: ["home", "network"]
 
 parts:
   hello:

--- a/tests/spread/core24/components/task.yaml
+++ b/tests/spread/core24/components/task.yaml
@@ -19,7 +19,7 @@ execute: |
   fi
 
   # assert snap metadata
-  if ! diff snap-contents/meta/snap.yaml expected-snap.yaml; then
+  if ! diff -u snap-contents/meta/snap.yaml expected-snap.yaml; then
     echo "Metadata for the snap is incorrect."
     exit 1
   fi
@@ -44,7 +44,7 @@ execute: |
   fi
   
   # assert contents of component metadata
-  if ! diff component-contents/meta/component.yaml expected-component.yaml; then
+  if ! diff -u component-contents/meta/component.yaml expected-component.yaml; then
     echo "Metadata for the share component is incorrect."
     exit 1
   fi

--- a/tests/spread/core24/components/task.yaml
+++ b/tests/spread/core24/components/task.yaml
@@ -11,10 +11,16 @@ restore: |
 execute: |
   snapcraft pack
 
-  # assert contents of default partition
+  # assert snap contents
   unsquashfs -dest "snap-contents" "hello-components_1.0_amd64.snap"
   if [ ! -e "snap-contents/bin/hello" ]; then
     echo "Expected 'bin/hello' in snap contents"
+    exit 1
+  fi
+
+  # assert snap metadata
+  if ! diff snap-contents/meta/snap.yaml expected-snap.yaml; then
+    echo "Metadata for the snap is incorrect."
     exit 1
   fi
 

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -3,7 +3,9 @@ summary: Test the store workflow
 manual: true
 
 environment:
-  SNAP: "/snapcraft/tests/spread/core22/components/"
+  # use a core22 snap with components but no component hooks
+  # this can be changed after the snap store and review-tools have more support for components
+  SNAP: "/snapcraft/tests/spread/core22/components-environment/"
   SNAPCRAFT_STORE_CREDENTIALS/ubuntu_one: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"
   SNAPCRAFT_STORE_CREDENTIALS/legacy: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_LEGACY})"
   SNAPCRAFT_STORE_CREDENTIALS/candid: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_CANDID})"

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -55,7 +55,7 @@ execute: |
   cd "$SNAP"
   snap_file=$(ls ./*.snap)
   foo_component_file=$(ls ./test-snapcraft*+foo_1.0.comp)
-  bar_component_file=$(ls ./test-snapcraft*+bar_1.0.comp)
+  bar_component_file=$(ls ./test-snapcraft*+bar-baz_1.0.comp)
   snap_name=$(grep "name: " snapcraft.yaml | sed -e "s/name: \(.*$\)/\1/")
 
   # Login mechanism
@@ -71,7 +71,7 @@ execute: |
   snapcraft list
 
   # Push and Release
-  snapcraft upload "${snap_file}" --release edge --component "foo=${foo_component_file}" --component "bar=${bar_component_file}"
+  snapcraft upload "${snap_file}" --release edge --component "foo=${foo_component_file}" --component "bar-baz=${bar_baz_component_file}"
 
   # Show revisions
   snapcraft list-revisions "${snap_name}"

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -55,7 +55,7 @@ execute: |
   cd "$SNAP"
   snap_file=$(ls ./*.snap)
   foo_component_file=$(ls ./test-snapcraft*+foo_1.0.comp)
-  bar_component_file=$(ls ./test-snapcraft*+bar-baz_1.0.comp)
+  bar_baz_component_file=$(ls ./test-snapcraft*+bar-baz_1.0.comp)
   snap_name=$(grep "name: " snapcraft.yaml | sed -e "s/name: \(.*$\)/\1/")
 
   # Login mechanism

--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -54,7 +54,8 @@ execute: |
   # Get information about our snap.
   cd "$SNAP"
   snap_file=$(ls ./*.snap)
-  component_file=$(ls ./*.comp)
+  foo_component_file=$(ls ./test-snapcraft*+foo_1.0.comp)
+  bar_component_file=$(ls ./test-snapcraft*+bar_1.0.comp)
   snap_name=$(grep "name: " snapcraft.yaml | sed -e "s/name: \(.*$\)/\1/")
 
   # Login mechanism
@@ -70,7 +71,7 @@ execute: |
   snapcraft list
 
   # Push and Release
-  snapcraft upload "${snap_file}" --release edge --component "share=${component_file}"
+  snapcraft upload "${snap_file}" --release edge --component "foo=${foo_component_file}" --component "bar=${bar_component_file}"
 
   # Show revisions
   snapcraft list-revisions "${snap_name}"

--- a/tests/unit/meta/test_component_yaml.py
+++ b/tests/unit/meta/test_component_yaml.py
@@ -50,6 +50,10 @@ def stub_project_data():
                 "summary": "test summary",
                 "description": "test description",
                 "version": "1.0",
+                "hooks": {
+                    "install": {"plugs": ["home", "network"]},
+                    "post-refresh": {},
+                },
             },
         },
     }

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022-2023 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -418,6 +418,21 @@ def complex_project():
             description: test
             type: test
             version: "1.0"
+            hooks:
+              install:
+                command-chain:
+                - test
+                environment:
+                  test-variable-1: test
+                  test-variable-2: test
+                plugs:
+                - home
+                - network
+                passthrough:
+                  somefield:
+                  - some
+                  - value
+              post-refresh: {}
           component-b:
             summary: test
             description: test
@@ -558,6 +573,21 @@ def test_complex_snap_yaml(complex_project, new_dir):
             summary: test
             description: test
             type: test
+            hooks:
+              install:
+                command-chain:
+                - test
+                environment:
+                  test-variable-1: test
+                  test-variable-2: test
+                plugs:
+                - home
+                - network
+                passthrough:
+                  somefield:
+                  - some
+                  - value
+              post-refresh: {}
           component-b:
             summary: test
             description: test

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -16,11 +16,12 @@
 
 import textwrap
 from pathlib import Path
+from typing import cast
 
 import pydantic
 import pytest
 import yaml
-from craft_application.models import SummaryStr, VersionStr
+from craft_application.models import SummaryStr, UniqueStrList, VersionStr
 
 from snapcraft import models
 from snapcraft.meta import snap_yaml
@@ -1369,6 +1370,14 @@ def test_component_metadata_from_component():
         description="test",
         type="test",
         version=VersionStr("1.0"),
+        hooks={
+            "install": models.Hook(
+                plugs=cast(UniqueStrList, ["home", "network"]),
+                command_chain=["test"],
+                environment={"test-variable-1": "test", "test-variable-2": "test"},
+                passthrough={"somefield": ["some", "value"]},
+            )
+        },
     )
 
     metadata = snap_yaml.ComponentMetadata.from_component(component)
@@ -1376,3 +1385,4 @@ def test_component_metadata_from_component():
     assert metadata.summary == component.summary
     assert metadata.description == component.description
     assert metadata.type == component.type
+    assert metadata.hooks == component.hooks

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -2050,12 +2050,14 @@ class TestComponents:
 
     @pytest.fixture
     def stub_component_data(self):
-        return {
+        data: dict[str, Any] = {
             "type": "test",
             "summary": "test summary",
             "description": "test description",
             "version": "1.0",
+            "hooks": None,
         }
+        return data
 
     def test_components_valid(self, project, project_yaml_data, stub_component_data):
         components = {"foo": stub_component_data, "bar": stub_component_data}

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -37,6 +37,18 @@ def extra_project_params(extra_project_params):
             "summary": SummaryStr("first component"),
             "description": "lorem ipsum",
             "version": VersionStr("1.0"),
+            "hooks": {
+                "install": {
+                    "command-chain": ["test"],
+                    "environment": {
+                        "test-variable-1": "test",
+                        "test-variable-2": "test",
+                    },
+                    "plugs": ["home", "network"],
+                    "passthrough": {"somefield": ["some", "value"]},
+                },
+                "post-refresh": {},
+            },
         },
         "secondcomponent": {
             "type": "test",
@@ -133,6 +145,21 @@ def test_write_metadata(
             summary: first component
             description: lorem ipsum
             type: test
+            hooks:
+              install:
+                command-chain:
+                - test
+                environment:
+                  test-variable-1: test
+                  test-variable-2: test
+                plugs:
+                - home
+                - network
+                passthrough:
+                  somefield:
+                  - some
+                  - value
+              post-refresh: {}
           secondcomponent:
             summary: second component
             description: lorem ipsum


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Support metadata for component hooks.

This includes the project definition and the output in the component's `meta/component.yaml` file.

Built on #4701, so only the last 3 commits are relevant.

Fixes #4570
(CRAFT-2463)