### PR TITLE
do not load system libraries for classic core24 snaps, bump craft-parts, unregister dotnet

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts==1.30.0
 craft-providers==1.23.1
 craft-store==2.6.2
 Deprecated==1.2.14

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts==1.30.0
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts==1.30.0
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -110,6 +110,13 @@ class Snapcraft(Application):
         return plugins.get_plugins(core22=False)
 
     @override
+    def _register_default_plugins(self) -> None:
+        """Register per application plugins when initializing."""
+        super()._register_default_plugins()
+        # dotnet is disabled for core24 because it is pending a rewrite
+        craft_parts.plugins.unregister("dotnet")
+
+    @override
     def _configure_services(self, provider_name: str | None) -> None:
         self.services.set_kwargs(
             "package",

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -666,8 +666,18 @@ def set_step_environment(step_info: StepInfo) -> bool:
     return True
 
 
-def patch_elf(step_info: StepInfo) -> bool:
-    """Patch rpath and interpreter in ELF files for classic mode."""
+def patch_elf(step_info: StepInfo, use_system_libs: bool = True) -> bool:
+    """Patch rpath and interpreter in ELF files for classic mode.
+
+    :param step_info: The step information.
+    :param use_system_libs: If true, search for dependencies in the default
+        library search paths.
+
+    :returns: True
+
+    :raises DynamicLinkerNotFound: If the dynamic linker is not found.
+    :raises PatcherError: If the ELF file cannot be patched.
+    """
     if "enable-patchelf" not in step_info.build_attributes:
         emit.debug(f"patch_elf: not enabled for part {step_info.part_name!r}")
         return True
@@ -708,7 +718,7 @@ def patch_elf(step_info: StepInfo) -> bool:
 
         relative_path = elf_file.path.relative_to(step_info.prime_dir)
         emit.progress(f"Patch ELF file: {str(relative_path)!r}")
-        patcher.patch(elf_file=elf_file)
+        patcher.patch(elf_file=elf_file, use_system_libs=use_system_libs)
 
     return True
 

--- a/snapcraft/services/lifecycle.py
+++ b/snapcraft/services/lifecycle.py
@@ -85,7 +85,12 @@ class Lifecycle(LifecycleService):
     @overrides
     def post_prime(self, step_info: StepInfo) -> bool:
         """Run post-prime parts steps for Snapcraft."""
-        return parts.patch_elf(step_info)
+        project = cast(models.Project, self._project)
+
+        # do not use system libraries in classic confinement
+        use_system_libs = not bool(project.confinement == "classic")
+
+        return parts.patch_elf(step_info, use_system_libs=use_system_libs)
 
     def get_prime_dir(self, component: str | None = None) -> Path:
         """Get the prime directory path for the default prime dir or a component.

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/snap/snapcraft.yaml
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ base: core24
 grade: devel
 confinement: classic
 
+apps:
+  classic-patchelf:
+    command: bin/hello-classic
+
 parts:
   hello:
     source: .

--- a/tests/spread/core24-suites/patchelf/classic-patchelf/task.yaml
+++ b/tests/spread/core24-suites/patchelf/classic-patchelf/task.yaml
@@ -1,19 +1,23 @@
 summary: Build a classic snap and validates elf patching
 
 prepare: |
-  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
-  . "$TOOLS_DIR/snapcraft-yaml.sh"
-  # set_base snap/snapcraft.yaml
-
   apt-get install patchelf dpkg-dev -y
   apt-mark auto patchelf dpkg-dev
 
 restore: |
-  snapcraft clean --destructive-mode
+  # unset SNAPCRAFT_BUILD_ENVIRONMENT=host
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  snapcraft clean
+
   rm -f ./*.snap
 
 execute: |
-  snapcraft prime --destructive-mode
+  # unset SNAPCRAFT_BUILD_ENVIRONMENT=host
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft pack
+
+  unsquashfs -dest snap-contents classic-patchelf_0.1_amd64.snap
 
   arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
 
@@ -22,17 +26,20 @@ execute: |
   RPATH_ORIGIN_MATCH="^\\\$ORIGIN/../fake-lib:/snap/core24/current/lib/$arch_triplet"
 
   # Verify typical binary.
-  patchelf --print-interpreter prime/bin/hello-classic | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-classic | MATCH "${RPATH_MATCH}"
+  patchelf --print-interpreter snap-contents/bin/hello-classic | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
+  patchelf --print-rpath snap-contents/bin/hello-classic | MATCH "${RPATH_MATCH}"
 
   # Verify binary w/ existing rpath.
-  patchelf --print-interpreter prime/bin/hello-classic-existing-rpath | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-classic-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
+  patchelf --print-interpreter snap-contents/bin/hello-classic-existing-rpath | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
+  patchelf --print-rpath snap-contents/bin/hello-classic-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
 
   # Verify untouched no-patchelf.
-  patchelf --print-interpreter prime/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld.*.so.*"
-  rpath="$(patchelf --print-rpath prime/bin/hello-classic-no-patchelf)"
+  patchelf --print-interpreter snap-contents/bin/hello-classic-no-patchelf | MATCH "^/lib.*ld.*.so.*"
+  rpath="$(patchelf --print-rpath snap-contents/bin/hello-classic-no-patchelf)"
   if [[ -n "${rpath}" ]]; then
      echo "found rpath with no-patchelf: ${rpath}"
      exit 1
   fi
+
+  # verify `patchelf --no-default-lib` was applied
+  readelf --dynamic snap-contents/bin/hello-classic | MATCH "FLAGS_1.*NODEFLIB"

--- a/tests/spread/core24-suites/patchelf/strict-patchelf/task.yaml
+++ b/tests/spread/core24-suites/patchelf/strict-patchelf/task.yaml
@@ -5,7 +5,9 @@ prepare: |
   apt-mark auto patchelf dpkg-dev
 
 restore: |
-  snapcraft clean --destructive-mode
+  # unset SNAPCRAFT_BUILD_ENVIRONMENT=host
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+  snapcraft clean
   rm -f ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -13,13 +15,18 @@ restore: |
   restore_yaml "snap/snapcraft.yaml"
 
 execute: |
-  snapcraft prime --destructive-mode
+  # unset SNAPCRAFT_BUILD_ENVIRONMENT=host
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  snapcraft pack
+
+  unsquashfs -dest snap-contents strict-patchelf_0.1_amd64.snap
 
   arch_triplet="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
 
   # Verify typical strict binary has an untouched rpath
-  patchelf --print-interpreter prime/bin/hello-strict | MATCH "^/lib.*ld.*.so.*"
-  rpath="$(patchelf --print-rpath prime/bin/hello-strict)"
+  patchelf --print-interpreter snap-contents/bin/hello-strict | MATCH "^/lib.*ld.*.so.*"
+  rpath="$(patchelf --print-rpath snap-contents/bin/hello-strict)"
   if [[ -n "${rpath}" ]]; then
      echo "found rpath on strict binary: ${rpath}"
      exit 1
@@ -30,10 +37,12 @@ execute: |
   RPATH_ORIGIN_MATCH="^\\\$ORIGIN/../fake-lib:/snap/core24/current/lib/$arch_triplet"
 
   # Verify binary rpath patching with existing rpath
-  patchelf --print-interpreter prime/bin/hello-strict-existing-rpath | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-strict-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
+  patchelf --print-interpreter snap-contents/bin/hello-strict-existing-rpath | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
+  patchelf --print-rpath snap-contents/bin/hello-strict-existing-rpath | MATCH "${RPATH_ORIGIN_MATCH}"
 
   # Verify binary rpath patching without existing rpath
-  patchelf --print-interpreter prime/bin/hello-strict-enable-patchelf | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
-  patchelf --print-rpath prime/bin/hello-strict-enable-patchelf | MATCH "${RPATH_MATCH}"
+  patchelf --print-interpreter snap-contents/bin/hello-strict-enable-patchelf | MATCH "^/snap/core24/current/lib.*ld.*.so.*"
+  patchelf --print-rpath snap-contents/bin/hello-strict-enable-patchelf | MATCH "${RPATH_MATCH}"
 
+  # verify `patchelf --no-default-lib` was not applied
+  readelf --dynamic snap-contents/bin/hello-classic | NOMATCH "FLAGS_1.*NODEFLIB"

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -309,6 +309,15 @@ def test_application_plugins():
     assert "kernel" not in plugins
 
 
+def test_application_dotnet_not_registered():
+    """dotnet plugin is disable for core24."""
+    app = application.create_app()
+
+    plugins = app._get_app_plugins()
+
+    assert "dotnet" not in plugins
+
+
 def test_default_command_integrated(monkeypatch, mocker, new_dir):
     """Test that for core24 projects we accept "pack" as the default command."""
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

This PR has 3 commits for snapcraft 8.2.8.

Replacement PR for https://github.com/canonical/snapcraft/pull/4807

Commits:

- On core24, snapcraft should pass `--no-default-libs` to patchelf to not load libraries from default locations for classic snaps.
- Bump craft parts
- Unregister dotnet for core24