### PR TITLE
build(docs): fix version in rtd builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,10 @@ build:
     python: "3.10"
   apt_packages:
     - libapt-pkg-dev
+  jobs:
+    post_checkout:
+      - git fetch --tags --depth 1 # Also fetch tags
+      - git describe               # Useful for debugging
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -25,3 +29,5 @@ python:
   install:
     - requirements: docs/requirements.txt
     - requirements: docs/sphinx-resources/.sphinx/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -37,6 +37,7 @@ raven==6.10.0
 regex==2022.10.31
 requests-unixsocket==0.3.0
 semver==2.13.0
+setuptools==65.5.1
 simplejson==3.19.2
 snap-helpers==0.4.2
 spdx==2.5.1


### PR DESCRIPTION
Readthedocs builds don't fetch tags when cloning the repo. This is a problem for us because Snapcraft's version comes from the git tag, so do a fetch of the tags as a post-checkout step.

Additionally, explicitly install snapcraft itself (via "pip install .") so that the code that gets the version from git actually runs. Note that this already works on "latest" because that builds off of "main" where this fix has already been applied (when moving to canonical-sphinx).

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
