### PR TITLE
fix: do not load system libraries for classic core24 snaps

### DIFF
--- a/snapcraft/elf/_patcher.py
+++ b/snapcraft/elf/_patcher.py
@@ -49,13 +49,15 @@ class Patcher:
         self._patchelf_cmd = preferred_patchelf or utils.get_snap_tool("patchelf")
         self._strip_cmd = utils.get_snap_tool("strip")
 
-    def patch(self, *, elf_file: ElfFile) -> None:
+    def patch(self, *, elf_file: ElfFile, use_system_libs: bool = True) -> None:
         """Patch elf_file with the Patcher instance configuration.
 
         If the ELF is executable, patch it to use the configured linker.
         If the ELF has dependencies (DT_NEEDED), set an rpath to them.
 
         :param elf_file: a data object representing an elf file and its attributes.
+        :param use_system_libs: If true, search for dependencies in the default
+            library search paths.
 
         :raises PatcherError: if the ELF file cannot be patched.
         """
@@ -84,6 +86,9 @@ class Patcher:
             if not set(proposed_rpath).issubset(set(current_rpath)):
                 formatted_rpath = ":".join(proposed_rpath)
                 patchelf_args.extend(["--force-rpath", "--set-rpath", formatted_rpath])
+
+            if not use_system_libs:
+                patchelf_args.append("--no-default-lib")
 
         # no patchelf_args means there is nothing to do.
         if not patchelf_args:

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -666,8 +666,18 @@ def set_step_environment(step_info: StepInfo) -> bool:
     return True
 
 
-def patch_elf(step_info: StepInfo) -> bool:
-    """Patch rpath and interpreter in ELF files for classic mode."""
+def patch_elf(step_info: StepInfo, use_system_libs: bool = True) -> bool:
+    """Patch rpath and interpreter in ELF files for classic mode.
+
+    :param step_info: The step information.
+    :param use_system_libs: If true, search for dependencies in the default
+        library search paths.
+
+    :returns: True
+
+    :raises DynamicLinkerNotFound: If the dynamic linker is not found.
+    :raises PatcherError: If the ELF file cannot be patched.
+    """
     if "enable-patchelf" not in step_info.build_attributes:
         emit.debug(f"patch_elf: not enabled for part {step_info.part_name!r}")
         return True
@@ -708,7 +718,7 @@ def patch_elf(step_info: StepInfo) -> bool:
 
         relative_path = elf_file.path.relative_to(step_info.prime_dir)
         emit.progress(f"Patch ELF file: {str(relative_path)!r}")
-        patcher.patch(elf_file=elf_file)
+        patcher.patch(elf_file=elf_file, use_system_libs=use_system_libs)
 
     return True
 

--- a/snapcraft/services/lifecycle.py
+++ b/snapcraft/services/lifecycle.py
@@ -85,7 +85,12 @@ class Lifecycle(LifecycleService):
     @overrides
     def post_prime(self, step_info: StepInfo) -> bool:
         """Run post-prime parts steps for Snapcraft."""
-        return parts.patch_elf(step_info)
+        project = cast(models.Project, self._project)
+
+        # do not use system libraries in classic confinement
+        use_system_libs = not bool(project.confinement == "classic")
+
+        return parts.patch_elf(step_info, use_system_libs=use_system_libs)
 
     def get_prime_dir(self, component: str | None = None) -> Path:
         """Get the prime directory path for the default prime dir or a component.

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/Makefile
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/Makefile
@@ -8,4 +8,4 @@ install: hello-classic
 	install -D $^ $(DESTDIR)/bin/
 
 hello-classic: hello-classic.c
-	$(CC) hello-classic.c -o hello-classic -lcurl
+	$(CC) hello-classic.c -o hello-classic -lcurl -lpng

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/hello-classic.c
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/hello-classic.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <curl/curl.h>
+#include <png.h>
 
 int main() {
     curl_global_init(CURL_GLOBAL_DEFAULT);
+    png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 }

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ base: core24
 grade: devel
 confinement: classic
 
+apps:
+  classic-patchelf:
+    command: bin/hello-classic
+
 parts:
   hello:
     source: .
@@ -18,6 +22,7 @@ parts:
     build-packages:
       - gcc
       - libcurl4-openssl-dev
+      - libpng-dev
   hello-existing-rpath:
     source: .
     plugin: make

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/task.yaml
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/task.yaml
@@ -11,9 +11,10 @@ prepare: |
 restore: |
   snapcraft clean --destructive-mode
   rm -f ./*.snap
+  apt remove libpng16-16t64 -y
 
 execute: |
-  snapcraft prime --destructive-mode
+  snapcraft pack --destructive-mode
 
   arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
 
@@ -36,3 +37,12 @@ execute: |
      echo "found rpath with no-patchelf: ${rpath}"
      exit 1
   fi
+
+  # ensure system libraries are not loaded
+  snap install classic-patchelf_0.1_amd64.snap --dangerous --classic
+  classic-patchelf
+  apt install libpng16-16t64 -y
+  classic-patchelf
+
+  # debugging - fail to see the test output
+  exit 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

On `core24`, snapcraft should pass `--no-default-libs` to `patchelf` to not load libraries from default locations.