### PR TITLE
tests: remove core24 snap workarounds

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -282,17 +282,6 @@ suites:
      - ubuntu-24.04*
    environment:
      SNAPCRAFT_BUILD_ENVIRONMENT: ""
-   prepare: |
-     # Workaround to be able to test the snaps
-     if snap list core24; then
-       # The already installed case
-       exit 0
-     elif snap install core24; then
-       echo Remove this workaround
-       exit 1
-     else
-       snap install core24 --edge
-     fi
 
  tests/spread/core24-suites/environment/:
    summary: core24 environment tests
@@ -313,17 +302,6 @@ suites:
    summary: core24 patchelf tests
    systems:
      - ubuntu-24.04*
-   prepare: |
-     # Workaround to be able to test the snaps
-     if snap list core24; then
-       # The already installed case
-       exit 0
-     elif snap install core24; then
-       echo Remove this workaround
-       exit 1
-     else
-       snap install core24 --edge
-     fi
 
  # General, core suite
  tests/spread/general/:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Drop core24 workarounds in the spread tests.