### PR TITLE
feat: support "build-for: [all]" in core24

### DIFF
--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -109,3 +109,4 @@ jobs:
           LAUNCHPAD_TOKEN: "${{ secrets.LAUNCHPAD_TOKEN }}"
         run: |
           spread google:${{ matrix.system }}:tests/spread/general/remote-build
+          spread google:${{ matrix.system }}:tests/spread/core24/remote-build

--- a/docs/howto/architectures.rst
+++ b/docs/howto/architectures.rst
@@ -2,18 +2,58 @@ Architectures
 =============
 
 By default, Snapcraft builds a snap to run on the same architecture as the build
-environment. This behaviour can be modified with the root keyword
-``architectures`` in the snap’s ``snapcraft.yaml``.
+environment. This behaviour can be modified with the top-level keywords
+``architectures`` and ``platforms`` in the snap’s ``snapcraft.yaml``.
 
-The ``architectures`` keyword is used to create a build plan. See
-:ref:`build plans<build-plans>` for an explanation on how build plans are
-created.
+The ``architectures`` and ``platforms`` keywords are used to create a build
+plan. See :ref:`build plans<build-plans>` for an explanation on how build
+plans are created.
+
+The keywords are base-dependent:
+
+* ``platforms`` is used for ``core24`` snaps
+* ``architectures`` is used for ``core20`` and ``core22`` snaps
 
 How to create a snap for a specific architecture
 ------------------------------------------------
 
 To create a snap that will be built on ``amd64`` and built for ``amd64``, use
 one of the ``snapcraft.yaml`` snippets below.
+
+core24
+^^^^^^
+
+.. code-block:: yaml
+
+  platforms:
+    amd64:
+      build-on: [amd64]
+      build-for: [amd64]
+
+Building on ``amd64`` will produce one snap built for ``amd64``.
+
+If the platform name is a valid architecture and ``build-for`` is omitted,
+``build-for`` will assume the platform name. The following snippet will produce
+the same result as above:
+
+.. code-block:: yaml
+
+  platforms:
+    amd64:
+      build-on: [amd64]
+
+If the platform name is a valid architecture, then ``build-on`` and
+``build-for`` will assume the platform name. The following snippet will
+produce the same result:
+
+.. code-block:: yaml
+
+  platforms:
+    amd64:
+
+Note that ``build-for`` can be omitted if ``build-on`` is defined but the
+converse is not true; ``build-on`` cannot be omitted if ``build-for`` is
+defined.
 
 core22
 ^^^^^^
@@ -27,8 +67,8 @@ core22
 Building on ``amd64`` will produce one snap built for ``amd64``. Snapcraft will
 raise an error when building on another architecture.
 
-If ``build-for`` is omitted, then it will assume the value of ``build-on``. The
-following snippet snippet will produce the same result:
+If ``build-for`` is omitted, it will assume the value of ``build-on``. The
+following snippet will produce the same result:
 
 .. code-block:: yaml
 
@@ -48,8 +88,8 @@ Building on ``amd64`` will produce one snap built for ``amd64``. Snapcraft will
 not raise an error when building on another architecture. Instead, it will
 ignore the ``architectures`` keyword and build for the build-on architecture.
 
-If ``run-on`` is omitted, then it will assume the value of ``build-on``. The
-following snippet snippet will produce the same result:
+If ``run-on`` is omitted, it will assume the value of ``build-on``. The
+following snippet will produce the same result:
 
 .. code-block:: yaml
 
@@ -66,8 +106,54 @@ The shorthand format will also produce the same result:
 How to create a set of snaps for multiple architectures
 -------------------------------------------------------
 
+core24
+^^^^^^
+
+``core24`` snaps accept a single build-for architecture per-platform. To create
+a set of snaps for multiple architectures, define a set of platforms:
+
+.. code-block:: yaml
+
+  platforms:
+    amd64:
+      build-on: [amd64]
+      build-for: [amd64]
+    arm64:
+      build-on: [arm64]
+      build-for: [arm64]
+
+Building on ``amd64`` will produce one snap for ``amd64``. Building on
+``arm64`` will produce one snap for ``arm64``. Snapcraft will raise an error
+when building on another architecture.
+
+If the platform name is a valid architecture and ``build-for`` is omitted,
+``build-for`` will assume the platform name. The following snippet will produce
+the same result as above:
+
+.. code-block:: yaml
+
+  platforms:
+    amd64:
+      build-on: [amd64]
+    arm64:
+      build-on: [arm64]
+
+If the platform name is a valid architecture, then ``build-on`` and
+``build-for`` will assume the platform name. The following snippet will
+produce the same result:
+
+.. code-block:: yaml
+
+  platforms:
+    amd64:
+    arm64:
+
 core22
 ^^^^^^
+
+``core22`` snaps accept a single ``build-for`` architecture per
+``build-on``/``build-for`` pair. To create a set of snaps for multiple
+architectures, define a set of ``build-on``/``build-for`` pairs:
 
 .. code-block:: yaml
 
@@ -81,8 +167,8 @@ Building on ``amd64`` will produce one snap for ``amd64``. Building on ``arm64``
 will produce one snap for ``arm64``. Snapcraft will raise an error when building
 on another architecture.
 
-If ``build-for`` is omitted, then it will assume the value of ``build-on``. The
-following snippet snippet will produce the same result:
+If ``build-for`` is omitted, it will assume the value of ``build-on``. The
+following snippet will produce the same result:
 
 .. code-block:: yaml
 
@@ -106,14 +192,14 @@ Building on ``amd64`` will produce one snap built for ``amd64``. Building on
 an error when building on another architecture. Instead, it will ignore the
 ``architectures`` keyword and build for the build-on architecture.
 
-If ``run-on`` is omitted, then it will assume the value of ``build-on``. The
-following snippet snippet will produce the same result:
+If ``run-on`` is omitted, it will assume the value of ``build-on``. The
+following snippet will produce the same result:
 
 .. code-block:: yaml
 
   architectures:
-    - build-on: amd64
-    - build-on: arm64
+    - build-on: [amd64]
+    - build-on: [arm64]
 
 The shorthand format will also produce the same result:
 
@@ -130,6 +216,14 @@ How to create an architecture independent snap
 a snap that is a shell or python script. It cannot be combined with other
 architectures. Click :ref:`here<reference-build-for>` for more information on
 the ``all`` keyword.
+
+core24
+^^^^^^
+
+platforms:
+  all:
+    build-on: [amd64]
+    build-for: [all]
 
 core22
 ^^^^^^
@@ -151,6 +245,51 @@ core20
 
 How to build a snap for a different architecture
 ------------------------------------------------
+
+core24
+^^^^^^
+
+.. code-block:: yaml
+
+  platforms:
+    arm64:
+      build-on: [amd64]
+      build-for: [arm64]
+
+Building on ``amd64`` will produce one snap built for ``arm64``.
+
+If the platform name is a valid architecture and ``build-for`` is omitted,
+``build-for`` will assume the platform name. The following snippet will produce
+the same result as above:
+
+.. code-block:: yaml
+
+  platforms:
+    arm64:
+      build-on: [amd64]
+
+``core24`` can handle complex build plans. For example:
+
+.. code-block:: yaml
+
+  platforms:
+      amd64:
+          build-on: [amd64]
+          build-for: [amd64]
+      arm64:
+          build-on: [amd64, arm64]
+          build-for: [arm64]
+
+Building on ``arm64`` will produce one snap built for ``arm64``.
+
+Building on ``amd64`` will produce two snaps, one built for ``amd64`` and one
+built for ``arm64``. This only occurs using remote-build or a build provider.
+In destructive mode, Snapcraft can only produce one snap. ``--build-for`` or
+``--platform`` must be used to narrow down the build plan to a single snap.
+For example, ``snapcraft pack --destructive-mode --platform arm64`` on
+``amd64`` will produce one snap built for ``arm64``.
+
+Snapcraft will raise an error when building on another architecture.
 
 core22
 ^^^^^^

--- a/docs/reference/architectures.rst
+++ b/docs/reference/architectures.rst
@@ -5,7 +5,57 @@ snapcraft.yaml
 --------------
 
 The :doc:`architectures how-to</howto/architectures>` provides examples of how
-to use the ``architectures`` keyword.
+to use the ``platforms`` and ``architectures`` keyword.
+
+core24
+^^^^^^
+
+.. code-block:: yaml
+
+  platforms:
+      <platform 1>:
+          build-on: [<arch 1>, <arch 2>]
+          build-for: [<arch 1>]
+      <platform 2>:
+          build-on: [<arch 3>]
+          build-for: [<arch 4>]
+      ...
+
+platform
+""""""""
+
+The platform name describes a ``build-on``/``build-for`` pairing. If the
+platform name is a valid debian architecture, then ``build-on`` and
+``build-for`` can be omitted (see below for details).
+
+See here for a list of supported architectures.
+
+The recommended platform name is the ``build-for`` arch.
+
+build-on
+""""""""
+
+The ``build-on`` field is an optional list of architectures where the snap can
+be built. It can contain multiple architectures.
+
+If the platform name is a valid architecture and ``build-for`` is not defined,
+then ``build-on`` can be omitted. ``build-on`` will assume the platform name.
+
+build-for
+"""""""""
+
+The ``build-for`` field is an optional single-element list containing the
+architecture where the snap should run.
+
+If the platform name is a valid architecture, then ``build-for`` will
+assume the platform name.
+
+``build-for: [all]`` is a special keyword to denote an architecture-independent
+snap. If the ``all`` keyword is used, no other ``build-on/build-for`` pairs can
+be defined. See :ref:`this page<how-to-arch-build-for-all>` to learn how to
+use the ``all`` keyword.
+
+``all`` cannot be used for ``build-on``.
 
 core22
 ^^^^^^
@@ -105,6 +155,25 @@ The explicit and shorthand format cannot be mixed.
 
 Project variables
 -----------------
+
+core24
+^^^^^^
+
++----------------------------------+-------------------------------------------+
+| Project variable                 | Description                               |
++==================================+===========================================+
+| ``CRAFT_ARCH_BUILD_FOR``         | The architecture of the platform the snap |
+|                                  | is built for.                             |
++----------------------------------+-------------------------------------------+
+| ``CRAFT_ARCH_BUILD_ON``          | The architecture of the platform the snap |
+|                                  | is built on.                              |
++----------------------------------+-------------------------------------------+
+| ``CRAFT_ARCH_TRIPLET_BUILD_FOR`` | The architecture triplet of the platform  |
+|                                  | the snap is built for.                    |
++----------------------------------+-------------------------------------------+
+| ``CRAFT_ARCH_TRIPLET_BUILD_ON``  | The architecture triplet of the platform  |
+|                                  | the snap is built on.                     |
++----------------------------------+-------------------------------------------+
 
 core22
 ^^^^^^

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==2.8.0
+craft-application==3.0.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,7 +11,7 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.4.4
-craft-application==2.8.0
+craft-application==3.0.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.16.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==2.8.0
+craft-application==3.0.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ install_requires = [
     "attrs",
     "catkin-pkg; sys_platform == 'linux'",
     "click",
-    "craft-application",
+    "craft-application>=3.0.0",
     "craft-archives",
     "craft-cli",
     "craft-grammar",

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -468,11 +468,11 @@ def get_metadata_from_project(
 
     effective_base = project.get_effective_base()
 
-    if effective_base == "core22":
+    if arch == "all":
         # if arch is "all", do not include architecture-specific paths in the environment
-        arch_triplet: str | None = (
-            None if arch == "all" else project.get_build_for_arch_triplet()
-        )
+        arch_triplet: str | None = None
+    elif effective_base == "core22":
+        arch_triplet = project.get_build_for_arch_triplet()
     else:
         arch_triplet = get_arch_triplet(convert_architecture_deb_to_platform(arch))
 

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -21,6 +21,7 @@ import copy
 import re
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Dict,
     List,
@@ -43,7 +44,7 @@ from craft_providers import bases
 from pydantic import PrivateAttr, constr
 from typing_extensions import Self, override
 
-from snapcraft import errors, utils
+from snapcraft import utils
 from snapcraft.const import SUPPORTED_ARCHS, SnapArch
 from snapcraft.elf.elf_utils import get_arch_triplet
 from snapcraft.errors import ProjectValidationError
@@ -556,8 +557,6 @@ class Platform(models.Platform):
                     else:
                         build_for = cast(UniqueStrList, architecture.build_for)
 
-            if "all" in build_for:
-                raise errors.ArchAllInvalid()
             platforms[build_for[0]] = cls(build_for=build_for, build_on=build_on)
 
         return platforms

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1264,7 +1264,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
                 try:
                     platform = Platform(**platform_data)
                 except CraftValidationError as err:
-                    raise CraftValidationError(f"{error_prefix}: {str(err)}") from None
+                    raise ValueError(f"{error_prefix}: {str(err)}") from None
 
             # build_on and build_for are validated
             # let's also validate the platform label
@@ -1279,7 +1279,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
             if platform.build_for:
                 build_target = platform.build_for[0]
                 if platform_label in SUPPORTED_ARCHS and platform_label != build_target:
-                    raise CraftValidationError(
+                    raise ValueError(
                         str(
                             f"{error_prefix}: if 'build_for' is provided and the "
                             "platform entry label corresponds to a valid architecture, then "
@@ -1288,7 +1288,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
                     )
             # if no build-for is present, then the platform label needs to be a valid architecture
             elif platform_label not in SUPPORTED_ARCHS:
-                raise CraftValidationError(
+                raise ValueError(
                     str(
                         f"{error_prefix}: platform entry label must correspond to a "
                         "valid architecture if 'build-for' is not provided."
@@ -1297,7 +1297,7 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
 
             # Both build and target architectures must be supported
             if not any(b_o in SUPPORTED_ARCHS for b_o in build_on_one_of):
-                raise CraftValidationError(
+                raise ValueError(
                     str(
                         f"{error_prefix}: trying to build snap in one of "
                         f"{build_on_one_of}, but none of these build architectures are supported. "

--- a/tests/spread/core24/grammar-all/snap/snapcraft.yaml
+++ b/tests/spread/core24/grammar-all/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: grammar-build-for-all
+version: "1.0"
+summary: test
+description: |
+  Exercise snapcraft's advanced grammar keywords, `on`, and `to`.
+  This test leverages the platform keywords, `build-on` and `build-for`.
+confinement: strict
+base: core24
+platforms:
+  platform1:
+    build-on: amd64
+    build-for: all
+
+# grammar in root-level part keywords (including non-grammar elements)
+build-packages:
+  - libzstd1
+  - on amd64 to all:
+    - libogg-dev
+
+parts:
+  hello-world:
+    plugin: dump
+
+    # grammar-only string
+    source:
+    - on amd64 to all: src/on-amd64-to-all
+
+    # grammar dictionary
+    organize:
+    - on amd64 to all:
+        hello-world.sh: hello-world-all.sh
+
+    # grammar list (including non-grammar elements)
+    build-environment:
+    - HELLO: hello
+    - on amd64 to all:
+      - ARCH: all

--- a/tests/spread/core24/grammar-all/src/on-amd64-to-all/hello-world.sh
+++ b/tests/spread/core24/grammar-all/src/on-amd64-to-all/hello-world.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+echo "I was built on amd64 and built for all."

--- a/tests/spread/core24/grammar-all/task.yaml
+++ b/tests/spread/core24/grammar-all/task.yaml
@@ -1,0 +1,17 @@
+summary: Build snaps that test the 'all' target in advanced grammar
+
+systems:
+  - ubuntu-24.04-64
+  - ubuntu-24.04-amd64
+
+restore: |
+  snapcraft clean --destructive-mode
+
+execute: |
+  snapcraft prime --destructive-mode --build-for all
+
+  # verify `on amd64 to all` grammar was processed
+  if ! grep "I was built on amd64 and built for all." "prime/hello-world-all.sh"; then
+    echo "Grammar was not processed as expected!"
+    exit 1
+  fi

--- a/tests/spread/core24/platforms/snaps/all/expected-snaps.txt
+++ b/tests/spread/core24/platforms/snaps/all/expected-snaps.txt
@@ -1,0 +1,1 @@
+all_1.0_all.snap

--- a/tests/spread/core24/platforms/snaps/all/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/all/snap/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: all
+version: "1.0"
+summary: test
+description: A snap that builds for `all`.
+confinement: strict
+base: core24
+platforms:
+  platform1:
+    build-on: [amd64, arm64]
+    build-for: [all]
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core24/platforms/snaps/build-for-all/arguments.txt
+++ b/tests/spread/core24/platforms/snaps/build-for-all/arguments.txt
@@ -1,0 +1,1 @@
+--build-for all

--- a/tests/spread/core24/platforms/snaps/build-for-all/expected-snaps.txt
+++ b/tests/spread/core24/platforms/snaps/build-for-all/expected-snaps.txt
@@ -1,0 +1,1 @@
+build-for-all_1.0_all.snap

--- a/tests/spread/core24/platforms/snaps/build-for-all/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/build-for-all/snap/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: build-for-all
+version: "1.0"
+summary: test
+description: Match the `all` target via the build-for argument.
+confinement: strict
+base: core24
+platforms:
+  platform1:
+    build-on: [amd64]
+    build-for: [all]
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core24/platforms/snaps/env-var-all/environmental-variables.txt
+++ b/tests/spread/core24/platforms/snaps/env-var-all/environmental-variables.txt
@@ -1,0 +1,1 @@
+SNAPCRAFT_BUILD_FOR="all"

--- a/tests/spread/core24/platforms/snaps/env-var-all/expected-snaps.txt
+++ b/tests/spread/core24/platforms/snaps/env-var-all/expected-snaps.txt
@@ -1,0 +1,1 @@
+env-var-all_1.0_all.snap

--- a/tests/spread/core24/platforms/snaps/env-var-all/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/env-var-all/snap/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: env-var-all
+version: "1.0"
+summary: test
+description: Match the `all` target via `SNAPCRAFT_BUILD_FOR`
+confinement: strict
+base: core24
+platforms:
+  platform1:
+    build-on: [amd64]
+    build-for: [all]
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core24/platforms/snaps/platform-all/arguments.txt
+++ b/tests/spread/core24/platforms/snaps/platform-all/arguments.txt
@@ -1,0 +1,1 @@
+--platform platform1

--- a/tests/spread/core24/platforms/snaps/platform-all/expected-snaps.txt
+++ b/tests/spread/core24/platforms/snaps/platform-all/expected-snaps.txt
@@ -1,0 +1,1 @@
+platform-all_1.0_all.snap

--- a/tests/spread/core24/platforms/snaps/platform-all/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/platform-all/snap/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: platform-all
+version: "1.0"
+summary: test
+description: Match the `all` target via the platform.
+confinement: strict
+base: core24
+platforms:
+  platform1:
+    build-on: amd64
+    build-for: [all]
+
+parts:
+  nil:
+    plugin: nil

--- a/tests/spread/core24/platforms/task.yaml
+++ b/tests/spread/core24/platforms/task.yaml
@@ -1,12 +1,16 @@
 summary: Build snaps that test the build-on/build-for architecture logic in snapcraft.
 
 environment:
+  SNAP/all: all
+  SNAP/build_for_all: build-for-all
   SNAP/build_for_match: build-for-match
   SNAP/build_for_no_match: build-for-no-match
   SNAP/build_on_no_match: build-on-no-match
+  SNAP/env_var_all: env-var-all
   SNAP/env_var_match: env-var-match
   SNAP/env_var_no_match: env-var-no-match
   SNAP/multiple_build_for: multiple-build-for
+  SNAP/platform_all: platform-all
   SNAP/platform_match: platform-match
   SNAP/platform_no_match: platform-no-match
   SNAP/single_arch: single-arch
@@ -34,20 +38,25 @@ execute: |
     if [[ -e "arguments.txt" ]]; then
       call_args=$(cat "arguments.txt")
     fi
+
     env_vars=""
     if [[ -e "environmental-variables.txt" ]]; then
       env_vars=$(cat "environmental-variables.txt")
     fi
+
     # shellcheck disable=SC2086
     eval $env_vars snapcraft pack --destructive-mode $call_args 2>&1 | MATCH -f expected-failure.txt
+
   # if the environmental variable file exists, then call snapcraft with the environmental variables
   elif [[ -e "environmental-variables.txt" ]]; then
     # shellcheck disable=SC2046
     eval $(cat "environmental-variables.txt") snapcraft pack --destructive-mode
+
   # if the arguments variable file exists, then call snapcraft with the arguments
   elif [[ -e "arguments.txt" ]]; then
     # shellcheck disable=SC2046
     eval snapcraft pack --destructive-mode $(cat "arguments.txt")
+
   # otherwise, just call `snapcraft pack`
   else
     snapcraft pack --destructive-mode

--- a/tests/spread/core24/remote-build/snaps/all/expected-snaps.txt
+++ b/tests/spread/core24/remote-build/snaps/all/expected-snaps.txt
@@ -1,0 +1,1 @@
+test-snap-all-core24_1.0_all.snap

--- a/tests/spread/core24/remote-build/snaps/all/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/all/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: test-snap-all-core24
+base: core24
+version: '1.0'
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+platforms:
+  platform1:
+    build-on: [amd64, arm64]
+    build-for: [all]
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/remote-build/snaps/no-platforms/expected-snaps.txt
+++ b/tests/spread/core24/remote-build/snaps/no-platforms/expected-snaps.txt
@@ -1,0 +1,1 @@
+test-snap-no-platforms-core24_1.0_amd64.snap

--- a/tests/spread/core24/remote-build/snaps/no-platforms/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/no-platforms/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: test-snap-no-platforms-core24
+base: core24
+version: '0.1'
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/remote-build/snaps/platforms/expected-snaps.txt
+++ b/tests/spread/core24/remote-build/snaps/platforms/expected-snaps.txt
@@ -1,0 +1,3 @@
+test-snap-platforms-core24_1.0_amd64.snap
+test-snap-platforms-core24_1.0_arm64.snap
+test-snap-platforms-core24_1.0_armhf.snap

--- a/tests/spread/core24/remote-build/snaps/platforms/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/platforms/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: test-snap-platforms-core24
+base: core24
+version: '0.1'
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+platforms:
+  # implicit build-on and build-for
+  amd64:
+  # implicit build-for
+  armhf:
+    build-on: [arm64]
+  # fully defined
+  arm64:
+    build-on: [amd64, arm64]
+    build-for: [arm64]
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/remote-build/task.yaml
+++ b/tests/spread/core24/remote-build/task.yaml
@@ -4,32 +4,54 @@ kill-timeout: 180m
 
 environment:
   LAUNCHPAD_TOKEN: "$(HOST: echo ${LAUNCHPAD_TOKEN})"
+  SNAP/all: all
+  SNAP/platforms: platforms
+  SNAP/no_platforms: no-platforms
 
 prepare: |
+  cd "./snaps/$SNAP"
+
   if [[ -z "$LAUNCHPAD_TOKEN" ]]; then
     echo "No credentials set in env LAUNCHPAD_TOKEN"
     exit 1
   fi
 
-  snapcraft init
-  sed -i 's/base: core22/base: core24/' snap/snapcraft.yaml
-
-  # Commit the project
+  # commit the project
   git config --global --add safe.directory "$PWD"
   git init
   git add snap/snapcraft.yaml
   git commit -m "Initial Commit"
 
-  # Setup launchpad token
+  # set up launchpad token
   mkdir -p ~/.local/share/snapcraft/
   echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
 
 restore: |
+  cd "./snaps/$SNAP"
+
   rm -f ./*.snap ./*.txt
 
   rm -rf snap .git
 
 execute: |
+  cd "./snaps/$SNAP"
+
   snapcraft remote-build --launchpad-accept-public-upload
 
   find . -maxdepth 1 -name "*.snap" | MATCH ".snap"
+
+  # confirm the snaps with the expected architectures were built
+  while read -r expected_snap; do
+    if [[ ! -e $expected_snap ]]; then
+      echo "Could not find snap '$expected_snap'"
+      exit 1
+    fi
+  done < "expected-snaps.txt"
+
+  # confirm no other snaps were built
+  expected_number_of_snaps=$(wc -l < "expected-snaps.txt")
+  actual_number_of_snaps=$(find . -wholename "./*.snap" | wc -l)
+  if [[ $expected_number_of_snaps -ne $actual_number_of_snaps ]]; then
+    echo "Expected $expected_number_of_snaps to be built, but $actual_number_of_snaps were built."
+    exit 1
+  fi

--- a/tests/spread/general/remote-build/task.yaml
+++ b/tests/spread/general/remote-build/task.yaml
@@ -33,7 +33,7 @@ prepare: |
   git add snap/snapcraft.yaml
   git commit -m "Initial Commit"
 
-  # Setup launchpad token
+  # Set up launchpad token
   if [[ $STRATEGY == "disable-fallback" ]]; then
     mkdir -p ~/.local/share/snapcraft/
     echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -23,7 +23,7 @@ import pytest
 import yaml
 from craft_application.models import SummaryStr, UniqueStrList, VersionStr
 
-from snapcraft import models
+from snapcraft import const, models
 from snapcraft.meta import snap_yaml
 from snapcraft.meta.snap_yaml import ContentPlug, ContentSlot, SnapMetadata
 from snapcraft.models import Project
@@ -1289,13 +1289,14 @@ def test_architectures(arch, arch_triplet, simple_project, new_dir):
     ) in content
 
 
-def test_architectures_all(simple_project, new_dir):
+@pytest.mark.parametrize("base", const.CURRENT_BASES - {"devel"})
+def test_architectures_all(base, simple_project, new_dir):
     """LD_LIBRARY_PATH should not contain arch-specific paths when arch = "all"."""
     # create library directories
     (new_dir / "usr/lib/x86_64-linux-gnu").mkdir(parents=True)
     (new_dir / "lib/x86_64-linux-gnu").mkdir(parents=True)
 
-    snap_yaml.write(simple_project(), prime_dir=Path(new_dir), arch="all")
+    snap_yaml.write(simple_project(base=base), prime_dir=Path(new_dir), arch="all")
 
     yaml_file = Path("meta/snap.yaml")
     assert yaml_file.is_file()

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -2225,7 +2225,7 @@ def test_project_platform_error_has_context():
             }
         )
 
-    assert "'test-platform': 'build_for' expects 'build_on'" in str(raised.value)
+    assert "'build_for' expects 'build_on' to also be provided." in str(raised.value)
 
 
 def test_project_platform_mismatch():
@@ -2262,8 +2262,8 @@ def test_project_platform_unknown_name():
         )
 
     assert (
-        "platform entry label must correspond to a valid architecture "
-        "if 'build-for' is not provided." in str(raised.value)
+        "Invalid architecture: 'unknown' must be a valid debian architecture."
+        in str(raised.value)
     )
 
 

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -2230,7 +2230,7 @@ def test_project_platform_error_has_context():
 
 def test_project_platform_mismatch():
     """Raise an error if platform name and build-for are valid but different archs."""
-    with pytest.raises(CraftValidationError) as raised:
+    with pytest.raises(pydantic.ValidationError) as raised:
         snapcraft.models.project.SnapcraftBuildPlanner.parse_obj(
             {
                 "name": "test-snap",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Supports `build-for: [all]` for core24 snaps.

Fixes #4854
CRAFT-3017