### PR TITLE
chore(core24): update package for linter spread test

### DIFF
--- a/tests/spread/core24/linters-pack/library-unused/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-unused/snap/snapcraft.yaml
@@ -13,6 +13,6 @@ parts:
     plugin: nil
     source: src
     stage-packages:
-      - libpng16-16
+      - libpng16-16t64
     override-build:
       gcc -o $CRAFT_PART_INSTALL/linter-test test.c


### PR DESCRIPTION
The package we chose was affected by the time_t change.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
