### PR TITLE
feat: drop `build-base: devel` requirement for core24

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -771,15 +771,6 @@ class Project(models.Project):
             raise ValueError("grade must be 'devel' when build-base is 'devel'")
         return values
 
-    @pydantic.root_validator()
-    @classmethod
-    def _validate_base(cls, values):
-        """Not allowed to use unstable base without devel build-base."""
-        if values.get("base") == "core24" and values.get("build_base") != "devel":
-            raise ValueError("build-base must be 'devel' when base is 'core24'")
-
-        return values
-
     @pydantic.validator("build_base", always=True)
     @classmethod
     def _validate_build_base(cls, build_base, values):

--- a/tests/spread/core24-suites/environment/snaps/paths-all-null/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/environment/snaps/paths-all-null/snap/snapcraft.yaml
@@ -9,7 +9,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 environment:
   LD_LIBRARY_PATH: null

--- a/tests/spread/core24-suites/environment/snaps/paths-one-null/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/environment/snaps/paths-one-null/snap/snapcraft.yaml
@@ -8,7 +8,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 apps:
   paths-one-null:

--- a/tests/spread/core24-suites/environment/snaps/paths-user-defined/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/environment/snaps/paths-user-defined/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: Defining LD_LIBRARY_PATH or PATH should override default values.
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 apps:
   paths-user-defined:

--- a/tests/spread/core24-suites/environment/snaps/staged-common-library/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/environment/snaps/staged-common-library/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 apps:
   staged-common-library:

--- a/tests/spread/core24-suites/environment/snaps/test-variables/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/environment/snaps/test-variables/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   hello:

--- a/tests/spread/core24-suites/manifest/manifest-creation/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/manifest/manifest-creation/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: manifest
 base: core24
-build-base: devel
 version: '0.1'
 summary: Single-line elevator pitch for your amazing snap
 description: |

--- a/tests/spread/core24-suites/manifest/manifest-info-envvars/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/manifest/manifest-info-envvars/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: manifest
 base: core24
-build-base: devel
 version: '0.1'
 summary: Single-line elevator pitch for your amazing snap
 description: |

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: |
   Build a classic confined snap, mostly used to test the provisioning
   of `core` inside a snap.
 base: core24
-build-base: devel
 
 grade: devel
 confinement: classic

--- a/tests/spread/core24-suites/patchelf/strict-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/patchelf/strict-patchelf/snap/snapcraft.yaml
@@ -4,7 +4,6 @@ summary: Build a strictly confined snap
 description: |
   Build a strictly confined snap to test ELF patching
 base: core24
-build-base: devel
 
 grade: devel
 confinement: strict

--- a/tests/spread/core24-suites/scriptlets/empty-overrides/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/scriptlets/empty-overrides/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: test-snap
 base: core24
-build-base: devel
 version: '0.1'
 summary: test snap
 description: test snap

--- a/tests/spread/core24-suites/scriptlets/scriptlet-failures/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/scriptlets/scriptlet-failures/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: craftctl-build-failure
 base: core24
-build-base: devel
 version: '0.1'
 summary: Fail on snapcraftctl build
 description: |

--- a/tests/spread/core24/appstream-desktop/desktop/snap/snapcraft.yaml
+++ b/tests/spread/core24/appstream-desktop/desktop/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: appstream-desktop
 base: core24
-build-base: devel
 
 grade: devel
 confinement: strict

--- a/tests/spread/core24/appstream-desktop/icon-desktop/snap/snapcraft.yaml
+++ b/tests/spread/core24/appstream-desktop/icon-desktop/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: appstream-desktop
 base: core24
-build-base: devel
 
 grade: devel
 confinement: strict

--- a/tests/spread/core24/chisel-base/snapcraft.yaml
+++ b/tests/spread/core24/chisel-base/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: core2x
 type: base
-build-base: devel
 summary: base using chisel from core24 assets
 description: |
   Test creating a base using a stable release of chisel

--- a/tests/spread/core24/chisel-base/snapcraft.yaml
+++ b/tests/spread/core24/chisel-base/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: core2x
 type: base
+build-base: devel
 summary: base using chisel from core24 assets
 description: |
   Test creating a base using a stable release of chisel

--- a/tests/spread/core24/clean/snaps/clean-with-long-name/snap/snapcraft.yaml
+++ b/tests/spread/core24/clean/snaps/clean-with-long-name/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   part1:

--- a/tests/spread/core24/clean/snaps/clean/snap/snapcraft.yaml
+++ b/tests/spread/core24/clean/snaps/clean/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   part1:

--- a/tests/spread/core24/components/snapcraft.yaml
+++ b/tests/spread/core24/components/snapcraft.yaml
@@ -3,7 +3,6 @@ version: "1.0"
 summary: Build a snap with components
 description: Build a snap with components
 base: core24
-build-base: devel
 grade: devel
 confinement: strict
 

--- a/tests/spread/core24/content-interface-provider-found/snapcraft.yaml
+++ b/tests/spread/core24/content-interface-provider-found/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 
 grade: devel
 base: core24
-build-base: devel
 confinement: devmode
 
 plugs:

--- a/tests/spread/core24/content-interface-provider-not-found/snapcraft.yaml
+++ b/tests/spread/core24/content-interface-provider-not-found/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 
 grade: devel
 base: core24
-build-base: devel
 confinement: devmode
 
 plugs:

--- a/tests/spread/core24/craftctl/test-craftctl-default/snap/snapcraft.yaml
+++ b/tests/spread/core24/craftctl/test-craftctl-default/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 apps:
   craftctl-default:

--- a/tests/spread/core24/craftctl/test-craftctl-get-set/snap/snapcraft.yaml
+++ b/tests/spread/core24/craftctl/test-craftctl-get-set/snap/snapcraft.yaml
@@ -4,7 +4,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 adopt-info: hello
 
 apps:

--- a/tests/spread/core24/grammar/snap/snapcraft.yaml
+++ b/tests/spread/core24/grammar/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/hooks/aux/build-aux/snap/snapcraft.yaml
+++ b/tests/spread/core24/hooks/aux/build-aux/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: hooks
 base: core24
-build-base: devel
 version: '1.0'
 summary: Test conflicting generated and project hooks.
 description: Project hooks in $PROJECT/snap/hooks/ should take priority over conflicting code generated hooks.

--- a/tests/spread/core24/hooks/default/snap/snapcraft.yaml
+++ b/tests/spread/core24/hooks/default/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: hooks
 base: core24
-build-base: devel
 version: '1.0'
 summary: Test conflicting generated and project hooks.
 description: Project hooks in $PROJECT/snap/hooks/ should take priority over conflicting code generated hooks.

--- a/tests/spread/core24/invalid-utf8/snapcraft.yaml
+++ b/tests/spread/core24/invalid-utf8/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: invalid-utf8
 base: core24
-build-base: devel
 summary: a project that echos invalid utf-8 text
 description: a project that echos invalid utf-8 text
 version: "1.0"

--- a/tests/spread/core24/lifecycle/snapcraft.yaml
+++ b/tests/spread/core24/lifecycle/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: hello
 base: core24
-build-base: devel
 version: '0.1'
 summary: snapcraft lifecycle
 description: |

--- a/tests/spread/core24/linters-file/lint-file/snapcraft.yaml
+++ b/tests/spread/core24/linters-file/lint-file/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: lint-file
 base: core24
-build-base: devel
 version: '0.1'
 summary: Lint a packaged snapcraft file.
 description: spread test

--- a/tests/spread/core24/linters-pack/classic-libc/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/classic-libc/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Single-line elevator pitch for your amazing snap
 description: |

--- a/tests/spread/core24/linters-pack/classic/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/classic/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Single-line elevator pitch for your amazing snap
 description: |

--- a/tests/spread/core24/linters-pack/library-gnome/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-gnome/snap/snapcraft.yaml
@@ -23,7 +23,6 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
 base: core24
-build-base: devel
 
 slots:
   # for GtkApplication registration

--- a/tests/spread/core24/linters-pack/library-ignore-missing/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-ignore-missing/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Ignore missing library linter issues
 description: spread test

--- a/tests/spread/core24/linters-pack/library-ignore-unused/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-ignore-unused/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Ignore unused library linter issues
 description: spread test

--- a/tests/spread/core24/linters-pack/library-ignored-mixed/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-ignored-mixed/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Ignore a mix of unused and missing library linter issues
 description: spread test

--- a/tests/spread/core24/linters-pack/library-missing/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-missing/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Raise linter warnings for missing libraries
 description: spread test

--- a/tests/spread/core24/linters-pack/library-unused/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-unused/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: linter-test
 base: core24
-build-base: devel
 version: '0.1'
 summary: Raise linter warnings for unused libraries.
 description: spread test

--- a/tests/spread/core24/metadata-links/snapcraft.yaml
+++ b/tests/spread/core24/metadata-links/snapcraft.yaml
@@ -7,7 +7,6 @@ version: "1.0"
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 issues:
   - https://github.com/acme/project/issues
   - https://bugs.launchpad.net/project/filebug

--- a/tests/spread/core24/package-repositories/test-apt-key-fingerprint/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-apt-key-fingerprint/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   test-ppa:

--- a/tests/spread/core24/package-repositories/test-apt-key-name/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-apt-key-name/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   test-ppa:

--- a/tests/spread/core24/package-repositories/test-apt-keyserver/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-apt-keyserver/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   test-ppa:

--- a/tests/spread/core24/package-repositories/test-apt-path/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-apt-path/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   test-ppa:

--- a/tests/spread/core24/package-repositories/test-apt-ppa/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-apt-ppa/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   test-ppa:

--- a/tests/spread/core24/package-repositories/test-foreign-armhf/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-foreign-armhf/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test package repos with different architectures
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   amd64:
 

--- a/tests/spread/core24/package-repositories/test-foreign-i386/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-foreign-i386/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test package repos with different architectures
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   amd64:
 

--- a/tests/spread/core24/package-repositories/test-multi-keys/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-multi-keys/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test installing a package repository with an asset file with multip
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 parts:
   test-ppa:

--- a/tests/spread/core24/package-repositories/test-pin/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-pin/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: test
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 
 apps:
   test-pin:

--- a/tests/spread/core24/packing/snap/snapcraft.yaml
+++ b/tests/spread/core24/packing/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
   we live in tweetspace and your description wants to look good in the snap
   store.
 base: core24
-build-base: devel
 
 grade: devel
 confinement: devmode

--- a/tests/spread/core24/platforms/snaps/build-for-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/build-for-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/platforms/snaps/build-for-no-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/build-for-no-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/platforms/snaps/build-on-no-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/build-on-no-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: arm64

--- a/tests/spread/core24/platforms/snaps/env-var-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/env-var-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/platforms/snaps/env-var-no-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/env-var-no-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/platforms/snaps/multiple-build-for/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/multiple-build-for/snap/snapcraft.yaml
@@ -6,7 +6,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: [amd64]

--- a/tests/spread/core24/platforms/snaps/platform-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/platform-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/platforms/snaps/platform-no-match/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/platform-no-match/snap/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: amd64

--- a/tests/spread/core24/platforms/snaps/single-arch/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/single-arch/snap/snapcraft.yaml
@@ -6,7 +6,6 @@ description: |
 grade: devel
 confinement: strict
 base: core24
-build-base: devel
 platforms:
   platform1:
     build-on: [amd64, arm64]

--- a/tests/spread/core24/plugs-warn/snap/snapcraft.yaml
+++ b/tests/spread/core24/plugs-warn/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: plugs-warn
 base: core24
-build-base: devel
 version: '0.1'
 summary: Check warnings for top-level enabling of slots and plugs
 description: Check warnings for top-level enabling of slots and plugs.

--- a/tests/spread/core24/python-hello/classic/snap/snapcraft.yaml
+++ b/tests/spread/core24/python-hello/classic/snap/snapcraft.yaml
@@ -3,7 +3,6 @@ version: "1.0"
 summary: simple python application
 description: build a python application using core24
 base: core24
-build-base: devel
 confinement: classic
 
 apps:

--- a/tests/spread/core24/python-hello/strict/snap/snapcraft.yaml
+++ b/tests/spread/core24/python-hello/strict/snap/snapcraft.yaml
@@ -3,7 +3,6 @@ version: "1.0"
 summary: simple python application
 description: build a python application using core24
 base: core24
-build-base: devel
 confinement: strict
 
 apps:

--- a/tests/spread/core24/remote-build/task.yaml
+++ b/tests/spread/core24/remote-build/task.yaml
@@ -13,7 +13,6 @@ prepare: |
 
   snapcraft init
   sed -i 's/base: core22/base: core24/' snap/snapcraft.yaml
-  echo "build-base: devel" >> snap/snapcraft.yaml
 
   # Commit the project
   git config --global --add safe.directory "$PWD"

--- a/tests/spread/core24/root-packages/snapcraft.yaml
+++ b/tests/spread/core24/root-packages/snapcraft.yaml
@@ -3,7 +3,6 @@ version: "1.0"
 summary: test build-snaps and build-packages at the root
 description: verify that these keys are processed correctly
 base: core24
-build-base: devel
 confinement: strict
 grade: devel
 

--- a/tests/spread/core24/set-version-twice/modified-snapcraft.yaml
+++ b/tests/spread/core24/set-version-twice/modified-snapcraft.yaml
@@ -1,6 +1,5 @@
 name: test-set-version-twice
 base: core24
-build-base: devel
 version: '0.1'
 summary: Test fix for set version and out of order step execution
 description: |

--- a/tests/spread/core24/set-version-twice/original-snapcraft.yaml
+++ b/tests/spread/core24/set-version-twice/original-snapcraft.yaml
@@ -1,6 +1,5 @@
 name: test-set-version-twice
 base: core24
-build-base: devel
 version: '0.1'
 summary: Test fix for set version and out of order step execution
 description: |

--- a/tests/spread/core24/simple-snap/snap/snapcraft.yaml
+++ b/tests/spread/core24/simple-snap/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: |
   Build a simple confined snap to test the build process.
 
 base: core24
-build-base: devel
 
 grade: devel
 confinement: strict

--- a/tests/spread/core24/snap-creation/package-cutoff/snap/snapcraft.yaml
+++ b/tests/spread/core24/snap-creation/package-cutoff/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: package-cutoff
 base: core24
-build-base: devel
 version: '1.0'
 summary: 'test'
 description: test

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -394,7 +394,6 @@ def default_project(extra_project_params):
         summary=SummaryStr("default project"),
         description="default project",
         base="core24",
-        build_base="devel",
         grade="devel",
         parts=parts,
         license="MIT",

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -39,7 +39,7 @@ from snapcraft.models.project import apply_root_packages
 from snapcraft.utils import get_host_architecture
 
 # required project data for core24 snaps
-CORE24_DATA = {"base": "core24", "build_base": "devel", "grade": "devel"}
+CORE24_DATA = {"base": "core24", "grade": "devel"}
 
 
 @pytest.fixture
@@ -584,12 +584,6 @@ class TestProjectValidation:
 
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(project_yaml_data(build_base="devel", grade="stable"))
-
-    def test_project_development_base_error(self, project_yaml_data):
-        error = "build-base must be 'devel' when base is 'core24'"
-
-        with pytest.raises(errors.ProjectValidationError, match=error):
-            Project.unmarshal(project_yaml_data(base="core24"))
 
     def test_project_global_plugs_warning(self, project_yaml_data, emitter):
         data = project_yaml_data(plugs={"desktop": None, "desktop-legacy": None})

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -144,7 +144,6 @@ def test_application_expand_extensions(emitter, monkeypatch, extension_source, n
             summary: default project
             description: default project
             base: core24
-            build-base: devel
             license: MIT
             parts:
                 fake-extension/fake-part:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Drop requirement for `build-base: devel` for `core24` snaps.