### PR TITLE
build(deps): bump craft-parts to 1.31.0

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -10,7 +10,17 @@ Snapcraft.
 .. toctree::
    :maxdepth: 1
 
+   /common/craft-parts/reference/plugins/dotnet_plugin
+   /common/craft-parts/reference/plugins/ant_plugin
+   /common/craft-parts/reference/plugins/autotools_plugin
+   /common/craft-parts/reference/plugins/cmake_plugin
    /common/craft-parts/reference/plugins/dump_plugin
+   /common/craft-parts/reference/plugins/go_plugin
+   /common/craft-parts/reference/plugins/make_plugin
    plugins/maven_plugin
+   /common/craft-parts/reference/plugins/meson_plugin
+   /common/craft-parts/reference/plugins/nil_plugin
+   /common/craft-parts/reference/plugins/npm_plugin
    plugins/python_plugin
    /common/craft-parts/reference/plugins/rust_plugin
+   /common/craft-parts/reference/plugins/scons_plugin

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,7 +17,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts @ git+https://github.com/canonical/craft-parts@new-plugin-docs
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts @ git+https://github.com/canonical/craft-parts@new-plugin-docs
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts @ git+https://github.com/canonical/craft-parts@new-plugin-docs
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5


### PR DESCRIPTION
Version 1.31.0 brings in a new set of plugin docs.

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
