### PR TITLE
Activate installed_base_by_architecture metrics

### DIFF
--- a/snapcraft_legacy/cli/_metrics.py
+++ b/snapcraft_legacy/cli/_metrics.py
@@ -30,11 +30,13 @@ METRIC_NAMES_TO_SERIES_LABEL_MAPPINGS = {
     metrics_module.MetricsNames.INSTALLED_BASE_BY_COUNTRY.value: "Country",
     metrics_module.MetricsNames.INSTALLED_BASE_BY_OPERATING_SYSTEM.value: "OS",
     metrics_module.MetricsNames.INSTALLED_BASE_BY_VERSION.value: "Version",
+    metrics_module.MetricsNames.INSTALLED_BASE_BY_ARCHITECTURE.value: "Architecture",
     metrics_module.MetricsNames.WEEKLY_DEVICE_CHANGE.value: "Devices",
     metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_CHANNEL.value: "Channel",
     metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_COUNTRY.value: "Country",
     metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_OPERATING_SYSTEM.value: "OS",
     metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_VERSION.value: "Version",
+    metrics_module.MetricsNames.WEEKLY_INSTALLED_BASE_BY_ARCHITECTURE.value: "Architecture",
 }
 
 

--- a/snapcraft_legacy/storeapi/metrics.py
+++ b/snapcraft_legacy/storeapi/metrics.py
@@ -36,11 +36,13 @@ MetricsStatus = enum.Enum(  # type: ignore
 
 class MetricsNames(enum.Enum):
     DAILY_DEVICE_CHANGE = "daily_device_change"
+    INSTALLED_BASE_BY_ARCHITECTURE = "installed_base_by_architecture"
     INSTALLED_BASE_BY_CHANNEL = "installed_base_by_channel"
     INSTALLED_BASE_BY_COUNTRY = "installed_base_by_country"
     INSTALLED_BASE_BY_OPERATING_SYSTEM = "installed_base_by_operating_system"
     INSTALLED_BASE_BY_VERSION = "installed_base_by_version"
     WEEKLY_DEVICE_CHANGE = "weekly_device_change"
+    WEEKLY_INSTALLED_BASE_BY_ARCHITECTURE = "weekly_installed_base_by_architecture"
     WEEKLY_INSTALLED_BASE_BY_CHANNEL = "weekly_installed_base_by_channel"
     WEEKLY_INSTALLED_BASE_BY_COUNTRY = "weekly_installed_base_by_country"
     WEEKLY_INSTALLED_BASE_BY_OPERATING_SYSTEM = (

--- a/tests/legacy/unit/cli/test_metrics.py
+++ b/tests/legacy/unit/cli/test_metrics.py
@@ -35,11 +35,13 @@ def test_get_series_label_from_metric_name():
         "installed_base_by_country": "Country",
         "installed_base_by_operating_system": "OS",
         "installed_base_by_version": "Version",
+        "installed_base_by_architecture": "Architecture",
         "weekly_device_change": "Devices",
         "weekly_installed_base_by_channel": "Channel",
         "weekly_installed_base_by_country": "Country",
         "weekly_installed_base_by_operating_system": "OS",
         "weekly_installed_base_by_version": "Version",
+        "weekly_installed_base_by_architecture": "Architecture",
     }
 
 

--- a/tests/legacy/unit/store/test_metrics.py
+++ b/tests/legacy/unit/store/test_metrics.py
@@ -366,6 +366,17 @@ def test_metrics_results_unmarshal_multiple_metrics():
             MetricResults(
                 status=MetricsStatus["OK"],
                 snap_id="test-snap-id",
+                metric_name="installed_base_by_architecture",
+                buckets=["2021-01-01"],
+                series=[
+                    Series(name="blah", values=[1], currently_released=None),
+                    Series(name="blahh", values=[1, 2], currently_released=None),
+                    Series(name="blahhh", values=[1, 2, 3], currently_released=None),
+                ],
+            ),
+            MetricResults(
+                status=MetricsStatus["OK"],
+                snap_id="test-snap-id",
                 metric_name="installed_base_by_channel",
                 buckets=["2021-01-01"],
                 series=[
@@ -411,6 +422,17 @@ def test_metrics_results_unmarshal_multiple_metrics():
                 status=MetricsStatus["OK"],
                 snap_id="test-snap-id",
                 metric_name="weekly_device_change",
+                buckets=["2021-01-01"],
+                series=[
+                    Series(name="blah", values=[1], currently_released=None),
+                    Series(name="blahh", values=[1, 2], currently_released=None),
+                    Series(name="blahhh", values=[1, 2, 3], currently_released=None),
+                ],
+            ),
+            MetricResults(
+                status=MetricsStatus["OK"],
+                snap_id="test-snap-id",
+                metric_name="weekly_installed_base_by_architecture",
                 buckets=["2021-01-01"],
                 series=[
                     Series(name="blah", values=[1], currently_released=None),


### PR DESCRIPTION
Pursuant to my post on Discourse
(https://forum.snapcraft.io/t/enable-by-architecture-in-the-snapcraft-metrics-cli-tooling/39750), this commit activates the installed_base_by_architecture and weekly_installed_base_by_architecture metrics in the snapcraft metrics tool.

The metric was previously introduced according to this PR https://github.com/canonical/snapcraft.io/issues/1680#issuecomment-688928336

A subsequent issue will be raised against the documentation.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
