### PR TITLE
fix: re-register dotnet for core22

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -105,13 +105,14 @@ class Snapcraft(Application):
         except FileNotFoundError:
             self._snapcraft_yaml_path = self._snapcraft_yaml_data = None
 
-        self._known_core24 = self._get_known_craft_app_base()
+        self._known_core24 = self._get_known_core24()
 
         for craft_var, snapcraft_var in MAPPED_ENV_VARS.items():
             if env_val := os.getenv(snapcraft_var):
                 os.environ[craft_var] = env_val
 
-    def _get_known_craft_app_base(self) -> bool:
+    def _get_known_core24(self) -> bool:
+        """Return true if the project is known to be core24."""
         if self._snapcraft_yaml_data:
             base = self._snapcraft_yaml_data.get("base")
             build_base = self._snapcraft_yaml_data.get("build-base")

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -129,8 +129,10 @@ class Snapcraft(Application):
     def _register_default_plugins(self) -> None:
         """Register per application plugins when initializing."""
         super()._register_default_plugins()
-        # dotnet is disabled for core24 because it is pending a rewrite
-        craft_parts.plugins.unregister("dotnet")
+
+        if self._known_core24:
+            # dotnet is disabled for core24 and newer because it is pending a rewrite
+            craft_parts.plugins.unregister("dotnet")
 
     @override
     def _configure_services(self, provider_name: str | None) -> None:

--- a/tests/spread/core24/dotnet/snapcraft.yaml
+++ b/tests/spread/core24/dotnet/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: dotnet-hello
+base: core24
+version: '1.0'
+summary: a simple dotnet snap
+description: a simple dotnet snap
+
+confinement: strict
+
+apps:
+  dotnet-hello:
+    command: dotnet
+
+parts:
+  hello:
+    plugin: dotnet
+    source: .
+    dotnet-self-contained-runtime-identifier: linux-x64
+    build-snaps: [dotnet-sdk]

--- a/tests/spread/core24/dotnet/task.yaml
+++ b/tests/spread/core24/dotnet/task.yaml
@@ -1,0 +1,11 @@
+summary: Build a snap with the dotnet plugin
+
+restore: |
+  rm -rf ./*.snap
+
+execute: |
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
+  # dotnet is disabled for core24 until the dotnet sdk snap is rewritten
+  snapcraft pack 2>&1 | MATCH "plugin not registered: 'dotnet'"

--- a/tests/spread/plugins/craft-parts/build-and-run-hello/dotnet-hello/dotnet.csproj
+++ b/tests/spread/plugins/craft-parts/build-and-run-hello/dotnet-hello/dotnet.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+</Project>

--- a/tests/spread/plugins/craft-parts/build-and-run-hello/dotnet-hello/hello.cs
+++ b/tests/spread/plugins/craft-parts/build-and-run-hello/dotnet-hello/hello.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("hello world");

--- a/tests/spread/plugins/craft-parts/build-and-run-hello/dotnet-hello/snap/snapcraft.yaml
+++ b/tests/spread/plugins/craft-parts/build-and-run-hello/dotnet-hello/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: dotnet-hello
+base: core22
+version: '1.0'
+summary: a simple dotnet snap
+description: a simple dotnet snap
+
+confinement: strict
+
+apps:
+  dotnet-hello:
+    command: dotnet
+
+parts:
+  hello:
+    plugin: dotnet
+    source: .
+    dotnet-self-contained-runtime-identifier: linux-x64
+    build-snaps: [dotnet-sdk]

--- a/tests/spread/plugins/craft-parts/build-and-run-hello/task.yaml
+++ b/tests/spread/plugins/craft-parts/build-and-run-hello/task.yaml
@@ -10,6 +10,7 @@ environment:
   SNAP/python: python-hello
   SNAP/qmake: qmake-hello
   SNAP/maven: maven-hello
+  SNAP/dotnet: dotnet-hello
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -28,6 +29,7 @@ restore: |
   # Undo changes to hello
   [ -f hello ] && git checkout hello
   [ -f hello.c ] && git checkout hello.c
+  [ -f hello.cs ] && git checkout hello.cs
   [ -f subdir/hello.c ] && git checkout subdir/hello.c
   [ -f hello.js ] && git checkout hello.js
   [ -f main.go ] && git checkout main.go
@@ -72,6 +74,8 @@ execute: |
     modified_file=hello
   elif [ -f hello.c ]; then
     modified_file=hello.c
+  elif [ -f hello.cs ]; then
+    modified_file=hello.cs
   elif [ -f subdir/hello.c ]; then
     modified_file=subdir/hello.c
   elif [ -f hello.js ]; then

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock
 
 import pytest
 import yaml
-from craft_parts import Features, callbacks
+from craft_parts import Features, callbacks, plugins
 from craft_providers import Executor, Provider
 from craft_providers.base import Base
 from overrides import override
@@ -35,6 +35,13 @@ from snapcraft.extensions import extension, register, unregister
 @pytest.fixture(autouse=True)
 def unregister_callbacks(mocker):
     callbacks.unregister_all()
+
+
+@pytest.fixture(autouse=True)
+def reset_plugins():
+    # craft-part modifies a dictionary of plugins that doesn't get reloaded between tests
+    # 'unregister_all()' resets to the dictionary to the default value
+    plugins.unregister_all()
 
 
 @pytest.fixture

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -517,3 +517,26 @@ def test_run_envvar_invalid(snapcraft_yaml, base, monkeypatch):
         "'SNAPCRAFT_REMOTE_BUILD_STRATEGY'. Valid values are 'disable-fallback' and "
         "'force-fallback'"
     )
+
+
+@pytest.mark.parametrize(
+    ("base", "build_base", "is_known_core24"),
+    [
+        ("core20", None, False),
+        ("core20", "core20", False),
+        ("core20", "devel", False),
+        ("core22", None, False),
+        ("core22", "core22", False),
+        ("core22", "devel", False),
+        ("core24", "core22", True),
+        ("core24", None, True),
+        ("core24", "core24", True),
+        ("core24", "devel", True),
+    ],
+)
+def test_known_core24(snapcraft_yaml, base, build_base, is_known_core24):
+    snapcraft_yaml(base=base, build_base=build_base)
+
+    app = application.create_app()
+
+    assert app._known_core24 == is_known_core24


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

- re-register dotnet for core22
- add core22 and core24 dotnet spread tests
- refactor `Application` to allow snapcraft to register/unregister plugins per-base
    - this includes renaming `_known_core24` to `_known_craft_app_base` in preparation for core26

Fixes #4825 
(CRAFT-2979)