### PR TITLE
build(deps): bump craft-application to 2.8.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 attrs==23.1.0
 catkin-pkg==0.5.2
 click==8.1.7
-craft-application==2.7.0
+craft-application==2.8.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.4.4
-craft-application==2.7.0
+craft-application==2.8.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==2.7.0
+craft-application==2.8.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Craft-application 2.8.0 makes the following remote-build fixes:
- handling comma-separated architectures in `snapcraft remote-build --build-for <arch1>,<arch2>,...`
- retries for launchpad API calls, with an exponential backoff
- correct log file names for remote build logs