### PR TITLE
tests: update chisel-base test to use core24

### DIFF
--- a/tests/spread/core24/chisel-base/snapcraft.yaml
+++ b/tests/spread/core24/chisel-base/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: core2x
 type: base
-build-base: devel
+build-base: core24
 summary: base using chisel from core24 assets
 description: |
   Test creating a base using a stable release of chisel


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Update chisel-base spread test now that `devel` points to Ubuntu 24.10.