### PR TITLE
fix(remote): use launchpad credentials from legacy location

### DIFF
--- a/tests/spread/core24/remote-build/task.yaml
+++ b/tests/spread/core24/remote-build/task.yaml
@@ -4,6 +4,8 @@ kill-timeout: 180m
 
 environment:
   LAUNCHPAD_TOKEN: "$(HOST: echo ${LAUNCHPAD_TOKEN})"
+  CREDENTIAL_FILE/current: "$HOME/.local/share/snapcraft/launchpad-credentials"
+  CREDENTIAL_FILE/legacy: "$HOME/.local/share/snapcraft/provider/launchpad/credentials"
 
 prepare: |
   if [[ -z "$LAUNCHPAD_TOKEN" ]]; then
@@ -16,12 +18,13 @@ prepare: |
 
   # Commit the project
   git config --global --add safe.directory "$PWD"
+  git init
   git add snap/snapcraft.yaml
   git commit -m "Initial Commit"
 
   # Setup launchpad token
-  mkdir -p ~/.local/share/snapcraft/
-  echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
+  mkdir -p "$(dirname "$CREDENTIAL_FILE")"
+  echo -e "$LAUNCHPAD_TOKEN" > "$CREDENTIAL_FILE"
 
 restore: |
   rm -f ./*.snap ./*.txt

--- a/tests/spread/general/remote-build/task.yaml
+++ b/tests/spread/general/remote-build/task.yaml
@@ -17,12 +17,13 @@ prepare: |
 
   # Commit the project
   git config --global --add safe.directory "$PWD"
+  git init
   git add snap/snapcraft.yaml
   git commit -m "Initial Commit"
 
   # Setup launchpad token
-  mkdir -p ~/.local/share/snapcraft/provider/launchpad/
-  echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
+  mkdir -p "$HOME/.local/share/snapcraft/provider/launchpad/"
+  echo -e "$LAUNCHPAD_TOKEN" > "$HOME/.local/share/snapcraft/provider/launchpad/credentials"
 
 restore: |
   rm -f ./*.snap ./*.txt


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

If launchpad credentials do not exist in the new location (`$XDG_DATA_HOME/snapcraft/launchpad-credentials`) but exist in the legacy location (`$XDG_DATA_HOME/snapcraft/provider/launchpad/credentials`), then emit a deprecation warning and copy the credentials to the new location.