### PR TITLE
ci: adjust tags for spread runs

### DIFF
--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -26,7 +26,7 @@ jobs:
           sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
 
   kernel-plugins:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: [snap-build]
     strategy:
       fail-fast: false
@@ -52,7 +52,7 @@ jobs:
           spread google:ubuntu-22.04-64:tests/spread/plugins/${{ matrix.type }}/kernel
 
   remote-build-core24:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: [snap-build]
     strategy:
       fail-fast: false
@@ -81,7 +81,7 @@ jobs:
           spread google:${{ matrix.system }}:tests/spread/core24/remote-build
 
   remote-build:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: [snap-build]
     strategy:
       fail-fast: false

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -27,7 +27,7 @@ jobs:
           sudo snap install --dangerous --classic ${{ steps.build-snapcraft.outputs.snap }}
 
   integration-spread-tests:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: build
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -70,7 +70,7 @@ jobs:
           done
 
   integration-spread-tests-store:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: build
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.


### PR DESCRIPTION
This ensures we can use any machine with the spread-installed tag. Necessary for upcoming changes to Canonical's self-hosted runners.

Spread will fail until a repo admin adjusts the runner tags.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
