### PR TITLE
ci: enable jazzy content sharing arm64 spread test

### DIFF
--- a/tests/spread/extensions/ros2-jazzy-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros2-jazzy-meta-hello/task.yaml
@@ -28,7 +28,7 @@ systems:
   - ubuntu-24.04
   - ubuntu-24.04-64
   - ubuntu-24.04-amd64
-  # - ubuntu-24.04-arm64
+  - ubuntu-24.04-arm64
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/extensions/ros2-jazzy-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-jazzy-meta-talker-listener/task.yaml
@@ -27,7 +27,7 @@ systems:
   - ubuntu-24.04
   - ubuntu-24.04-64
   - ubuntu-24.04-amd64
-  # - ubuntu-24.04-arm64
+  - ubuntu-24.04-arm64
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh


### PR DESCRIPTION
Enable ROS 2 Jazzy (core24) content-sharing spread tests for arm64 (now that the content sharing snaps are available for that arch).

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
