### PR TITLE
fix: use local keys for package-repos in core24

### DIFF
--- a/snapcraft/services/lifecycle.py
+++ b/snapcraft/services/lifecycle.py
@@ -29,6 +29,7 @@ from craft_parts.packages import Repository as Repo
 from overrides import overrides
 
 from snapcraft import __version__, errors, models, os_release, parts, utils
+from snapcraft.parts.yaml_utils import get_snap_project
 
 
 class Lifecycle(LifecycleService):
@@ -168,6 +169,15 @@ class Lifecycle(LifecycleService):
             build_snaps=[],
             primed_stage_packages=sorted(primed_stage_packages),
         )
+
+    @overrides
+    def _get_local_keys_path(self) -> Path | None:
+        snap_project = get_snap_project()
+        keys_dir = snap_project.assets_dir / "keys"
+        if keys_dir.is_dir():
+            return keys_dir
+
+        return None
 
 
 def get_prime_dirs_from_project(project_info: ProjectInfo) -> dict[str | None, Path]:

--- a/tests/spread/core24/package-repositories/test-apt-key-fingerprint/snap/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-apt-key-fingerprint/snap/snapcraft.yaml
@@ -25,3 +25,5 @@ package-repositories:
     suites: [focal]
     key-id: 78E1918602959B9C59103100F1831DDAFC42E99D
     url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu
+    # Set an invalid keyserver here to force the use of the local key
+    key-server: keyserver.invalid.com


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
