### PR TITLE
fix(providers): do not install snapd from edge

### DIFF
--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -202,11 +202,6 @@ def get_base_configuration(
         hostname=instance_name,
         snaps=[
             Snap(
-                name="snapd",
-                channel="latest/edge",
-                classic=True,
-            ),
-            Snap(
                 name=snap_name,
                 channel=snap_channel,
                 classic=True,

--- a/tests/spread/core22/components/task.yaml
+++ b/tests/spread/core22/components/task.yaml
@@ -1,12 +1,8 @@
 summary: Build a snap with components
 
-prepare: |
-  snap refresh snapd --edge
-
 restore: |
   snapcraft clean
   rm -f ./*.snap ./*.comp
-  snap refresh snapd --stable
 
 execute: |
   snapcraft pack

--- a/tests/spread/core24/components/task.yaml
+++ b/tests/spread/core24/components/task.yaml
@@ -1,12 +1,8 @@
 summary: Build a snap with components
 
-prepare: |
-  snap refresh snapd --edge
-
 restore: |
   snapcraft clean
   rm -f ./*.snap ./*.comp
-  snap refresh snapd --stable
 
 execute: |
   snapcraft pack

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -214,7 +214,6 @@ def test_get_base_configuration(
         environment="test-env",
         hostname="test-instance-name",
         snaps=[
-            Snap(name="snapd", channel="latest/edge", classic=True),
             Snap(name="test-snap-name", channel="test-channel", classic=True),
         ],
         packages=["gnupg", "dirmngr", "git"],
@@ -260,7 +259,6 @@ def test_get_base_configuration_snap_channel(
         environment=ANY,
         hostname=ANY,
         snaps=[
-            Snap(name="snapd", channel="latest/edge", classic=True),
             Snap(name="snapcraft", channel=snap_channel, classic=True),
         ],
         packages=ANY,
@@ -297,7 +295,6 @@ def test_get_base_configuration_snap_instance_name_default(
         environment=ANY,
         hostname=ANY,
         snaps=[
-            Snap(name="snapd", channel="latest/edge", classic=True),
             Snap(name="snapcraft", channel=None, classic=True),
         ],
         packages=ANY,
@@ -334,7 +331,6 @@ def test_get_base_configuration_snap_instance_name_not_running_as_snap(
         environment=ANY,
         hostname=ANY,
         snaps=[
-            Snap(name="snapd", channel="latest/edge", classic=True),
             Snap(name="snapcraft", channel=None, classic=True),
         ],
         packages=ANY,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

snapd was installed from the edge channel to support components. This has been replaced with the `_retry_with_newer_snapd` decorator.