### PR TITLE
feat(extensions): pass app name to `get_app_snippet()`

### DIFF
--- a/snapcraft/extensions/_ros2_humble_meta.py
+++ b/snapcraft/extensions/_ros2_humble_meta.py
@@ -64,8 +64,8 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
         return root_snippet
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
-        app_snippet = super().get_app_snippet()
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        app_snippet = super().get_app_snippet(app_name=app_name)
         python_paths = app_snippet["environment"]["PYTHONPATH"]
         new_python_paths = [
             f"$SNAP/opt/ros/underlay_ws/opt/ros/{self.ROS_DISTRO}/lib/python3.10/site-packages",

--- a/snapcraft/extensions/_ros2_jazzy_meta.py
+++ b/snapcraft/extensions/_ros2_jazzy_meta.py
@@ -64,8 +64,8 @@ class ROS2JazzyMetaBase(ROS2JazzyExtension):
         return root_snippet
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
-        app_snippet = super().get_app_snippet()
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        app_snippet = super().get_app_snippet(app_name=app_name)
         python_paths = app_snippet["environment"]["PYTHONPATH"]
         new_python_paths = [
             f"$SNAP/opt/ros/underlay_ws/opt/ros/{self.ROS_DISTRO}/lib/python3.12/site-packages",

--- a/snapcraft/extensions/_utils.py
+++ b/snapcraft/extensions/_utils.py
@@ -79,8 +79,8 @@ def _apply_extension(
         )
 
     # Apply the app-specific components of the extension (if any)
-    app_extension = extension.get_app_snippet()
     for app_name in app_names:
+        app_extension = extension.get_app_snippet(app_name=app_name)
         app_definition = yaml_data["apps"][app_name]
         for property_name, property_value in app_extension.items():
             app_definition[property_name] = _apply_extension_property(

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -66,8 +66,11 @@ class Extension(abc.ABC):
         """Return the root snippet to apply."""
 
     @abc.abstractmethod
-    def get_app_snippet(self) -> Dict[str, Any]:
-        """Return the app snippet to apply."""
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        """Return the app snippet to apply.
+
+        :param app_name: the name of the app where the snippet will be applied
+        """
 
     @abc.abstractmethod
     def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -85,7 +85,7 @@ class GNOME(Extension):
         return False
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
         command_chain = ["snap/command-chain/desktop-launch"]
         if self.yaml_data["base"] == "core24":
             command_chain.insert(0, "snap/command-chain/gpu-2404-wrapper")

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -89,7 +89,7 @@ class KDENeon(Extension):
         return False
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
         return {
             "command-chain": ["snap/command-chain/desktop-launch"],
             "plugs": ["desktop", "desktop-legacy", "opengl", "wayland", "x11"],

--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -88,7 +88,7 @@ class KDENeon6(Extension):
         return False
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
         return {
             "command-chain": ["snap/command-chain/desktop-launch6"],
             "plugs": [

--- a/snapcraft/extensions/ros2_humble.py
+++ b/snapcraft/extensions/ros2_humble.py
@@ -87,7 +87,7 @@ class ROS2HumbleExtension(Extension):
         }
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
         python_paths = [
             f"$SNAP/opt/ros/{self.ROS_DISTRO}/lib/python3.10/site-packages",
             "$SNAP/usr/lib/python3/dist-packages",

--- a/snapcraft/extensions/ros2_jazzy.py
+++ b/snapcraft/extensions/ros2_jazzy.py
@@ -85,7 +85,7 @@ class ROS2JazzyExtension(Extension):
         }
 
     @overrides
-    def get_app_snippet(self) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
         python_paths = [
             f"$SNAP/opt/ros/{self.ROS_DISTRO}/lib/python3.12/site-packages",
             "$SNAP/usr/lib/python3/dist-packages",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,7 +97,7 @@ def fake_extension():
         def get_root_snippet(self) -> Dict[str, Any]:
             return {"grade": "fake-grade"}
 
-        def get_app_snippet(self) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
             return {"plugs": ["fake-plug"]}
 
         def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
@@ -136,7 +136,7 @@ def fake_extension_extra():
         def get_root_snippet(self) -> Dict[str, Any]:
             return {}
 
-        def get_app_snippet(self) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
             return {"plugs": ["fake-plug", "fake-plug-extra"]}
 
         def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
@@ -170,7 +170,7 @@ def fake_extension_invalid_parts():
         def get_root_snippet(self) -> Dict[str, Any]:
             return {"grade": "fake-grade"}
 
-        def get_app_snippet(self) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
             return {"plugs": ["fake-plug"]}
 
         def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
@@ -206,7 +206,7 @@ def fake_extension_experimental():
         def get_root_snippet(self) -> Dict[str, Any]:
             return {}
 
-        def get_app_snippet(self) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
             return {}
 
         def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
@@ -242,7 +242,7 @@ def fake_extension_name_from_legacy():
         def get_root_snippet(self) -> Dict[str, Any]:
             return {}
 
-        def get_app_snippet(self) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
             return {"plugs": ["fake-plug", "fake-plug-extra"]}
 
         def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -81,14 +81,14 @@ def test_is_experimental(base):
 
 
 def test_get_app_snippet(gnome_extension):
-    assert gnome_extension.get_app_snippet() == {
+    assert gnome_extension.get_app_snippet(app_name="test-app") == {
         "command-chain": ["snap/command-chain/desktop-launch"],
         "plugs": ["desktop", "desktop-legacy", "gsettings", "opengl", "wayland", "x11"],
     }
 
 
 def test_get_app_snippet_core24(gnome_extension_core24):
-    assert gnome_extension_core24.get_app_snippet() == {
+    assert gnome_extension_core24.get_app_snippet(app_name="test-app") == {
         "command-chain": [
             "snap/command-chain/gpu-2404-wrapper",
             "snap/command-chain/desktop-launch",

--- a/tests/unit/extensions/test_kde_neon.py
+++ b/tests/unit/extensions/test_kde_neon.py
@@ -81,7 +81,7 @@ def test_is_experimental():
 
 
 def test_get_app_snippet(kde_neon_extension):
-    assert kde_neon_extension.get_app_snippet() == {
+    assert kde_neon_extension.get_app_snippet(app_name="test-app") == {
         "command-chain": ["snap/command-chain/desktop-launch"],
         "plugs": ["desktop", "desktop-legacy", "opengl", "wayland", "x11"],
     }

--- a/tests/unit/extensions/test_kde_neon_6.py
+++ b/tests/unit/extensions/test_kde_neon_6.py
@@ -88,7 +88,7 @@ def test_is_experimental():
 
 
 def test_get_app_snippet(kde_neon_6_extension):
-    assert kde_neon_6_extension.get_app_snippet() == {
+    assert kde_neon_6_extension.get_app_snippet(app_name="test-app") == {
         "command-chain": ["snap/command-chain/desktop-launch6"],
         "plugs": [
             "desktop",

--- a/tests/unit/parts/extensions/test_ros2_humble.py
+++ b/tests/unit/parts/extensions/test_ros2_humble.py
@@ -110,7 +110,7 @@ class TestExtensionROS2HumbleExtension:
             "${PYTHONPATH}",
         ]
         extension = setup_method_fixture()
-        assert extension.get_app_snippet() == {
+        assert extension.get_app_snippet(app_name="test-app") == {
             "command-chain": ["snap/command-chain/ros2-launch"],
             "environment": {
                 "ROS_VERSION": "2",

--- a/tests/unit/parts/extensions/test_ros2_humble_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_humble_meta.py
@@ -142,7 +142,7 @@ class TestExtensionROS2HumbleMetaExtensions:
             "$SNAP/opt/ros/underlay_ws/usr/lib/python3/dist-packages",
         ]
         extension = setup_method_fixture(extension_class)
-        assert extension.get_app_snippet() == {
+        assert extension.get_app_snippet(app_name="test-app") == {
             "command-chain": ["snap/command-chain/ros2-launch"],
             "environment": {
                 "ROS_VERSION": "2",

--- a/tests/unit/parts/extensions/test_ros2_jazzy.py
+++ b/tests/unit/parts/extensions/test_ros2_jazzy.py
@@ -110,7 +110,7 @@ class TestExtensionROS2JazzyExtension:
             "${PYTHONPATH}",
         ]
         extension = setup_method_fixture()
-        assert extension.get_app_snippet() == {
+        assert extension.get_app_snippet(app_name="test-app") == {
             "command-chain": ["snap/command-chain/ros2-launch"],
             "environment": {
                 "ROS_VERSION": "2",

--- a/tests/unit/parts/extensions/test_ros2_jazzy_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_jazzy_meta.py
@@ -142,7 +142,7 @@ class TestExtensionROS2JazzyMetaExtensions:
             "$SNAP/opt/ros/underlay_ws/usr/lib/python3/dist-packages",
         ]
         extension = setup_method_fixture(extension_class)
-        assert extension.get_app_snippet() == {
+        assert extension.get_app_snippet(app_name="test-app") == {
             "command-chain": ["snap/command-chain/ros2-launch"],
             "environment": {
                 "ROS_VERSION": "2",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

To support https://github.com/canonical/snapcraft/pull/4925, where an extension needs to know the name of the app when creating the app's snippet.

source: https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$6GuTjHbBgrKzNoUcc6XKCLLqsy_roBsw4OMDFQIUPY4?via=ubuntu.com&via=matrix.org&via=kde.org