### PR TITLE
tests: disable `build-base: devel` spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -321,10 +321,11 @@ suites:
      - ubuntu-20.04*
      - ubuntu-22.04*
 
- tests/spread/core-devel/:
-   summary: tests of devel base snaps
-   environment:
-     SNAPCRAFT_BUILD_ENVIRONMENT: ""
+# 'build-base: devel' fails due to an issue with the 24.10 buildd image (#4921)
+# tests/spread/core-devel/:
+#   summary: tests of devel base snaps
+#   environment:
+#     SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
  # General, core suite
  tests/spread/cross-compile/:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Disable `build-base: devel` spread tests until we have the resources to debug the underlying issue with 24.10 buildd images and `systemd-resolved` (#4921).

We should be able to address this issue in 2024-Nov.

Fixes #4910
(CRAFT-3105)