### PR TITLE
feat: support refresh-mode: ignore-running

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -775,7 +775,8 @@
                             "description": "controls if the app should be restarted at all",
                             "enum": [
                                 "endure",
-                                "restart"
+                                "restart",
+                                "ignore-running"
                             ]
                         },
                         "stop-mode": {

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -372,7 +372,7 @@ class App(models.CraftBaseModel):
     daemon: Optional[Literal["simple", "forking", "oneshot", "notify", "dbus"]]
     after: UniqueStrList = cast(UniqueStrList, [])
     before: UniqueStrList = cast(UniqueStrList, [])
-    refresh_mode: Optional[Literal["endure", "restart"]]
+    refresh_mode: Optional[Literal["endure", "restart", "ignore-running"]]
     stop_mode: Optional[
         Literal[
             "sigterm",

--- a/tests/legacy/unit/project/test_schema.py
+++ b/tests/legacy/unit/project/test_schema.py
@@ -502,7 +502,7 @@ def test_valid_restart_conditions(data, condition):
     Validator(data).validate()
 
 
-_REFRESH_MODES = ["endure", "restart"]
+_REFRESH_MODES = ["endure", "restart", "ignore-running"]
 
 
 @pytest.mark.parametrize("mode", _REFRESH_MODES)

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -936,7 +936,9 @@ class TestAppValidation:
         with pytest.raises(errors.ProjectValidationError, match=error):
             Project.unmarshal(data)
 
-    @pytest.mark.parametrize("refresh_mode", ["endure", "restart", "_invalid"])
+    @pytest.mark.parametrize(
+        "refresh_mode", ["endure", "restart", "ignore-running", "_invalid"]
+    )
     def test_app_refresh_mode(self, refresh_mode, app_yaml_data):
         data = app_yaml_data(refresh_mode=refresh_mode)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Snapd 2.57 allows for a [new value](https://github.com/snapcore/snapd/commit/33acdb6167735e23744a7e93149aec366c11ed03) for `refresh-mode` named `ignore-running`

Fixes https://github.com/canonical/snapcraft/issues/4747