### PR TITLE
tests: re-enable core24 linter spread test check

### DIFF
--- a/tests/spread/core24/linters-file/task.yaml
+++ b/tests/spread/core24/linters-file/task.yaml
@@ -20,12 +20,9 @@ execute: |
     snapcraft lint lint-file_0.1_*.snap 2> output.txt
   }
 
-  # TODO: restore this when core24 is stable
-  # core24 testing has undefined symbol warnings
-  # get the lint warnings at end of the log file
-  #sed -n '/Running linters.../,+4 p' < output.txt > linter-output.txt
+  sed -n '/Running linters.../,+4 p' < output.txt > linter-output.txt
 
-  #diff -u linter-output.txt expected-linter-output.txt
+  diff -u linter-output.txt expected-linter-output.txt
 
   MATCH "library: linter-test: missing dependency 'libcaca.so.0'" < output.txt
   MATCH "library: libogg.so.0: unused library" < output.txt


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

The spread test passed locally.