### PR TITLE
docs: exclude overlay step, bump craft-parts to 1.34.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,8 @@ exclude_patterns = [
     # errors).
     "common/craft-parts/explanation/overlay_parameters.rst",
     "common/craft-parts/explanation/overlays.rst",
+    "common/craft-parts/explanation/how_parts_are_built.rst",
+    "common/craft-parts/explanation/parts.rst",
     "common/craft-parts/how-to/craftctl.rst",
     "common/craft-parts/reference/parts_steps.rst",
     "common/craft-parts/reference/step_execution_environment.rst",

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -11,7 +11,6 @@ Explanation
    components
    remote-build
    /common/craft-parts/explanation/filesets
-   /common/craft-parts/explanation/parts
-   /common/craft-parts/explanation/how_parts_are_built
+   parts
    /common/craft-parts/explanation/lifecycle
    /common/craft-parts/explanation/dump_plugin

--- a/docs/explanation/parts.rst
+++ b/docs/explanation/parts.rst
@@ -1,0 +1,10 @@
+.. include:: /common/craft-parts/explanation/parts.rst
+   :end-before: _include-how-parts-are-built:
+..
+  exclude the overlay step explanation from craft-parts
+
+.. include:: /common/craft-parts/explanation/how_parts_are_built.rst
+   :end-before: _overlay-step-begin:
+
+.. include:: /common/craft-parts/explanation/how_parts_are_built.rst
+   :start-after: _overlay-step-end:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,7 +17,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.34.0
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,7 +21,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.34.0
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.34.0
 craft-providers==1.23.1
 craft-store==2.6.2
 cryptography==42.0.5

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ install_requires = [
     "craft-archives",
     "craft-cli>=2.6.0",
     "craft-grammar",
-    "craft-parts>=1.33.0",
+    "craft-parts>=1.34.0",
     "craft-providers",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Fix failing snapcraft doc build due to https://github.com/canonical/craft-parts/pull/765, which added a reference to an excluded overlays explanation.

Depends on https://github.com/canonical/craft-parts/pull/795

### Changelog

#### 1.34.0 (2024-08-01)

-  Allow numbers in partitions, partition namespaces, and namespaced partitions.
-  Add documentation for chisel and the overlay step
-  Improve README onboarding

Unblocks CRAFT-3043