### PR TITLE
fix(schema): add ROS 2 core22 extensions for remote-build

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -923,7 +923,11 @@
                                     "ros2-foxy",
                                     "ros2-foxy-ros-base",
                                     "ros2-foxy-ros-core",
-                                    "ros2-foxy-desktop"
+                                    "ros2-foxy-desktop",
+                                    "ros2-humble",
+                                    "ros2-humble-ros-base",
+                                    "ros2-humble-ros-core",
+                                    "ros2-humble-desktop"
                                 ]
                             }
                         }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Adds ROS 2 core22 extensions in the legacy schema for remote-build.

Refering to this commit: https://github.com/canonical/snapcraft/commit/f509ac032fc9df0eb2bb02ce31057fdc23bf0e84

remote-building always uses legacy and use the legacy schema to validate.