### PR TITLE
fix: set project variables for core24

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -38,6 +38,7 @@ from snapcraft import cli, commands, errors, models, services
 from snapcraft.commands import unimplemented
 from snapcraft.extensions import apply_extensions
 from snapcraft.models.project import SnapcraftBuildPlanner, apply_root_packages
+from snapcraft.parts import set_global_environment
 from snapcraft.utils import get_host_architecture
 from snapcraft_legacy.cli import legacy
 
@@ -229,6 +230,12 @@ class Snapcraft(Application):
             extra_global_args=self._global_arguments,
             default_command=craft_app_commands.lifecycle.PackCommand,
         )
+
+    @override
+    def _set_global_environment(self, info: craft_parts.ProjectInfo) -> None:
+        """Set global environment variables."""
+        super()._set_global_environment(info)
+        set_global_environment(info)
 
 
 def create_app() -> Snapcraft:

--- a/snapcraft/parts/__init__.py
+++ b/snapcraft/parts/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,7 +18,13 @@
 
 from craft_parts import validate_part
 
-from .lifecycle import patch_elf
+from .lifecycle import patch_elf, set_global_environment, set_step_environment
 from .parts import PartsLifecycle
 
-__all__ = ["PartsLifecycle", "patch_elf", "validate_part"]
+__all__ = [
+    "PartsLifecycle",
+    "patch_elf",
+    "set_global_environment",
+    "set_step_environment",
+    "validate_part",
+]

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -83,8 +83,8 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
     build_plan = get_build_plan(yaml_data, parsed_args)
 
     # Register our own callbacks
-    callbacks.register_prologue(_set_global_environment)
-    callbacks.register_pre_step(_set_step_environment)
+    callbacks.register_prologue(set_global_environment)
+    callbacks.register_pre_step(set_step_environment)
     callbacks.register_post_step(patch_elf, step_list=[Step.PRIME])
 
     build_count = utils.get_parallel_build_count()
@@ -574,12 +574,10 @@ def _expose_prime(
     instance.mount(host_source=project_path / "prime", target=dirs.prime_dir)
 
 
-def _set_global_environment(info: ProjectInfo) -> None:
+def set_global_environment(info: ProjectInfo) -> None:
     """Set global environment variables."""
     info.global_environment.update(
         {
-            "SNAPCRAFT_ARCH_TRIPLET": info.arch_triplet,
-            "SNAPCRAFT_TARGET_ARCH": info.target_arch,
             "SNAPCRAFT_PARALLEL_BUILD_COUNT": str(info.parallel_build_count),
             "SNAPCRAFT_PROJECT_VERSION": info.get_project_var("version", raw_read=True),
             "SNAPCRAFT_PROJECT_GRADE": info.get_project_var("grade", raw_read=True),
@@ -589,6 +587,15 @@ def _set_global_environment(info: ProjectInfo) -> None:
             "SNAPCRAFT_PRIME": str(info.prime_dir),
         }
     )
+
+    # add deprecated environment variables for core22
+    if info.base == "core22":
+        info.global_environment.update(
+            {
+                "SNAPCRAFT_ARCH_TRIPLET": info.arch_triplet,
+                "SNAPCRAFT_TARGET_ARCH": info.target_arch,
+            }
+        )
 
     if info.partitions:
         info.global_environment.update(_get_environment_for_partitions(info))
@@ -645,7 +652,7 @@ def _check_experimental_plugins(
         )
 
 
-def _set_step_environment(step_info: StepInfo) -> bool:
+def set_step_environment(step_info: StepInfo) -> bool:
     """Set the step environment before executing each lifecycle step."""
     step_info.step_environment.update(
         {
@@ -737,6 +744,7 @@ def _expand_environment(
     dirs = craft_parts.ProjectDirs(work_dir=work_dir, partitions=partitions)
     info = craft_parts.ProjectInfo(
         application_name="snapcraft",  # not used in environment expansion
+        base=yaml_utils.get_base_from_yaml(snapcraft_yaml) or "",
         cache_dir=Path(),  # not used in environment expansion
         arch=convert_architecture_deb_to_platform(target_arch),
         parallel_build_count=parallel_build_count,
@@ -745,7 +753,7 @@ def _expand_environment(
         project_vars=project_vars,
         partitions=partitions,
     )
-    _set_global_environment(info)
+    set_global_environment(info)
 
     craft_parts.expand_environment(snapcraft_yaml, info=info, skip=["name", "version"])
 

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022-2023 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -127,6 +127,18 @@ def get_base(filestream: TextIO) -> Optional[str]:
     :raises SnapcraftError: If the yaml could not be loaded.
     """
     data = safe_load(filestream)
+    return get_base_from_yaml(data)
+
+
+def get_base_from_yaml(data: dict[str, Any]) -> str | None:
+    """Get the effective base from a dictionary of yaml data.
+
+    :param data: The YAML data to load.
+
+    :returns: Effective base of the project or None if the base cannot be determined.
+
+    :raises SnapcraftError: If the yaml could not be loaded.
+    """
     return utils.get_effective_base(
         base=data.get("base"),
         build_base=data.get("build-base"),

--- a/snapcraft/services/lifecycle.py
+++ b/snapcraft/services/lifecycle.py
@@ -24,7 +24,7 @@ from typing import Any, cast
 
 from craft_application import AppMetadata, LifecycleService, ServiceFactory
 from craft_application.models import BuildInfo
-from craft_parts import ProjectInfo, StepInfo
+from craft_parts import ProjectInfo, StepInfo, callbacks
 from overrides import overrides
 
 from snapcraft import __version__, errors, models, os_release, parts, utils
@@ -68,6 +68,8 @@ class Lifecycle(LifecycleService):
             confinement=project.confinement,
             project_base=project.base or "",
         )
+        callbacks.register_prologue(parts.set_global_environment)
+        callbacks.register_pre_step(parts.set_step_environment)
         super().setup()
 
     @overrides

--- a/tests/spread/core24-suites/environment/test-variables/task.yaml
+++ b/tests/spread/core24-suites/environment/test-variables/task.yaml
@@ -26,8 +26,18 @@ execute: |
     echo "==== $file ===="
     cat "$file"
     for exp in \
-      "^CRAFT_ARCH_TRIPLET=x86_64-linux-gnu$" \
-      "^CRAFT_TARGET_ARCH=amd64$" \
+      "^SNAPCRAFT_PROJECT_GRADE=devel$" \
+      "^SNAPCRAFT_PROJECT_NAME=None$" \
+      "^SNAPCRAFT_PROJECT_VERSION=1$" \
+      "^SNAPCRAFT_PARALLEL_BUILD_COUNT=[0-9]\+$" \
+      "^SNAPCRAFT_PROJECT_DIR=${root}$" \
+      "^SNAPCRAFT_PART_SRC=${root}/parts/hello/src$" \
+      "^SNAPCRAFT_PART_SRC_WORK=${root}/parts/hello/src$" \
+      "^SNAPCRAFT_PART_BUILD=${root}/parts/hello/build$" \
+      "^SNAPCRAFT_PART_BUILD_WORK=${root}/parts/hello/build$" \
+      "^SNAPCRAFT_PART_INSTALL=${root}/parts/hello/install$" \
+      "^SNAPCRAFT_STAGE=${root}/stage$" \
+      "^SNAPCRAFT_PRIME=${root}/prime$" \
       "^CRAFT_PARALLEL_BUILD_COUNT=[0-9]\+$" \
       "^CRAFT_PROJECT_DIR=${root}$" \
       "^CRAFT_PART_NAME=hello$" \

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022-2023 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -23,13 +23,18 @@ from unittest.mock import Mock
 
 import pytest
 import yaml
-from craft_parts import Features
+from craft_parts import Features, callbacks
 from craft_providers import Executor, Provider
 from craft_providers.base import Base
 from overrides import override
 from pymacaroons import Caveat, Macaroon
 
 from snapcraft.extensions import extension, register, unregister
+
+
+@pytest.fixture(autouse=True)
+def unregister_callbacks(mocker):
+    callbacks.unregister_all()
 
 
 @pytest.fixture

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022-2023 Canonical Ltd.
+# Copyright 2022-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -199,3 +199,53 @@ def test_apply_yaml_defines_root_packages(minimal_yaml_data, key, value):
         "architectures": [Architecture(build_on="amd64", build_for="amd64")],
         "parts": {"nil": {}, "snapcraft/core": {"plugin": "nil", key: ["foo"]}},
     }
+
+
+def test_get_base(mocker):
+    mock_get_effective_base = mocker.patch(
+        "snapcraft.parts.yaml_utils.utils.get_effective_base",
+        return_value="test-effective-base",
+    )
+    yaml = io.StringIO(
+        dedent(
+            """\
+            name: test-name
+            type: test-type
+            base: test-base
+            build-base: test-build-base
+            """
+        )
+    )
+
+    effective_base = yaml_utils.get_base(yaml)
+
+    mock_get_effective_base.assert_called_with(
+        base="test-base",
+        build_base="test-build-base",
+        name="test-name",
+        project_type="test-type",
+    )
+    assert effective_base == "test-effective-base"
+
+
+def test_get_base_from_yaml(mocker):
+    mock_get_effective_base = mocker.patch(
+        "snapcraft.parts.yaml_utils.utils.get_effective_base",
+        return_value="test-effective-base",
+    )
+    yaml_dict = {
+        "name": "test-name",
+        "type": "test-type",
+        "base": "test-base",
+        "build-base": "test-build-base",
+    }
+
+    effective_base = yaml_utils.get_base_from_yaml(yaml_dict)
+
+    mock_get_effective_base.assert_called_with(
+        base="test-base",
+        build_base="test-build-base",
+        name="test-name",
+        project_type="test-type",
+    )
+    assert effective_base == "test-effective-base"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Set project variables for core24 snaps.

`CRAFT_PROJECT_NAME` and `CRAFT_PROJECT_VERSION` are not set, see https://github.com/canonical/craft-application/issues/320 for details.


Fixes #4704
Fixes #4702 
(CRAFT-2657)
(CRAFT-2655)