### PR TITLE
fix(remote-build): don't fail with certain archs

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -24,6 +24,7 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import Any, cast
 
+import craft_cli
 import lazr.restfulclient.errors
 from craft_application import errors
 from craft_application.application import filter_plan
@@ -174,6 +175,16 @@ class RemoteBuildCommand(ExtensibleCommand):
         )
 
         emit.trace(f"Project directory: {project_dir}")
+
+        if project.architectures:
+            for arch in project.architectures:
+                if isinstance(arch, models.Architecture) and arch.build_for and "all" in arch.build_for:
+                    raise craft_cli.CraftError(
+                        message="Remote build does not support architecture 'all'.",
+                        resolution="Reconfigure your snap for architecture-dependent builds.",
+                        reportable=False,
+                        retcode=78  # Configuration error
+                    )
 
         possible_build_plan = filter_plan(
             self._app.BuildPlannerClass.unmarshal(project.marshal()).get_build_plan(),

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -178,12 +178,16 @@ class RemoteBuildCommand(ExtensibleCommand):
 
         if project.architectures:
             for arch in project.architectures:
-                if isinstance(arch, models.Architecture) and arch.build_for and "all" in arch.build_for:
+                if (
+                    isinstance(arch, models.Architecture)
+                    and arch.build_for
+                    and "all" in arch.build_for
+                ):
                     raise craft_cli.CraftError(
                         message="Remote build does not support architecture 'all'.",
                         resolution="Reconfigure your snap for architecture-dependent builds.",
                         reportable=False,
-                        retcode=78  # Configuration error
+                        retcode=78,  # Configuration error
                     )
 
         possible_build_plan = filter_plan(

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -98,6 +98,20 @@ class InvalidArchitecture(SnapcraftError):
         )
 
 
+class ArchAllInvalid(SnapcraftError):
+    """Architecture 'all' is invalid in this use case."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Cannot use architecture 'all'.",
+            details="This command does not support using architecture 'all' in your snap.",
+            resolution="Set your snap to architecture-dependent builds.",
+            logpath_report=False,
+            reportable=False,
+            retcode=78,
+        )
+
+
 class LinterError(SnapcraftError):
     """Snap linting returned an error.
 

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1225,10 +1225,13 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
             error_prefix = f"Error for platform entry '{platform_label}'"
 
             # Make sure the provided platform_set is valid
-            try:
-                platform = Platform(**platform_data)
-            except CraftValidationError as err:
-                raise CraftValidationError(f"{error_prefix}: {str(err)}") from None
+            if isinstance(platform_data, Platform):
+                platform = platform_data
+            else:
+                try:
+                    platform = Platform(**platform_data)
+                except CraftValidationError as err:
+                    raise CraftValidationError(f"{error_prefix}: {str(err)}") from None
 
             # build_on and build_for are validated
             # let's also validate the platform label

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -545,9 +545,10 @@ class Platform(models.CraftBaseModel):
             if isinstance(architecture, str):
                 build_on = build_for = [architecture]
             else:
-                build_for = (  # type: ignore[assignment]
-                    architecture.build_for or architecture.build_on
-                )
+                if architecture.build_for:
+                    build_for = architecture.build_for  # type: ignore[assignment]
+                else:
+                    build_for = architecture.build_on  # type: ignore[assignment]
                 build_on = architecture.build_on  # type: ignore[assignment]
 
             if isinstance(build_for, str):

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -543,21 +543,21 @@ class Platform(models.CraftBaseModel):
         platforms: dict[str, Self] = {}
         for architecture in architectures:
             if isinstance(architecture, str):
-                build_on = build_for = [architecture]
+                build_on = build_for = cast(UniqueStrList, [architecture])
             else:
-                if architecture.build_for:
-                    build_for = architecture.build_for  # type: ignore[assignment]
+                if isinstance(architecture.build_on, str):
+                    build_on = build_for = cast(UniqueStrList, [architecture.build_on])
                 else:
-                    build_for = architecture.build_on  # type: ignore[assignment]
-                build_on = architecture.build_on  # type: ignore[assignment]
+                    build_on = build_for = cast(UniqueStrList, architecture.build_on)
+                if architecture.build_for:
+                    if isinstance(architecture.build_for, str):
+                        build_for = cast(UniqueStrList, [architecture.build_for])
+                    else:
+                        build_for = cast(UniqueStrList, architecture.build_for)
 
-            if isinstance(build_for, str):
-                build_for = [build_for]
-            if isinstance(build_on, str):
-                build_on = [build_on]
             platforms[build_for[0]] = cls(
-                build_for=build_for,  # type: ignore[assignment]
-                build_on=build_on,  # type: ignore[assignment]
+                build_for=build_for,
+                build_on=build_on,
             )
 
         return platforms

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1179,6 +1179,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
     build_base: str | None = None
     name: str
     platforms: dict[str, Any] | None = None
+    architectures: List[Union[str, Architecture]] | None = None
     project_type: str | None = pydantic.Field(default=None, alias="type")
 
     @pydantic.validator("platforms")
@@ -1260,6 +1261,9 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
         # set default value
         if self.platforms is None:
             self.platforms = {get_host_architecture(): None}
+            # For backwards compatibility with core22, convert the platforms.
+            if self.base == "core22" and self.architectures:
+                self.platforms = utils.convert_architectures_to_platforms(self.architectures)
 
         for platform_entry, platform in self.platforms.items():
             for build_for in platform.build_for or [platform_entry]:

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1107,7 +1107,9 @@ class ComponentProject(models.CraftBaseModel, extra=pydantic.Extra.ignore):
         return _get_partitions_from_components(self.components)
 
 
-def _format_pydantic_errors(errors, *, file_name: str = "snapcraft.yaml"):
+def _format_pydantic_errors(  # pylint: disable=redefined-outer-name
+    errors, *, file_name: str = "snapcraft.yaml"
+):
     """Format errors.
 
     Example 1: Single error.

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -47,6 +47,7 @@ from pydantic import PrivateAttr, constr
 from typing_extensions import Self
 
 from snapcraft import utils
+from snapcraft import errors
 from snapcraft.const import SUPPORTED_ARCHS, SnapArch
 from snapcraft.elf.elf_utils import get_arch_triplet
 from snapcraft.errors import ProjectValidationError
@@ -555,6 +556,8 @@ class Platform(models.CraftBaseModel):
                     else:
                         build_for = cast(UniqueStrList, architecture.build_for)
 
+            if "all" in build_for:
+                raise errors.ArchAllInvalid()
             platforms[build_for[0]] = cls(
                 build_for=build_for,
                 build_on=build_on,

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1263,7 +1263,9 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
             self.platforms = {get_host_architecture(): None}
             # For backwards compatibility with core22, convert the platforms.
             if self.base == "core22" and self.architectures:
-                self.platforms = utils.convert_architectures_to_platforms(self.architectures)
+                self.platforms = utils.convert_architectures_to_platforms(
+                    self.architectures
+                )
 
         for platform_entry, platform in self.platforms.items():
             for build_for in platform.build_for or [platform_entry]:

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1291,7 +1291,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
         if self.platforms is None:
             self.platforms = {get_host_architecture(): None}
             # For backwards compatibility with core22, convert the platforms.
-            if self.base == "core22" and self.architectures:
+            if effective_base == "22.04" and self.architectures:
                 self.platforms = Platform.from_architectures(self.architectures)
 
         for platform_entry, platform in self.platforms.items():

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -44,10 +44,9 @@ from craft_cli import emit
 from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, GrammarStrList
 from craft_providers import bases
 from pydantic import PrivateAttr, constr
-from typing_extensions import override, Self
+from typing_extensions import Self, override
 
-from snapcraft import utils
-from snapcraft import errors
+from snapcraft import errors, utils
 from snapcraft.const import SUPPORTED_ARCHS, SnapArch
 from snapcraft.elf.elf_utils import get_arch_triplet
 from snapcraft.errors import ProjectValidationError

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -34,9 +34,6 @@ from craft_parts.sources.git_source import GitSource
 
 from snapcraft import errors
 
-if TYPE_CHECKING:
-    pass
-
 
 @dataclass
 class OSPlatform:

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -33,10 +33,9 @@ from craft_cli import emit
 from craft_parts.sources.git_source import GitSource
 
 from snapcraft import errors
-from snapcraft.models import project
 
 if TYPE_CHECKING:
-    from snapcraft import models
+    pass
 
 
 @dataclass
@@ -491,27 +490,3 @@ def process_version(version: Optional[str]) -> str:
 def is_snapcraft_running_from_snap() -> bool:
     """Check if snapcraft is running from the snap."""
     return os.getenv("SNAP_NAME") == "snapcraft" and os.getenv("SNAP") is not None
-
-
-def convert_architectures_to_platforms(
-    architectures: list[str | models.Architecture],
-) -> dict[str, models.Platform]:
-    """Convert a core22 architectures configuration to core24 platforms."""
-    platforms: dict[str, models.Platform] = {}
-    for architecture in architectures:
-        if isinstance(architecture, str):
-            build_on = build_for = [architecture]
-        else:
-            build_for = architecture.build_for or architecture.build_on  # type: ignore[assignment]
-            build_on = architecture.build_on  # type: ignore[assignment]
-
-        if isinstance(build_for, str):
-            build_for = [build_for]
-        if isinstance(build_on, str):
-            build_on = [build_on]
-        platforms[build_for[0]] = project.Platform(
-            build_for=build_for,  # type: ignore[assignment]
-            build_on=build_on,  # type: ignore[assignment]
-        )
-
-    return platforms

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -33,6 +33,7 @@ from craft_cli import emit
 from craft_parts.sources.git_source import GitSource
 
 from snapcraft import errors
+from snapcraft.models import project
 
 if TYPE_CHECKING:
     from snapcraft import models
@@ -508,7 +509,7 @@ def convert_architectures_to_platforms(
             build_for = [build_for]
         if isinstance(build_on, str):
             build_on = [build_on]
-        platforms[build_for[0]] = models.Platform(
+        platforms[build_for[0]] = project.Platform(
             build_for=build_for,  # type: ignore[assignment]
             build_on=build_on,  # type: ignore[assignment]
         )

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -16,6 +16,7 @@
 
 """Utilities for snapcraft."""
 from __future__ import annotations
+
 import multiprocessing
 import os
 import pathlib
@@ -492,7 +493,7 @@ def is_snapcraft_running_from_snap() -> bool:
 
 
 def convert_architectures_to_platforms(
-    architectures: list[str | models.Architecture]
+    architectures: list[str | models.Architecture],
 ) -> dict[str, dict[str, list[str]]]:
     """Convert a core22 architectures configuration to core24 platforms."""
     platforms = {}
@@ -513,4 +514,3 @@ def convert_architectures_to_platforms(
             }
 
     return platforms
-

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -27,7 +27,7 @@ import sys
 from dataclasses import dataclass
 from getpass import getpass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Optional
+from typing import Iterable, List, Optional
 
 from craft_cli import emit
 from craft_parts.sources.git_source import GitSource

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -494,23 +494,23 @@ def is_snapcraft_running_from_snap() -> bool:
 
 def convert_architectures_to_platforms(
     architectures: list[str | models.Architecture],
-) -> dict[str, dict[str, list[str]]]:
+) -> dict[str, models.Platform]:
     """Convert a core22 architectures configuration to core24 platforms."""
-    platforms = {}
+    platforms: dict[str, models.Platform] = {}
     for architecture in architectures:
         if isinstance(architecture, str):
-            platforms[architecture] = None
+            build_on = build_for = [architecture]
         else:
-            build_for = architecture.build_for or architecture.build_on
-            build_on = architecture.build_on
+            build_for = architecture.build_for or architecture.build_on  # type: ignore[assignment]
+            build_on = architecture.build_on  # type: ignore[assignment]
 
-            if isinstance(build_for, str):
-                build_for = [build_for]
-            if isinstance(build_on, str):
-                build_on = [build_on]
-            platforms[build_for[0]] = {
-                "build-for": build_for,
-                "build-on": build_on,
-            }
+        if isinstance(build_for, str):
+            build_for = [build_for]
+        if isinstance(build_on, str):
+            build_on = [build_on]
+        platforms[build_for[0]] = models.Platform(
+            build_for=build_for,  # type: ignore[assignment]
+            build_on=build_on,  # type: ignore[assignment]
+        )
 
     return platforms

--- a/tests/spread/general/remote-build/architectures-snap.yaml
+++ b/tests/spread/general/remote-build/architectures-snap.yaml
@@ -1,0 +1,19 @@
+name: test-snap
+version: '0.1'
+summary: test
+description: test
+
+grade: devel
+confinement: devmode
+
+base: core22
+
+architectures:
+  - build-on: arm64
+  - amd64
+  - build-for: s390x
+
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/general/remote-build/platforms-snap.yaml
+++ b/tests/spread/general/remote-build/platforms-snap.yaml
@@ -1,0 +1,22 @@
+name: test-snap
+version: '0.1'
+summary: test
+description: test
+
+grade: devel
+confinement: devmode
+
+base: core24
+
+platforms:
+  arm64:
+  x64:
+    build-for: [amd64]
+    build-on: [arm64, amd64, riscv64]
+  mainframe:
+    build-on: [s390x]
+
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/general/remote-build/task.yaml
+++ b/tests/spread/general/remote-build/task.yaml
@@ -4,8 +4,12 @@ kill-timeout: 180m
 
 environment:
   LAUNCHPAD_TOKEN: "$(HOST: echo ${LAUNCHPAD_TOKEN})"
+  STRATEGY: ""
   STRATEGY/DISABLE_FALLBACK: "disable-fallback"
   STRATEGY/FORCE_FALLBACK: "force-fallback"
+  SNAPCRAFT_FILE: ""
+  SNAPCRAFT_FILE/architectures: "architectures-snap.yaml"
+  SNAPCRAFT_FILE/platforms: "platforms-snap.yaml"
 
 prepare: |
   if [[ -z "$LAUNCHPAD_TOKEN" ]]; then
@@ -13,7 +17,12 @@ prepare: |
     exit 1
   fi
 
-  snapcraft init
+  if [ -z "${SNAPCRAFT_FILE}" ]; then
+    snapcraft init
+  else
+    mkdir snap
+    cp "${SNAPCRAFT_FILE}" snap/snapcraft.yaml
+  fi
 
   # Commit the project
   git config --global --add safe.directory "$PWD"

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -16,6 +16,7 @@
 
 """Remote-build command tests."""
 
+import argparse
 import os
 import shutil
 import subprocess
@@ -24,13 +25,14 @@ import time
 from pathlib import Path
 from unittest.mock import ANY, Mock
 
+import craft_cli
 import pytest
 from craft_application import launchpad
 from craft_application.errors import RemoteBuildError
 from craft_application.remote.git import GitRepo
 from craft_application.remote.utils import get_build_id
 
-from snapcraft import application
+from snapcraft import application, commands, models
 from snapcraft.const import SnapArch
 from snapcraft.errors import ClassicFallback
 from snapcraft.parts.yaml_utils import CURRENT_BASES, LEGACY_BASES
@@ -409,6 +411,30 @@ def test_run_in_shallow_repo_unsupported(
 ######################
 # Architecture tests #
 ######################
+
+
+def test_no_architecture_all(
+    mocker, snapcraft_yaml, fake_services, mock_remote_builder_fake_build_process
+):
+    """Test that remote builds error out early with an architecture 'all'."""
+    project = snapcraft_yaml(
+        base="core22",
+        architectures=[{"build-on": "amd64", "build-for": "all"}]
+    )
+    fake_services.project = models.Project.unmarshal(project)
+    cmd = commands.RemoteBuildCommand(
+        {"app": application.APP_METADATA, "services": fake_services}
+    )
+
+    with pytest.raises(
+        craft_cli.CraftError, match="Remote build does not support architecture 'all'"
+    ):
+        cmd.run(
+            argparse.Namespace(
+                project=None,
+                launchpad_accept_public_upload=True,
+            )
+        )
 
 
 @pytest.mark.parametrize("base", CURRENT_BASES)

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -418,8 +418,7 @@ def test_no_architecture_all(
 ):
     """Test that remote builds error out early with an architecture 'all'."""
     project = snapcraft_yaml(
-        base="core22",
-        architectures=[{"build-on": "amd64", "build-for": "all"}]
+        base="core22", architectures=[{"build-on": "amd64", "build-for": "all"}]
     )
     fake_services.project = models.Project.unmarshal(project)
     cmd = commands.RemoteBuildCommand(

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -710,6 +710,66 @@ class TestPlatforms:
             "Use 'architectures' keyword instead." in str(raised.value)
         )
 
+    @pytest.mark.parametrize(
+        ("architectures", "expected"),
+        [
+            ([], {}),
+            (
+                ["amd64"],
+                {
+                    "amd64": Platform(
+                        build_for=[const.SnapArch("amd64")],
+                        build_on=[const.SnapArch("amd64")],
+                    )
+                },
+            ),
+            (
+                [Architecture(build_on="amd64", build_for="riscv64")],
+                {
+                    "riscv64": Platform(
+                        build_for=[const.SnapArch("riscv64")],
+                        build_on=[const.SnapArch("amd64")],
+                    )
+                },
+            ),
+            (
+                [
+                    Architecture.unmarshal(
+                        {"build_on": ["amd64"], "build_for": ["riscv64"]}
+                    )
+                ],
+                {
+                    "riscv64": Platform(
+                        build_for=[const.SnapArch("riscv64")],
+                        build_on=[const.SnapArch("amd64")],
+                    )
+                },
+            ),
+            (
+                [
+                    Architecture.unmarshal(
+                        {"build_on": ["amd64", "arm64"], "build_for": ["riscv64"]}
+                    ),
+                    Architecture.unmarshal(
+                        {"build_on": ["amd64", "arm64"], "build_for": ["arm64"]}
+                    ),
+                ],
+                {
+                    "riscv64": Platform(
+                        build_for=[const.SnapArch("riscv64")],
+                        build_on=[const.SnapArch("amd64"), const.SnapArch("arm64")],
+                    ),
+                    "arm64": Platform(
+                        build_for=[const.SnapArch("arm64")],
+                        build_on=[const.SnapArch("amd64"), const.SnapArch("arm64")],
+                    ),
+                },
+            ),
+        ],
+    )
+    def test_from_architectures(self, architectures, expected):
+        assert Platform.from_architectures(architectures) == expected
+
 
 class TestAppValidation:
     """Validate apps."""

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -770,6 +770,11 @@ class TestPlatforms:
     def test_from_architectures(self, architectures, expected):
         assert Platform.from_architectures(architectures) == expected
 
+    def test_from_architectures_no_all(self):
+        """Test that 'from_architectures' does not support architecture 'all'."""
+        with pytest.raises(errors.ArchAllInvalid):
+            Platform.from_architectures([Architecture(build_on="amd64", build_for="all")])
+
 
 class TestAppValidation:
     """Validate apps."""

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -23,9 +23,8 @@ from craft_application.errors import CraftValidationError
 from craft_application.models import BuildInfo, UniqueStrList
 from craft_providers.bases import BaseName
 
-from snapcraft import utils
 import snapcraft.models
-from snapcraft import const, errors, providers
+from snapcraft import const, errors, providers, utils
 from snapcraft.models import (
     MANDATORY_ADOPTABLE_FIELDS,
     Architecture,
@@ -789,7 +788,9 @@ class TestPlatforms:
     def test_from_architectures_no_all(self):
         """Test that 'from_architectures' does not support architecture 'all'."""
         with pytest.raises(errors.ArchAllInvalid):
-            Platform.from_architectures([Architecture(build_on="amd64", build_for="all")])
+            Platform.from_architectures(
+                [Architecture(build_on="amd64", build_for="all")]
+            )
 
 
 class TestAppValidation:
@@ -2055,8 +2056,8 @@ def test_build_planner_get_build_plan(platforms, expected_build_infos):
                     platform=utils.get_host_architecture(),
                 )
             ],
-            id="no_arch"
-        )
+            id="no_arch",
+        ),
     ],
 )
 def test_build_planner_get_build_plan_core22(architectures, expected_build_infos):

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -1974,6 +1974,74 @@ def test_build_planner_get_build_plan(platforms, expected_build_infos):
     assert actual_build_infos == expected_build_infos
 
 
+@pytest.mark.parametrize(
+    ("architectures", "expected_build_infos"),
+    [
+        pytest.param(
+            ["amd64"],
+            [
+                BuildInfo(
+                    build_on="amd64",
+                    build_for="amd64",
+                    base=BaseName(name="ubuntu", version="22.04"),
+                    platform="amd64",
+                )
+            ],
+            id="single_platform_as_arch",
+        ),
+        pytest.param(
+            [
+                {
+                    "build-on": ["arm64", "armhf"],
+                    "build-for": ["arm64"],
+                },
+            ],
+            [
+                BuildInfo(
+                    build_on="arm64",
+                    build_for="arm64",
+                    base=BaseName(name="ubuntu", version="22.04"),
+                    platform="arm64",
+                ),
+                BuildInfo(
+                    build_on="armhf",
+                    build_for="arm64",
+                    base=BaseName(name="ubuntu", version="22.04"),
+                    platform="arm64",
+                ),
+            ],
+            id="multiple_build_on",
+        ),
+        pytest.param(
+            [
+                {
+                    "build-on": ["amd64"],
+                    "build-for": "amd64",
+                },
+            ],
+            [
+                BuildInfo(
+                    build_on="amd64",
+                    build_for="amd64",
+                    base=BaseName(name="ubuntu", version="22.04"),
+                    platform="amd64",
+                )
+            ],
+            id="fully_defined_arch",
+        ),
+    ],
+)
+def test_build_planner_get_build_plan_core22(architectures, expected_build_infos):
+    """Test `get_build_plan()` function with different platforms."""
+    planner = snapcraft.models.project.SnapcraftBuildPlanner.parse_obj(
+        {"name": "test-snap", "base": "core22", "architectures": architectures}
+    )
+
+    actual_build_infos = planner.get_build_plan()
+
+    assert actual_build_infos == expected_build_infos
+
+
 def test_get_build_plan_devel():
     """Test that "devel" build-bases are correctly reflected on the build plan"""
     planner = snapcraft.models.project.SnapcraftBuildPlanner.parse_obj(

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -23,6 +23,7 @@ from craft_application.errors import CraftValidationError
 from craft_application.models import BuildInfo, UniqueStrList
 from craft_providers.bases import BaseName
 
+from snapcraft import utils
 import snapcraft.models
 from snapcraft import const, errors
 from snapcraft.models import (
@@ -2029,6 +2030,18 @@ def test_build_planner_get_build_plan(platforms, expected_build_infos):
             ],
             id="fully_defined_arch",
         ),
+        pytest.param(
+            None,
+            [
+                BuildInfo(
+                    build_on=utils.get_host_architecture(),
+                    build_for=utils.get_host_architecture(),
+                    base=BaseName(name="ubuntu", version="22.04"),
+                    platform=utils.get_host_architecture(),
+                )
+            ],
+            id="no_arch"
+        )
     ],
 )
 def test_build_planner_get_build_plan_core22(architectures, expected_build_infos):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,7 +22,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from snapcraft import const, errors, models, utils
+from snapcraft import errors, utils
 
 
 @pytest.fixture
@@ -656,64 +656,3 @@ def test_confirm_with_user_pause_emitter(mock_isatty, emitter):
 
     with patch("snapcraft.utils.input", fake_input):
         utils.confirm_with_user("prompt")
-
-
-@pytest.mark.parametrize(
-    ("architectures", "expected"),
-    [
-        ([], {}),
-        (
-            ["amd64"],
-            {
-                "amd64": models.Platform(
-                    build_for=[const.SnapArch("amd64")],
-                    build_on=[const.SnapArch("amd64")],
-                )
-            },
-        ),
-        (
-            [models.Architecture(build_on="amd64", build_for="riscv64")],
-            {
-                "riscv64": models.Platform(
-                    build_for=[const.SnapArch("riscv64")],
-                    build_on=[const.SnapArch("amd64")],
-                )
-            },
-        ),
-        (
-            [
-                models.Architecture.unmarshal(
-                    {"build_on": ["amd64"], "build_for": ["riscv64"]}
-                )
-            ],
-            {
-                "riscv64": models.Platform(
-                    build_for=[const.SnapArch("riscv64")],
-                    build_on=[const.SnapArch("amd64")],
-                )
-            },
-        ),
-        (
-            [
-                models.Architecture.unmarshal(
-                    {"build_on": ["amd64", "arm64"], "build_for": ["riscv64"]}
-                ),
-                models.Architecture.unmarshal(
-                    {"build_on": ["amd64", "arm64"], "build_for": ["arm64"]}
-                ),
-            ],
-            {
-                "riscv64": models.Platform(
-                    build_for=[const.SnapArch("riscv64")],
-                    build_on=[const.SnapArch("amd64"), const.SnapArch("arm64")],
-                ),
-                "arm64": models.Platform(
-                    build_for=[const.SnapArch("arm64")],
-                    build_on=[const.SnapArch("amd64"), const.SnapArch("arm64")],
-                ),
-            },
-        ),
-    ],
-)
-def test_convert_architectures_to_platforms(architectures, expected):
-    assert utils.convert_architectures_to_platforms(architectures) == expected

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,7 +22,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from snapcraft import errors, models, utils
+from snapcraft import const, errors, models, utils
 
 
 @pytest.fixture
@@ -662,10 +662,23 @@ def test_confirm_with_user_pause_emitter(mock_isatty, emitter):
     ("architectures", "expected"),
     [
         ([], {}),
-        (["amd64"], {"amd64": None}),
+        (
+            ["amd64"],
+            {
+                "amd64": models.Platform(
+                    build_for=[const.SnapArch("amd64")],
+                    build_on=[const.SnapArch("amd64")],
+                )
+            },
+        ),
         (
             [models.Architecture(build_on="amd64", build_for="riscv64")],
-            {"riscv64": {"build-on": ["amd64"], "build-for": ["riscv64"]}},
+            {
+                "riscv64": models.Platform(
+                    build_for=[const.SnapArch("riscv64")],
+                    build_on=[const.SnapArch("amd64")],
+                )
+            },
         ),
         (
             [
@@ -673,7 +686,12 @@ def test_confirm_with_user_pause_emitter(mock_isatty, emitter):
                     {"build_on": ["amd64"], "build_for": ["riscv64"]}
                 )
             ],
-            {"riscv64": {"build-on": ["amd64"], "build-for": ["riscv64"]}},
+            {
+                "riscv64": models.Platform(
+                    build_for=[const.SnapArch("riscv64")],
+                    build_on=[const.SnapArch("amd64")],
+                )
+            },
         ),
         (
             [
@@ -685,8 +703,14 @@ def test_confirm_with_user_pause_emitter(mock_isatty, emitter):
                 ),
             ],
             {
-                "riscv64": {"build-on": ["amd64", "arm64"], "build-for": ["riscv64"]},
-                "arm64": {"build-on": ["amd64", "arm64"], "build-for": ["arm64"]},
+                "riscv64": models.Platform(
+                    build_for=[const.SnapArch("riscv64")],
+                    build_on=[const.SnapArch("amd64"), const.SnapArch("arm64")],
+                ),
+                "arm64": models.Platform(
+                    build_for=[const.SnapArch("arm64")],
+                    build_on=[const.SnapArch("amd64"), const.SnapArch("arm64")],
+                ),
             },
         ),
     ],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -665,23 +665,31 @@ def test_confirm_with_user_pause_emitter(mock_isatty, emitter):
         (["amd64"], {"amd64": None}),
         (
             [models.Architecture(build_on="amd64", build_for="riscv64")],
-            {"riscv64": {"build-on": ["amd64"], "build-for": ["riscv64"]}}
-        ),
-        (
-            [models.Architecture.unmarshal({"build_on": ["amd64"], "build_for": ["riscv64"]})],
-            {"riscv64": {"build-on": ["amd64"], "build-for": ["riscv64"]}}
+            {"riscv64": {"build-on": ["amd64"], "build-for": ["riscv64"]}},
         ),
         (
             [
-                models.Architecture.unmarshal({"build_on": ["amd64", "arm64"], "build_for": ["riscv64"]}),
-                models.Architecture.unmarshal({"build_on": ["amd64", "arm64"], "build_for": ["arm64"]}),
+                models.Architecture.unmarshal(
+                    {"build_on": ["amd64"], "build_for": ["riscv64"]}
+                )
+            ],
+            {"riscv64": {"build-on": ["amd64"], "build-for": ["riscv64"]}},
+        ),
+        (
+            [
+                models.Architecture.unmarshal(
+                    {"build_on": ["amd64", "arm64"], "build_for": ["riscv64"]}
+                ),
+                models.Architecture.unmarshal(
+                    {"build_on": ["amd64", "arm64"], "build_for": ["arm64"]}
+                ),
             ],
             {
                 "riscv64": {"build-on": ["amd64", "arm64"], "build-for": ["riscv64"]},
-                "arm64": {"build-on": ["amd64", "arm64"], "build-for": ["arm64"]}
-            }
+                "arm64": {"build-on": ["amd64", "arm64"], "build-for": ["arm64"]},
+            },
         ),
-    ]
+    ],
 )
 def test_convert_architectures_to_platforms(architectures, expected):
     assert utils.convert_architectures_to_platforms(architectures) == expected


### PR DESCRIPTION
This fixes the initial reported bug in #4780. However, I haven't tested some other use cases listed in that bug report.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
