### PR TITLE
build(deps): use the ruff snap

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -34,6 +34,18 @@ lxc exec snapcraft-dev -- sudo -iu ubuntu bash
 
 Import your keys (`ssh-import-id`) and add a `Host` entry to your ssh config if you are interested in [Code's](https://snapcraft.io/code) [Remote-SSH](https://code.visualstudio.com/docs/remote/ssh) plugin.
 
+### Tooling
+
+We use a large number of tools for our project. Most of these are installed for
+you with tox, but you'll need to install:
+
+- Python 3.10 (default on Ubuntu 22.04, available on Ubuntu 24.04 through the
+  [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) PPA) with setuptools.
+- [tox](https://tox.wiki) version 3.8 or later
+- [pyright](https://github.com/microsoft/pyright)  (also available via snap: `snap install pyright`)
+- [ruff](https://github.com/astral/ruff) (also available via snap: `snap install ruff`)
+- [ShellCheck](https://www.shellcheck.net/)  (also available via snap: `snap install shellcheck`)
+
 ### Testing
 
 See the [Testing guide](TESTING.md).

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -147,7 +147,9 @@ class RemoteBuildCommand(ExtensibleCommand):
                 retcode=77,
             )
 
-    def _run(self, parsed_args: argparse.Namespace, **kwargs: Any) -> int | None:
+    def _run(  # noqa: PLR0915 [too-many-statements]
+        self, parsed_args: argparse.Namespace, **kwargs: Any
+    ) -> int | None:
         """Run the remote-build command.
 
         :param parsed_args: Snapcraft's argument namespace.
@@ -237,7 +239,7 @@ class RemoteBuildCommand(ExtensibleCommand):
                 emit.progress("Cancelling builds.")
                 builder.cancel_builds()
             returncode = 0
-        except Exception:
+        except Exception:  # noqa: BLE001 [blind-except]
             returncode = 1  # General error on any other exception
         if returncode != 75:  # TimeoutError
             emit.progress("Cleaning up")

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -801,7 +801,7 @@ class TestAppstreamContent:
         assert metadata.contact == ["rrroschan@gmail.com"]
         assert metadata.donation == ["https://www.buymeacoffee.com/alainm23"]
         assert metadata.website == ["https://hello.com"]
-        assert metadata.source_code == None
+        assert metadata.source_code is None
         assert metadata.issues == ["https://github.com/alainm23/planify/issues"]
 
     def test_appstream_parse_error(self):

--- a/tox.ini
+++ b/tox.ini
@@ -143,8 +143,8 @@ allowlist_externals:
     ruff: ruff
 commands =
     black: black {tty:--color} {posargs} .
-    ruff: ruff --fix --respect-gitignore setup.py snapcraft tests tools
-    ruff: ruff --fix --config snapcraft_legacy/ruff.toml snapcraft_legacy tests/legacy
+    ruff: ruff check --fix --respect-gitignore setup.py snapcraft tests tools
+    ruff: ruff check --fix --config snapcraft_legacy/ruff.toml snapcraft_legacy tests/legacy
     codespell: codespell --toml {tox_root}/pyproject.toml --write-changes {posargs}
 
 [docs]  # Sphinx documentation configuration


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

`ruff` was already used as a snap for CI but this PR formalizes using the snap.

- use the new `ruff check` call
- compatibility updates for ruff 0.5.4
- documentation changes