### PR TITLE
fix: set CRYPTOGRAPHY_OPENSSL_NO_LEGACY

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,10 @@ assumes:
 environment:
   PATH: "$SNAP/libexec/snapcraft:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   LD_LIBRARY_PATH: "$SNAP/none"
+  # cryptography>=42.0 cannot load legacy algorithms on
+  # Ubuntu 20.04 for armhf, ppc64el, riscv64, and s390x
+  CRYPTOGRAPHY_OPENSSL_NO_LEGACY: "1"
+
 
 apps:
   snapcraft:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

cryptography>=42.0 cannot load legacy algorithms on Ubuntu 20.04 for armhf, ppc64el, riscv64, and s390x.

@cmatsuoka was able to verify this fix in an emulated riscv64 20.04 machine from [here](https://cdimage.ubuntu.com/releases/20.04/release/).

See https://cryptography.io/en/latest/openssl/#legacy-provider-in-openssl-3-x for details on legacy algorithms. 

Fixes [LP#2064639](https://bugs.launchpad.net/snapcraft/+bug/2064639)