### PR TITLE
feat: package component hooks for core22

### DIFF
--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -58,10 +58,7 @@ def setup_assets(
     copy_assets(assets_dir, prime_dir, meta_directory_handler)
     setup_hooks(project.hooks, prime_dir)
 
-    # core22 doesn't provide a meta_directory_handler, which means that core22 component
-    # hooks would be handled like core22 snap hooks (with hook wrappers).
-    # This behavior is not desired, so component hooks are currently ignored for core22.
-    if project.components and project.get_effective_base() != "core22":
+    if project.components:
         for component_name, component in project.components.items():
             copy_assets(
                 assets_dir / "component" / component_name,

--- a/tests/spread/core22/components/snapcraft.yaml
+++ b/tests/spread/core22/components/snapcraft.yaml
@@ -54,3 +54,15 @@ parts:
     prime:
       # exclude a file in a partition
       - -(component/share)/other-file-in-component
+
+  # 'install' is a project hook (in 'snap/component/share/hooks/')
+  # 'remove' is generated at build time
+  hooks:
+    source: .
+    plugin: dump
+    override-build: |
+      touch ${CRAFT_PART_INSTALL}/remove
+      chmod +x ${CRAFT_PART_INSTALL}/remove
+      craftctl default
+    organize:
+      remove: (component/share)/meta/hooks/remove

--- a/tests/spread/core22/components/task.yaml
+++ b/tests/spread/core22/components/task.yaml
@@ -43,8 +43,22 @@ execute: |
     exit 1
   fi
   
-  # assert contents of component metadata
-  if ! diff -u component-contents/meta/component.yaml expected-component.yaml; then
+  component_meta_dir="component-contents/meta"
+
+  # assert component metadata
+  if ! diff -u "${component_meta_dir}/component.yaml" expected-component.yaml; then
     echo "Metadata for the share component is incorrect."
+    exit 1
+  fi
+
+  # assert component hooks
+  if [ ! -f "${component_meta_dir}/hooks/install" ] || [ ! -f "${component_meta_dir}/hooks/remove" ]; then
+    echo "Expected component hooks to be present."
+    exit 1
+  fi
+
+  # assert project hook has a hook wrapper
+  if [ ! -f component-contents/snap/hooks/install ]; then
+    echo "Expected hook wrapper to be present."
     exit 1
   fi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Package component hooks for core22.

The code was already completed via #4717, it just needed to be enabled.