### PR TITLE
build(deps): add 'validators' to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ install_requires = [
     "tinydb",
     "typing-extensions",
     "urllib3<2",  # requests-unixsocket does not yet work with urllib3 v2.0+
+    "validators>=0.28.3",
 ]
 
 docs_requires = {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

`validators` was added in https://github.com/canonical/snapcraft/pull/4888 to the requirement files but not to `setup.py`