### PR TITLE
build(deps): bump craft-providers to 1.25.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
 craft-parts==1.33.0
-craft-providers==1.23.1
+craft-providers==1.25.0
 craft-store==2.6.2
 cryptography==42.0.5
 Deprecated==1.2.14

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,7 +22,7 @@ craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
 craft-parts==1.33.0
-craft-providers==1.23.1
+craft-providers==1.25.0
 craft-store==2.6.2
 cryptography==42.0.5
 dill==0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
 craft-parts==1.33.0
-craft-providers==1.23.1
+craft-providers==1.25.0
 craft-store==2.6.2
 cryptography==42.0.5
 Deprecated==1.2.14

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     "craft-cli>=2.6.0",
     "craft-grammar",
     "craft-parts>=1.33.0",
-    "craft-providers",
+    "craft-providers>=1.25.0",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.
     "gnupg",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

### Changelog

#### 1.25.0 (2024-07-24)

* Use Ubuntu 24.04 buildd image for Multipass
* Remove Ubuntu 23.10 (Mantic) support

#### 1.24.1 (2024-02-07)

* Improve detection of installed LXD
* Update the link to the network troubleshooting docs

#### 1.24.0 (2024-06-18)

* Add support for Ubuntu 24.10 (Oracular)
