### PR TITLE
build(deps): bump craft-store to 2.6.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ craft-cli==2.5.1
 craft-grammar==1.2.0
 craft-parts==1.29.0
 craft-providers==1.23.1
-craft-store==2.6.1
+craft-store==2.6.2
 Deprecated==1.2.14
 distro==1.8.0
 gnupg==2.3.1

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -17,7 +17,7 @@ craft-cli==2.5.1
 craft-grammar==1.2.0
 craft-parts==1.29.0
 craft-providers==1.23.1
-craft-store==2.6.1
+craft-store==2.6.2
 cryptography==42.0.5
 Deprecated==1.2.14
 dill==0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ craft-cli==2.5.1
 craft-grammar==1.2.0
 craft-parts==1.29.0
 craft-providers==1.23.1
-craft-store==2.6.1
+craft-store==2.6.2
 cryptography==42.0.5
 Deprecated==1.2.14
 distro==1.9.0


### PR DESCRIPTION
Craft-store 2.6.2 disables libssl legacy providers and allows importing cryptography in focal.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
