### PR TITLE
Add "-f" for rm to ignore file not found error

### DIFF
--- a/snapcraft_legacy/plugins/v2/_kernel_build.py
+++ b/snapcraft_legacy/plugins/v2/_kernel_build.py
@@ -1111,7 +1111,7 @@ def _arrange_install_dir_cmd(install_dir: str) -> List[str]:
             # but snapd expects modules/ and firmware/
             mv {install_dir}/lib/modules {install_dir}/
             # remove symlinks modules/*/build and modules/*/source
-            rm {install_dir}/modules/*/build {install_dir}/modules/*/source
+            rm -f {install_dir}/modules/*/build {install_dir}/modules/*/source
             # if there is firmware dir, move it to snap root
             # this could have been from stage packages or from kernel build
             [ -d {install_dir}/lib/firmware ] && mv {install_dir}/lib/firmware {install_dir}

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -1768,7 +1768,7 @@ _finalize_install_cmd = [
         # but snapd expects modules/ and firmware/
         mv ${SNAPCRAFT_PART_INSTALL}/lib/modules ${SNAPCRAFT_PART_INSTALL}/
         # remove symlinks modules/*/build and modules/*/source
-        rm ${SNAPCRAFT_PART_INSTALL}/modules/*/build ${SNAPCRAFT_PART_INSTALL}/modules/*/source
+        rm -f ${SNAPCRAFT_PART_INSTALL}/modules/*/build ${SNAPCRAFT_PART_INSTALL}/modules/*/source
         # if there is firmware dir, move it to snap root
         # this could have been from stage packages or from kernel build
         [ -d ${SNAPCRAFT_PART_INSTALL}/lib/firmware ] && mv ${SNAPCRAFT_PART_INSTALL}/lib/firmware ${SNAPCRAFT_PART_INSTALL}

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1919,7 +1919,7 @@ _finalize_install_cmd = [
         # but snapd expects modules/ and firmware/
         mv ${CRAFT_PART_INSTALL}/lib/modules ${CRAFT_PART_INSTALL}/
         # remove symlinks modules/*/build and modules/*/source
-        rm ${CRAFT_PART_INSTALL}/modules/*/build ${CRAFT_PART_INSTALL}/modules/*/source
+        rm -f ${CRAFT_PART_INSTALL}/modules/*/build ${CRAFT_PART_INSTALL}/modules/*/source
         # if there is firmware dir, move it to snap root
         # this could have been from stage packages or from kernel build
         [ -d ${CRAFT_PART_INSTALL}/lib/firmware ] && mv ${CRAFT_PART_INSTALL}/lib/firmware ${CRAFT_PART_INSTALL}


### PR DESCRIPTION
Sometimes there may be no `{install_dir}/modules/*/source`, so I think it would be better to add `-rf` for `rm` command, just like how it is used in other lines of the same file(_kernel_build.py)