### PR TITLE
fix(remotebuild): require core20 snaps to use the legacy remote builder

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -41,8 +41,9 @@ remote-builder.
 Current
 ^^^^^^^
 
-The current remote builder is available for ``core20``, ``core22``, ``core24``,
-and newer snaps.
+The current remote builder is available for ``core22``, ``core24``,
+and newer snaps.  It is not available for ``core20`` snaps because it cannot
+parse ``core20``'s ``snapcraft.yaml`` schema (`[10]`_).
 
 It does not modify the project or project metadata.
 
@@ -70,7 +71,7 @@ If the environment variable is unset, the remote builder will be determined
 by the base:
 
 * ``core22``, ``core24``, and newer snaps will use the current remote builder
-* ``core20`` snaps will use the legacy remote builder by default.
+* ``core20`` snaps will use the legacy remote builder
 
 Platforms and architectures
 ---------------------------
@@ -172,3 +173,4 @@ Launchpad is not able to parse this notation (`[9]`_).
 .. _`[7]`: https://bugs.launchpad.net/snapcraft/+bug/1992557
 .. _`[8]`: https://bugs.launchpad.net/snapcraft/+bug/2007789
 .. _`[9]`: https://bugs.launchpad.net/snapcraft/+bug/2042167
+.. _`[10]`: https://github.com/canonical/snapcraft/issues/4885

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -274,12 +274,18 @@ class Snapcraft(Application):
                         "'SNAPCRAFT_REMOTE_BUILD_STRATEGY'. "
                         "Valid values are 'disable-fallback' and 'force-fallback'."
                     )
-                # Use legacy snapcraft unless explicitly forced to use craft-application
-                if (
-                    "core20" in (base, build_base)
-                    and build_strategy != "disable-fallback"
-                ):
+
+                # core20 must use the legacy remote builder because the Project model
+                # cannot parse core20 snapcraft.yaml schemas (#4885)
+                if "core20" in (base, build_base):
+                    if build_strategy == "disable-fallback":
+                        raise RuntimeError(
+                            "'SNAPCRAFT_REMOTE_BUILD_STRATEGY=disable-fallback' cannot "
+                            "be used for core20 snaps. Unset the environment variable "
+                            "or use 'force-fallback'."
+                        )
                     raise errors.ClassicFallback()
+
                 # Use craft-application unless explicitly forced to use legacy snapcraft
                 if (
                     "core22" in (base, build_base)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -440,18 +440,19 @@ def test_run_envvar(
 
 @pytest.mark.parametrize("base", const.LEGACY_BASES)
 @pytest.mark.usefixtures("mock_confirm", "mock_remote_build_argv")
-def test_run_envvar_disable_fallback_core20(
-    snapcraft_yaml, base, mock_remote_build_run, mock_run_legacy, monkeypatch
-):
-    """core20 base run new remote-build if envvar is `disable-fallback`."""
+def test_run_envvar_disable_fallback_core20(snapcraft_yaml, base, monkeypatch):
+    """core20 bases cannot use the new remote-build."""
     monkeypatch.setenv("SNAPCRAFT_REMOTE_BUILD_STRATEGY", "disable-fallback")
     snapcraft_yaml_dict = {"base": base}
     snapcraft_yaml(**snapcraft_yaml_dict)
 
-    application.main()
+    with pytest.raises(RuntimeError) as raised:
+        application.main()
 
-    mock_remote_build_run.assert_called_once()
-    mock_run_legacy.assert_not_called()
+    assert str(raised.value) == (
+        "'SNAPCRAFT_REMOTE_BUILD_STRATEGY=disable-fallback' cannot be used for core20 "
+        "snaps. Unset the environment variable or use 'force-fallback'."
+    )
 
 
 @pytest.mark.parametrize("base", const.LEGACY_BASES | {"core22"})


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Requires core20 snaps to use the legacy remote builder because the new remote builder cannot parse core20 `snapcraft.yaml` files (#4885).

Builds on #4892, so only the last commit is new.

Fixes #4886 
(CRAFT-3071)