### PR TITLE
chore: mark gnome-extension experimental for core24

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -82,6 +82,11 @@ class GNOME(Extension):
     @staticmethod
     @overrides
     def is_experimental(base: Optional[str]) -> bool:
+        # core24 is experimental until streamlined graphics support is finalized
+        # see https://forum.snapcraft.io/t/39718
+        if base == "core24":
+            return True
+
         return False
 
     @overrides

--- a/snapcraft/services/provider.py
+++ b/snapcraft/services/provider.py
@@ -30,3 +30,9 @@ class Provider(ProviderService):
             self.environment["SNAPCRAFT_BUILD_INFO"] = build_info
         if image_info := os.getenv("SNAPCRAFT_IMAGE_INFO"):
             self.environment["SNAPCRAFT_IMAGE_INFO"] = image_info
+        if experimental_extensions := os.getenv(
+            "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"
+        ):
+            self.environment["SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"] = (
+                experimental_extensions
+            )

--- a/tests/spread/core24/linters-pack/task.yaml
+++ b/tests/spread/core24/linters-pack/task.yaml
@@ -9,6 +9,8 @@ environment:
   SNAP/library_ignored_mixed: library-ignored-mixed
   SNAP/library_missing: library-missing
   SNAP/library_unused: library-unused
+  # gnome-extension core24 is experimental
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
 restore: |
   cd "${SNAP}"

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -68,9 +68,15 @@ def test_get_supported_confinement():
     assert gnome.GNOME.get_supported_confinement() == ("strict", "devmode")
 
 
-@pytest.mark.parametrize("base", ["core22", "core24"])
-def test_is_experimental(base):
-    assert gnome.GNOME.is_experimental(base=base) is False
+@pytest.mark.parametrize(
+    ("base", "is_experimental"),
+    [
+        ("core22", False),
+        ("core24", True),
+    ],
+)
+def test_is_experimental(base, is_experimental):
+    assert gnome.GNOME.is_experimental(base=base) is is_experimental
 
 
 def test_get_app_snippet(gnome_extension):

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -20,6 +20,11 @@
 def test_provider(provider_service, monkeypatch):
     monkeypatch.setenv("SNAPCRAFT_BUILD_INFO", "foo")
     monkeypatch.setenv("SNAPCRAFT_IMAGE_INFO", "bar")
+    monkeypatch.setenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "baz")
     provider_service.setup()
     assert provider_service.environment["SNAPCRAFT_BUILD_INFO"] == "foo"
     assert provider_service.environment["SNAPCRAFT_IMAGE_INFO"] == "bar"
+    assert (
+        provider_service.environment["SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"]
+        == "baz"
+    )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

gnome-extension will be experimental in core24 until support for streamlined graphics support is finalized.

See https://forum.snapcraft.io/t/39718

Note that `core24` snaps using the `gnome-extension` can only be built in environments where the `core24` snap has been pre-installed since `core24` is unavailable on stable.  Thus the extension still isn't being tested by spread ([source](https://github.com/canonical/snapcraft/blob/aed002bbe645a4f8708f3b2094f295b59f467fd6/tests/spread/core24/linters-pack/task.yaml#L23)).