### PR TITLE
build(deps): bump craft-application to 2.6.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 attrs==23.1.0
 catkin-pkg==0.5.2
 click==8.1.7
-craft-application==2.6.2
+craft-application==2.6.3
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.4.4
-craft-application==2.6.2
+craft-application==2.6.3
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==2.6.2
+craft-application==2.6.3
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/tests/spread/core24-suites/environment/snaps/test-variables/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/environment/snaps/test-variables/snap/snapcraft.yaml
@@ -6,6 +6,11 @@ grade: devel
 confinement: strict
 base: core24
 
+platforms:
+  s390x:
+    build-on: amd64
+    build-for: s390x
+
 parts:
   hello:
     plugin: nil

--- a/tests/spread/core24-suites/environment/test-variables/task.yaml
+++ b/tests/spread/core24-suites/environment/test-variables/task.yaml
@@ -1,5 +1,11 @@
 summary: Test scriptlets variables on core24
 
+# limit to amd64 for BUILD_ON variables
+systems:
+  - ubuntu-24.04
+  - ubuntu-24.04-64
+  - ubuntu-24.04-amd64
+
 environment:
   SNAP/test_variables: test-variables
 
@@ -38,6 +44,10 @@ execute: |
       "^SNAPCRAFT_PART_INSTALL=${root}/parts/hello/install$" \
       "^SNAPCRAFT_STAGE=${root}/stage$" \
       "^SNAPCRAFT_PRIME=${root}/prime$" \
+      "^CRAFT_ARCH_BUILD_ON=amd64$" \
+      "^CRAFT_ARCH_TRIPLET_BUILD_ON=x86_64-linux-gnu$" \
+      "^CRAFT_ARCH_BUILD_FOR=s390x$" \
+      "^CRAFT_ARCH_TRIPLET_BUILD_FOR=s390x-linux-gnu$" \
       "^CRAFT_PARALLEL_BUILD_COUNT=[0-9]\+$" \
       "^CRAFT_PROJECT_DIR=${root}$" \
       "^CRAFT_PART_NAME=hello$" \
@@ -52,10 +62,12 @@ execute: |
     done
   }
   
-  snapcraft pull
+  # exercise lifecycle commands with and without `--platform` and `--build-for`
+
+  snapcraft pull --platform s390x
   check_vars pull.txt
 
-  snapcraft build
+  snapcraft build --build-for s390x
   check_vars build.txt
 
   snapcraft stage

--- a/tests/spread/core24/linters-pack/library-gnome/snap/snapcraft.yaml
+++ b/tests/spread/core24/linters-pack/library-gnome/snap/snapcraft.yaml
@@ -92,6 +92,6 @@ parts:
     build-snaps: [core24, gtk-common-themes, gnome-46-2404/latest/edge]
     override-prime: |
       set -eux
-      for snap in "core24" "gtk-common-themes" "gnome-42-2204"; do
+      for snap in "core24" "gtk-common-themes" "gnome-46-2404"; do
         cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$CRAFT_PRIME/{}" \;
       done

--- a/tests/spread/core24/linters-pack/task.yaml
+++ b/tests/spread/core24/linters-pack/task.yaml
@@ -20,13 +20,12 @@ restore: |
 execute: |
   cd "${SNAP}"
 
-  # Remove this once library-gnome works (it will probably fail
-  # on the diff check.
-  if ! snapcraft pack 2> output.txt && [ "${SNAP}" = library-gnome ]; then
-    exit 0
+  snapcraft pack 2> output.txt
+
+  test -f linter-test_*.snap
+
+  # linter for gnome snap is not working as-expected (#4751)
+  if [ "${SNAP}" != "library-gnome" ]; then
+    sed -n '/^Running linters/,/^Creating snap/p' < output.txt > linter_output.txt
+    diff -u linter_output.txt expected_linter_output.txt
   fi
-
-  test -f linter-test_0.1_*.snap
-
-  sed -n '/^Running linters/,/^Creating snap/p' < output.txt > linter_output.txt
-  diff -u linter_output.txt expected_linter_output.txt

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -658,11 +658,11 @@ def test_build_for_error(
         "craft_application.services.remotebuild.RemoteBuildService.start_builds"
     )
     app = application.create_app()
-    assert app.run() == 78
+    assert app.run() == 1
 
     _, err = capsys.readouterr()
 
-    assert "build-for 'nonexistent' is not supported." in err
+    assert "Architecture 'nonexistent' is not supported." in err
 
 
 ########################


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Bump craft-application, enable gnome test, and add a regression test for BUILD_ON vars.