### PR TITLE
build(deps): bump craft-application to 2.7.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 attrs==23.1.0
 catkin-pkg==0.5.2
 click==8.1.7
-craft-application==2.6.3
+craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.4.4
-craft-application==2.6.3
+craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==2.6.3
+craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/snapcraft/commands/unimplemented.py
+++ b/snapcraft/commands/unimplemented.py
@@ -44,6 +44,20 @@ class UnimplementedMixin:
         # Fallback to the codepaths for non-core24-code.
         raise errors.ClassicFallback()
 
+    def needs_project(
+        self,
+        parsed_args: argparse.Namespace,  # noqa: ARG002 (unused argument is for subclasses)
+    ) -> bool:
+        """Property to determine if the command needs a project loaded.
+
+        Defaults to `self.always_load_project`.
+
+        :param parsed_args: Parsed arguments for the command.
+
+        :returns: True if the command needs a project loaded, False otherwise.
+        """
+        return self.always_load_project
+
     def run_managed(
         self,
         parsed_args: argparse.Namespace,  # noqa: ARG002 (the unused argument is for subclasses)

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -44,6 +44,7 @@ from craft_cli import emit
 from craft_grammar.models import GrammarSingleEntryDictList, GrammarStr, GrammarStrList
 from craft_providers import bases
 from pydantic import PrivateAttr, constr
+from typing_extensions import override
 
 from snapcraft import utils
 from snapcraft.const import SUPPORTED_ARCHS, SnapArch
@@ -601,6 +602,25 @@ class Project(models.Project):
     ua_services: Optional[UniqueStrList]
     provenance: Optional[str]
     components: Optional[Dict[ProjectName, Component]]
+
+    @override
+    @classmethod
+    def _providers_base(cls, base: str) -> bases.BaseAlias | None:
+        """Get a BaseAlias from snapcraft's base.
+
+        :param base: The application-specific base name.
+
+        :returns: The BaseAlias for the base.
+
+        :raises CraftValidationError: If the project's base cannot be determined.
+        """
+        if base == "bare":
+            return None
+
+        try:
+            return SNAPCRAFT_BASE_TO_PROVIDER_BASE[base]
+        except KeyError as err:
+            raise CraftValidationError(f"Unknown base {base!r}") from err
 
     @pydantic.validator("plugs")
     @classmethod


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Bump craft-application to 2.7.0.  Requires implementing `_providers_base()`.

Based on https://github.com/canonical/snapcraft/pull/4721