### PR TITLE
fix: install gpg and dirmngr in core24 builds

### DIFF
--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -10,7 +10,14 @@ environment:
   SNAP/test_foreign_armhf: test-foreign-armhf
   SNAP/test_foreign_i386: test-foreign-i386
 
+prepare: |
+  # Remove the currently installed "gpg" and "dirmngr" packages to ensure that
+  # Snapcraft itself is installing them when necessary.
+  sudo dpkg --remove --force-depends gpg dirmngr
+
 restore: |
+  sudo apt install -y gpg dirmngr
+
   cd "$SNAP"
   rm -f ./*.snap
   snapcraft clean


### PR DESCRIPTION
This commit mimicks the behavior for core22<= builds where gpg and dirmngr are installed at runtime for projects with package-repositories. The trigger for this commit is the fact that the environment where Snapcraft builds in Launchpad do _not_ have the 'dirmngr' package installed.

Unfortunately the strategy of bundling 'gpg' and 'dirmngr' as stage-packages in Snapcraft's own snap didn't work because gpg has the expected path to the 'dirmngr' executable hardcoded (always trying to call '/usr/bin/dirmngr').

Fixes #4740

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
