### PR TITLE
feat: write provenance to component metadata

### DIFF
--- a/snapcraft/meta/__init__.py
+++ b/snapcraft/meta/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,10 +18,11 @@
 
 from .extracted_metadata import ExtractedMetadata
 from .metadata import extract_metadata
-from .snap_yaml import SnapMetadata
+from .snap_yaml import SnapcraftMetadata, SnapMetadata
 
 __all__ = [
     "extract_metadata",
     "ExtractedMetadata",
     "SnapMetadata",
+    "SnapcraftMetadata",
 ]

--- a/snapcraft/meta/component_yaml.py
+++ b/snapcraft/meta/component_yaml.py
@@ -36,6 +36,7 @@ class ComponentMetadata(SnapcraftMetadata):
     version: str | None
     summary: str
     description: str
+    provenance: str | None
 
 
 def write(
@@ -64,6 +65,7 @@ def write(
         version=component.version,
         summary=component.summary,
         description=component.description,
+        provenance=project.provenance,
     )
 
     component_metadata.to_yaml_file(meta_dir / "component.yaml")

--- a/snapcraft/meta/component_yaml.py
+++ b/snapcraft/meta/component_yaml.py
@@ -18,13 +18,13 @@
 
 from pathlib import Path
 
-from craft_application.models import BaseMetadata
-
 from snapcraft import models
 from snapcraft.errors import SnapcraftError
 
+from . import SnapcraftMetadata
 
-class ComponentMetadata(BaseMetadata):
+
+class ComponentMetadata(SnapcraftMetadata):
     """The component.yaml model.
 
     Component hooks are not included in the component's metadata.

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -134,7 +134,7 @@ def _pack(
 def _retry_with_newer_snapd(func):
 
     @wraps(func)
-    def retry_with_beta_snapd(
+    def retry_with_edge_snapd(
         directory: Path, output_dir: Path, compression: Optional[str] = None
     ) -> str:
         try:
@@ -145,7 +145,7 @@ def _retry_with_newer_snapd(func):
                     "Refreshing snapd to support components"
                 ) as stream:
                     subprocess.run(
-                        ["snap", "refresh", "--beta", "snapd"],
+                        ["snap", "refresh", "--edge", "snapd"],
                         check=True,
                         stdout=stream,
                         stderr=stream,
@@ -159,7 +159,7 @@ def _retry_with_newer_snapd(func):
 
             return func(directory, output_dir, compression)
 
-    return retry_with_beta_snapd
+    return retry_with_edge_snapd
 
 
 @_retry_with_newer_snapd

--- a/tests/spread/core22/components/expected-component.yaml
+++ b/tests/spread/core22/components/expected-component.yaml
@@ -3,3 +3,4 @@ type: test
 version: '1.0'
 summary: Hello World
 description: Hello World
+provenance: test-provenance

--- a/tests/spread/core22/components/expected-snap.yaml
+++ b/tests/spread/core22/components/expected-snap.yaml
@@ -13,6 +13,7 @@ grade: devel
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+provenance: test-provenance
 components:
   share:
     summary: Hello World

--- a/tests/spread/core22/components/snapcraft.yaml
+++ b/tests/spread/core22/components/snapcraft.yaml
@@ -5,6 +5,7 @@ description: Build a snap with components
 base: core22
 grade: devel
 confinement: strict
+provenance: test-provenance
 
 apps:
   hello:

--- a/tests/spread/core24/components/expected-component.yaml
+++ b/tests/spread/core24/components/expected-component.yaml
@@ -3,3 +3,4 @@ type: test
 version: '1.0'
 summary: Hello World
 description: Hello World
+provenance: test-provenance

--- a/tests/spread/core24/components/expected-snap.yaml
+++ b/tests/spread/core24/components/expected-snap.yaml
@@ -13,6 +13,7 @@ grade: stable
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+provenance: test-provenance
 components:
   share:
     summary: Hello World

--- a/tests/spread/core24/components/snapcraft.yaml
+++ b/tests/spread/core24/components/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Build a snap with components
 description: Build a snap with components
 base: core24
 confinement: strict
+provenance: test-provenance
 
 apps:
   hello:

--- a/tests/unit/meta/test_component_yaml.py
+++ b/tests/unit/meta/test_component_yaml.py
@@ -34,6 +34,7 @@ def stub_project_data():
         "summary": "Single-line elevator pitch for your amazing snap",
         "description": "test-description",
         "confinement": "strict",
+        "provenance": "test-provenance",
         "parts": {
             "part1": {
                 "plugin": "nil",
@@ -60,7 +61,8 @@ def stub_project_data():
 
 
 @pytest.mark.parametrize("version", ["1.0", None])
-def test_unmarshal_component(version):
+@pytest.mark.parametrize("provenance", ["test-provenance", None])
+def test_unmarshal_component(version, provenance):
     """Unmarshal a dictionary containing a component."""
     component_data = {
         "component": "mytest+component-a",
@@ -68,6 +70,7 @@ def test_unmarshal_component(version):
         "version": version,
         "summary": "test summary",
         "description": "test description",
+        "provenance": provenance,
     }
 
     component = ComponentMetadata.unmarshal(component_data)
@@ -77,11 +80,13 @@ def test_unmarshal_component(version):
     assert component.version == version
     assert component.summary == "test summary"
     assert component.description == "test description"
+    assert component.provenance == provenance
 
 
 def test_write_component_yaml_minimal(stub_project_data, new_dir):
     """Write a component.yaml file from a project with minimal metadata."""
     stub_project_data["components"]["component-a"].pop("version")
+    stub_project_data.pop("provenance")
     project = models.Project.unmarshal(stub_project_data)
     yaml_file = Path("meta/component.yaml")
 
@@ -117,6 +122,7 @@ def test_write_component_yaml_complex(stub_project_data, new_dir):
         version: '1.0'
         summary: test summary
         description: test description
+        provenance: test-provenance
         """
     )
 

--- a/tests/unit/meta/test_component_yaml.py
+++ b/tests/unit/meta/test_component_yaml.py
@@ -59,12 +59,13 @@ def stub_project_data():
     }
 
 
-def test_unmarshal_component():
+@pytest.mark.parametrize("version", ["1.0", None])
+def test_unmarshal_component(version):
     """Unmarshal a dictionary containing a component."""
     component_data = {
         "component": "mytest+component-a",
         "type": "test",
-        "version": "1.0",
+        "version": version,
         "summary": "test summary",
         "description": "test description",
     }
@@ -73,13 +74,34 @@ def test_unmarshal_component():
 
     assert component.component == "mytest+component-a"
     assert component.type == "test"
-    assert component.version == "1.0"
+    assert component.version == version
     assert component.summary == "test summary"
     assert component.description == "test description"
 
 
-def test_write_component_yaml(stub_project_data, new_dir):
-    """Write a component.yaml file from a project."""
+def test_write_component_yaml_minimal(stub_project_data, new_dir):
+    """Write a component.yaml file from a project with minimal metadata."""
+    stub_project_data["components"]["component-a"].pop("version")
+    project = models.Project.unmarshal(stub_project_data)
+    yaml_file = Path("meta/component.yaml")
+
+    component_yaml.write(
+        project, component_name="component-a", component_prime_dir=new_dir
+    )
+
+    assert yaml_file.is_file()
+    assert yaml_file.read_text() == textwrap.dedent(
+        """\
+        component: mytest+component-a
+        type: test
+        summary: test summary
+        description: test description
+        """
+    )
+
+
+def test_write_component_yaml_complex(stub_project_data, new_dir):
+    """Write a component.yaml file from a project with all metadata."""
     project = models.Project.unmarshal(stub_project_data)
     yaml_file = Path("meta/component.yaml")
 

--- a/tests/unit/test_pack.py
+++ b/tests/unit/test_pack.py
@@ -345,7 +345,7 @@ def test_pack_component_error(fake_process, new_dir):
         returncode=1,
     )
     fake_process.register_subprocess(
-        ["snap", "refresh", "--beta", "snapd"],
+        ["snap", "refresh", "--edge", "snapd"],
     )
     fake_process.register_subprocess(
         ["snap", "pack", str(new_dir / "in"), str(new_dir / "out")],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Write `provenance` to a component's `meta/component.yaml` file.

Also, use the `SnapcraftMetadata` model such that None and default fields are not written.

source: https://github.com/snapcore/snapd/pull/13964#discussion_r1604828668

Fixes #4827
(CRAFT-2980)