### PR TITLE
chore: cherry-pick fixes to hotfix/8.3

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -110,10 +110,12 @@ jobs:
         name: Run spread
         env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+          SNAPCRAFT_ASSERTION_KEY: "${{ secrets.SNAPCRAFT_ASSERTION_KEY }}"
           SNAPCRAFT_STORE_CREDENTIALS_STAGING: "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS_STAGING }}"
           SNAPCRAFT_STORE_CREDENTIALS_STAGING_CANDID: "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS_STAGING_CANDID }}"
           SNAPCRAFT_STORE_CREDENTIALS_STAGING_LEGACY: "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS_STAGING_LEGACY }}"
-        run: spread google:ubuntu-22.04-64:tests/spread/general/store
+        run: |
+          spread google:ubuntu-22.04-64:tests/spread/store/
 
       - name: Discard spread workers
         if: always()

--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -24,14 +24,17 @@ import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+import craft_application.util
 import yaml
 from craft_application.commands import AppCommand
+from craft_application.errors import CraftValidationError
 from craft_cli import emit
 from overrides import overrides
 
 from snapcraft import errors, utils
 from snapcraft_legacy._store import StoreClientCLI
 from snapcraft_legacy.storeapi.errors import StoreValidationSetsError
+from snapcraft_legacy.storeapi.v2 import validation_sets
 
 if TYPE_CHECKING:
     import argparse
@@ -40,7 +43,7 @@ if TYPE_CHECKING:
 _VALIDATIONS_SETS_SNAPS_TEMPLATE = textwrap.dedent(
     """\
     snaps:
-    #  - name: <name>  # The name of the snap.
+      - name: hello  # The name of the snap.
     #    id:   <id>    # The ID of the snap. Optional, defaults to the current ID for
                        # the provided name.
     #    presence: [required|optional|invalid]  # Optional, defaults to required.
@@ -102,7 +105,9 @@ class StoreEditValidationSetsCommand(AppCommand):
         validation_sets_path.write_text(validation_sets_template, encoding="utf-8")
         edited_validation_sets = edit_validation_sets(validation_sets_path)
 
-        if edited_validation_sets == yaml.safe_load(validation_sets_template):
+        if edited_validation_sets == validation_sets.EditableBuildAssertion(
+            **yaml.safe_load(validation_sets_template)
+        ):
             emit.message("No changes made")
             return
 
@@ -119,7 +124,7 @@ class StoreEditValidationSetsCommand(AppCommand):
                         "Do you wish to amend the validation set?"
                     ):
                         raise errors.SnapcraftError(
-                            "Operation aborted"
+                            "operation aborted"
                         ) from validation_error
                     edited_validation_sets = edit_validation_sets(validation_sets_path)
         finally:
@@ -127,32 +132,43 @@ class StoreEditValidationSetsCommand(AppCommand):
 
 
 def _submit_validation_set(
-    edited_validation_sets: Dict[str, Any],
+    edited_validation_sets: validation_sets.EditableBuildAssertion,
     key_name: Optional[str],
     store_client: StoreClientCLI,
 ) -> None:
+    emit.debug(f"Posting assertion to build: {edited_validation_sets.json()}")
     build_assertion = store_client.post_validation_sets_build_assertion(
-        validation_sets=edited_validation_sets
+        validation_sets=edited_validation_sets.marshal()
     )
-    signed_validation_sets = _sign_assertion(
-        build_assertion.marshal(), key_name=key_name
+    build_assertion_dict = build_assertion.marshal_scalars_as_strings()
+
+    signed_validation_sets = _sign_assertion(build_assertion_dict, key_name=key_name)
+
+    emit.debug("Posting signed validation sets.")
+    response = store_client.post_validation_sets(
+        signed_validation_sets=signed_validation_sets
     )
-    store_client.post_validation_sets(signed_validation_sets=signed_validation_sets)
+    emit.debug(f"Response: {response.json()}")
 
 
 def _generate_template(
-    asserted_validation_sets, *, account_id: str, set_name: str, sequence: str
+    asserted_validation_sets: validation_sets.ValidationSets,
+    *,
+    account_id: str,
+    set_name: str,
+    sequence: str,
 ) -> str:
     """Generate a template to edit asserted_validation_sets."""
     try:
         # assertions should only have one item since a specific
         # sequence was requested.
-        revision = asserted_validation_sets.assertions[0].revision
+        revision = asserted_validation_sets.assertions[0].headers.revision
 
         snaps = yaml.dump(
             {
                 "snaps": [
-                    s.marshal() for s in asserted_validation_sets.assertions[0].snaps
+                    s.marshal()
+                    for s in asserted_validation_sets.assertions[0].headers.snaps
                 ]
             },
             default_flow_style=False,
@@ -174,7 +190,9 @@ def _generate_template(
     return unverified_validation_sets
 
 
-def edit_validation_sets(validation_sets_path: Path) -> Dict[str, Any]:
+def edit_validation_sets(
+    validation_sets_path: Path,
+) -> validation_sets.EditableBuildAssertion:
     """Spawn an editor to modify the validation-sets."""
     editor_cmd = os.getenv("EDITOR", "vi")
 
@@ -182,23 +200,29 @@ def edit_validation_sets(validation_sets_path: Path) -> Dict[str, Any]:
         with emit.pause():
             subprocess.run([editor_cmd, validation_sets_path], check=True)
         try:
-            edited_validation_sets = yaml.safe_load(
-                validation_sets_path.read_text(encoding="utf-8")
+            with validation_sets_path.open() as file:
+                data = craft_application.util.safe_yaml_load(file)
+            edited_validation_sets = validation_sets.EditableBuildAssertion.from_yaml_data(
+                data=data,
+                # filepath is only shown for pydantic errors and snapcraft should
+                # not expose the temp file name
+                filepath=Path("validation-sets"),
             )
             return edited_validation_sets
-        except yaml.YAMLError as yaml_error:
-            emit.message(f"A YAML parsing error occurred {yaml_error!s}")
+        except (yaml.YAMLError, CraftValidationError) as err:
+            emit.message(f"{err!s}")
             if not utils.confirm_with_user("Do you wish to amend the validation set?"):
-                raise errors.SnapcraftError("Operation aborted") from yaml_error
+                raise errors.SnapcraftError("operation aborted") from err
 
 
 def _sign_assertion(assertion: Dict[str, Any], *, key_name: Optional[str]) -> bytes:
+    emit.debug("Signing assertion.")
     cmdline = ["snap", "sign"]
     if key_name:
         cmdline += ["-k", key_name]
     snap_sign = subprocess.Popen(cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     signed_assertion, _ = snap_sign.communicate(input=json.dumps(assertion).encode())
     if snap_sign.returncode != 0:
-        raise errors.SnapcraftError("Failed to sign assertion")
+        raise errors.SnapcraftError("failed to sign assertion")
 
     return signed_assertion

--- a/snapcraft_legacy/cli/assertions.py
+++ b/snapcraft_legacy/cli/assertions.py
@@ -135,7 +135,8 @@ def list_validation_sets(name, sequence):
     else:
         headers = ["Account-ID", "Name", "Sequence", "Revision", "When"]
         assertions = list()
-        for assertion in asserted_validation_sets.assertions:
+        for assertion_header in asserted_validation_sets.assertions:
+            assertion = assertion_header.headers
             assertions.append(
                 [
                     assertion.account_id,

--- a/snapcraft_legacy/plugins/v2/_kernel_build.py
+++ b/snapcraft_legacy/plugins/v2/_kernel_build.py
@@ -1111,7 +1111,7 @@ def _arrange_install_dir_cmd(install_dir: str) -> List[str]:
             # but snapd expects modules/ and firmware/
             mv {install_dir}/lib/modules {install_dir}/
             # remove symlinks modules/*/build and modules/*/source
-            rm {install_dir}/modules/*/build {install_dir}/modules/*/source
+            rm -f {install_dir}/modules/*/build {install_dir}/modules/*/source
             # if there is firmware dir, move it to snap root
             # this could have been from stage packages or from kernel build
             [ -d {install_dir}/lib/firmware ] && mv {install_dir}/lib/firmware {install_dir}

--- a/snapcraft_legacy/storeapi/v2/_api_schema.py
+++ b/snapcraft_legacy/storeapi/v2/_api_schema.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020 Canonical Ltd
+# Copyright 2020,2024 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -273,77 +273,5 @@ WHOAMI_JSONSCHEMA: Dict[str, Any] = {
         },
     },
     "required": ["account", "channels", "packages", "permissions"],
-    "type": "object",
-}
-
-# https://dashboard.snapcraft.io/docs/v2/en/validation-sets.html
-BUILD_ASSERTION_JSONSCHEMA: Dict[str, Any] = {
-    "properties": {
-        "account-id": {
-            "description": 'The "account-id" assertion header',
-            "type": "string",
-        },
-        "authority-id": {
-            "description": 'The "authority-id" assertion header',
-            "type": "string",
-        },
-        "name": {"description": 'The "name" assertion header', "type": "string"},
-        "revision": {
-            "description": 'The "revision" assertion header',
-            "type": "string",
-        },
-        "sequence": {
-            "description": 'The "sequence" assertion header',
-            "type": "string",
-        },
-        "series": {"description": 'The "series" assertion header', "type": "string"},
-        "snaps": {
-            "items": {
-                "description": "List of snaps in a Validation Set assertion",
-                "properties": {
-                    "id": {
-                        "description": "Snap ID",
-                        "maxLength": 100,
-                        "type": "string",
-                    },
-                    "name": {
-                        "description": "Snap name",
-                        "maxLength": 100,
-                        "type": "string",
-                    },
-                    "presence": {
-                        "description": "Snap presence",
-                        "enum": ["required", "optional", "invalid"],
-                        "type": "string",
-                    },
-                    "revision": {"description": "Snap revision", "type": "string"},
-                },
-                "required": ["name"],
-                "type": "object",
-            },
-            "minItems": 1,
-            "type": "array",
-        },
-        "timestamp": {
-            "description": 'The "timestamp" assertion header',
-            "type": "string",
-        },
-        "type": {
-            "const": "validation-set",
-            "description": 'The "type" assertion header',
-            "type": "string",
-        },
-    },
-    "required": [
-        "type",
-        "authority-id",
-        "series",
-        "account-id",
-        "name",
-        "sequence",
-        # "revision",
-        "timestamp",
-        "snaps",
-    ],
     "type": "object",
 }

--- a/snapcraft_legacy/storeapi/v2/validation_sets.py
+++ b/snapcraft_legacy/storeapi/v2/validation_sets.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2021 Canonical Ltd
+# Copyright (C) 2021,2024 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,161 +14,135 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Annotated, Dict, Literal, TYPE_CHECKING
+import numbers
+import pydantic
 
-import jsonschema
-
-from ._api_schema import BUILD_ASSERTION_JSONSCHEMA
+from craft_application import models
 
 
-class Snap:
+if TYPE_CHECKING:
+    SnapName = str
+    SnapId = str
+else:
+    SnapName = pydantic.constr(max_length=40)
+    SnapId = pydantic.constr(max_length=40)
+
+
+def cast_dict_scalars_to_strings(data: dict) -> dict[str, Any]:
+    """Cast all scalars in a dictionary to strings.
+
+    Supported scalar types are str, bool, and numbers.
+    """
+    return {_to_string(key): _to_string(value) for key, value in data.items()}
+
+
+def _to_string(
+    data: dict | list | str | int | float | str | bool | None
+) -> dict[str, Any] | list | str | None:
+    """Recurse through nested dicts and lists and cast scalar values to strings.
+
+    Supported scalar types are str, bool, and numbers.
+    """
+    # start with a string as it is the most common scenario
+    if isinstance(data, str):
+        return data
+
+    if isinstance(data, dict):
+        return {_to_string(key): _to_string(value) for key, value in data.items()}
+
+    if isinstance(data, list):
+        return [_to_string(i) for i in data]
+
+    if isinstance(data, (numbers.Number, bool)):
+        return str(data)
+
+    return data
+
+
+class Snap(models.CraftBaseModel):
     """Represent a Snap in a Validation Set."""
 
-    @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "Snap":
-        jsonschema.validate(
-            payload, BUILD_ASSERTION_JSONSCHEMA["properties"]["snaps"]["items"]
-        )
+    name: SnapName
+    """Snap name"""
 
-        return cls(
-            name=payload["name"],
-            snap_id=payload.get("id"),
-            presence=payload.get("presence"),
-            revision=payload.get("revision"),
-        )
+    id: SnapId | None
+    """Snap ID"""
 
-    def marshal(self) -> Dict[str, Any]:
-        payload = {"name": self.name}
+    presence: Literal["required", "optional", "invalid"] | None
+    """Snap presence"""
 
-        if self.snap_id is not None:
-            payload["id"] = self.snap_id
-
-        if self.presence is not None:
-            payload["presence"] = self.presence
-
-        if self.revision is not None:
-            payload["revision"] = self.revision
-
-        return payload
-
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, Snap):
-            return False
-
-        return (
-            self.name == other.name
-            and self.snap_id == other.snap_id
-            and self.presence == other.presence
-            and self.revision == other.revision
-        )
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: {self.name!r}>"
-
-    def __init__(
-        self,
-        name: str,
-        snap_id: Optional[str] = None,
-        presence: Optional[str] = None,
-        revision: Optional[str] = None,
-    ):
-        self.name = name
-        self.snap_id = snap_id
-        self.presence = presence
-        self.revision = revision
+    revision: int | None
+    """Snap revision"""
 
 
-class BuildAssertion:
-    """Represent Validation Set assertion headers ready local signing."""
+class EditableBuildAssertion(models.CraftBaseModel):
+    """Subset of a build assertion that can be edited by the user.
 
-    @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "BuildAssertion":
-        jsonschema.validate(payload, BUILD_ASSERTION_JSONSCHEMA)
+    https://dashboard.snapcraft.io/docs/reference/v2/en/validation-sets.html#request-json-schema
+    """
+    account_id: str
+    """The "account-id" assertion header"""
 
-        return cls(
-            account_id=payload["account-id"],
-            authority_id=payload["authority-id"],
-            name=payload["name"],
-            revision=payload.get("revision", "0"),
-            sequence=payload["sequence"],
-            series=payload["series"],
-            snaps=[Snap.unmarshal(s) for s in payload["snaps"]],
-            timestamp=payload["timestamp"],
-            assertion_type=payload["type"],
-        )
+    name: str
+    """The "name" assertion header"""
 
-    def marshal(self) -> Dict[str, Any]:
-        return {
-            "account-id": self.account_id,
-            "authority-id": self.authority_id,
-            "name": self.name,
-            "revision": self.revision,
-            "sequence": self.sequence,
-            "snaps": [s.marshal() for s in self.snaps],
-            "timestamp": self.timestamp,
-            "type": self.assertion_type,
-            "series": self.series,
-        }
+    revision: str | None
+    """The "revision" assertion header"""
 
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, BuildAssertion):
-            return False
+    sequence: int
+    """The "sequence" assertion header"""
 
-        return (
-            self.name == other.name
-            and self.account_id == other.account_id
-            and self.authority_id == other.authority_id
-            and self.revision == other.revision
-            and self.sequence == other.sequence
-            and self.snaps == other.snaps
-            and self.timestamp == other.timestamp
-            and self.assertion_type == other.assertion_type
-            and self.series == other.series
-        )
+    snaps: Annotated[list[Snap], pydantic.Field(min_items=1)]
+    """List of snaps in a Validation Set assertion"""
 
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: {self.name!r}>"
-
-    def __init__(
-        self,
-        *,
-        account_id: str,
-        authority_id: str,
-        name: str,
-        revision: str,
-        sequence: str,
-        snaps: List[Snap],
-        timestamp: str,
-        assertion_type: str,
-        series: str = "16",
-    ):
-        self.account_id = account_id
-        self.authority_id = authority_id
-        self.name = name
-        self.revision = revision
-        self.sequence = sequence
-        self.snaps = snaps
-        self.series = series
-        self.timestamp = timestamp
-        self.assertion_type = assertion_type
+    def marshal_scalars_as_strings(self) -> Dict[str, Any]:
+        """Marshal the object where all scalars are represented as strings."""
+        data = self.marshal()
+        return cast_dict_scalars_to_strings(data)
 
 
-class ValidationSets:
-    @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "ValidationSets":
-        return cls(
-            assertions=[
-                BuildAssertion.unmarshal(a["headers"])
-                for a in payload.get("assertions", list())
-            ]
-        )
+class BuildAssertion(EditableBuildAssertion):
+    """Full build assertion header for a Validation Set.
 
-    def marshal(self) -> Dict[str, Any]:
-        return {"assertions": [{"headers": a.marshal()} for a in self.assertions]}
+    https://dashboard.snapcraft.io/docs/reference/v2/en/validation-sets.html#response-json-schema
+    """
+    authority_id: str
+    """The "authority-id" assertion header"""
 
-    def __repr__(self) -> str:
-        assertion_count = len(self.assertions)
-        return f"<{self.__class__.__name__}: assertions {assertion_count!r}>"
+    series: str
+    """The "series" assertion header"""
 
-    def __init__(self, assertions: List[BuildAssertion]) -> None:
-        self.assertions = assertions
+    sign_key_sha3_384: str | None
+    """Signing key ID."""
+
+    timestamp: str
+    """The "timestamp" assertion header"""
+
+    type: Literal["validation-set"]
+    """The "type" assertion header"""
+
+    @pydantic.root_validator(pre=True)
+    def remove_sign_key(cls, values):
+        """Accept but always ignore the sign key.
+
+        The API can return and accept the sign key but the previous implementation
+        ignored it.
+        """
+        values.pop("sign-key-sha3-384", None)
+        return values
+
+
+class Headers(models.CraftBaseModel):
+    """Assertion headers for a validation set."""
+    headers: BuildAssertion
+    """Assertion headers"""
+
+
+class ValidationSets(models.CraftBaseModel):
+    """Validation sets.
+
+    https://dashboard.snapcraft.io/docs/reference/v2/en/validation-sets.html#id4
+    """
+    assertions: list[Headers]
+    """List of validation-set assertions"""

--- a/spread.yaml
+++ b/spread.yaml
@@ -377,6 +377,15 @@ suites:
      sudo apt-get install git
      sudo apt-mark auto git
 
+ tests/spread/store/:
+   summary: tests of store-related snapcraft commands
+   manual: true
+   environment:
+     STORE_DASHBOARD_URL: https://dashboard.staging.snapcraft.io
+     STORE_API_URL: https://api.staging.snapcraft.io
+     STORE_UPLOAD_URL: https://storage.staging.snapcraftcontent.com
+     UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com
+
 path: /snapcraft/
 include:
   - tests/

--- a/spread.yaml
+++ b/spread.yaml
@@ -321,10 +321,11 @@ suites:
      - ubuntu-20.04*
      - ubuntu-22.04*
 
- tests/spread/core-devel/:
-   summary: tests of devel base snaps
-   environment:
-     SNAPCRAFT_BUILD_ENVIRONMENT: ""
+# 'build-base: devel' fails due to an issue with the 24.10 buildd image (#4921)
+# tests/spread/core-devel/:
+#   summary: tests of devel base snaps
+#   environment:
+#     SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
  # General, core suite
  tests/spread/cross-compile/:

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -1768,7 +1768,7 @@ _finalize_install_cmd = [
         # but snapd expects modules/ and firmware/
         mv ${SNAPCRAFT_PART_INSTALL}/lib/modules ${SNAPCRAFT_PART_INSTALL}/
         # remove symlinks modules/*/build and modules/*/source
-        rm ${SNAPCRAFT_PART_INSTALL}/modules/*/build ${SNAPCRAFT_PART_INSTALL}/modules/*/source
+        rm -f ${SNAPCRAFT_PART_INSTALL}/modules/*/build ${SNAPCRAFT_PART_INSTALL}/modules/*/source
         # if there is firmware dir, move it to snap root
         # this could have been from stage packages or from kernel build
         [ -d ${SNAPCRAFT_PART_INSTALL}/lib/firmware ] && mv ${SNAPCRAFT_PART_INSTALL}/lib/firmware ${SNAPCRAFT_PART_INSTALL}

--- a/tests/legacy/unit/store/test_store_client.py
+++ b/tests/legacy/unit/store/test_store_client.py
@@ -438,7 +438,7 @@ class ValidationSetsTestCase(StoreTestCase):
 
         self.assertThat(vs, IsInstance(validation_sets.ValidationSets))
         self.assertThat(vs.assertions, HasLength(1))
-        self.assertThat(vs.assertions[0], Equals(build_assertion))
+        self.assertThat(vs.assertions[0].headers, Equals(build_assertion))
 
     def test_post_invalid_assertion(self):
         build_assertion = self.client.post_validation_sets_build_assertion(
@@ -516,7 +516,7 @@ class ValidationSetsTestCase(StoreTestCase):
 
         self.assertThat(vs, IsInstance(validation_sets.ValidationSets))
         self.expectThat(vs.assertions, HasLength(1))
-        self.expectThat(vs.assertions[0].name, Equals("acme-cert-2020-10"))
+        self.expectThat(vs.assertions[0].headers.name, Equals("acme-cert-2020-10"))
 
     def test_get_invalid_sequence(self):
         raised = self.assertRaises(

--- a/tests/legacy/unit/store/v2/test_validation_sets.py
+++ b/tests/legacy/unit/store/v2/test_validation_sets.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2021 Canonical Ltd
+# Copyright (C) 2021,2024 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,127 +19,136 @@ import pytest
 from snapcraft_legacy.storeapi.v2 import validation_sets
 
 
-@pytest.mark.parametrize("snap_id", (None, "snap_id"))
-@pytest.mark.parametrize("presence", (None, "required", "optional", "invalid"))
-@pytest.mark.parametrize("revision", ("42", None))
-def test_snap(snap_id, presence, revision):
-    payload = {
-        "name": "set-1",
+@pytest.fixture()
+def fake_snap_data():
+    return {
+        "name": "snap-name",
+        "id": "snap-id",
+        "presence": "required",
+        "revision": 42,
     }
 
-    if presence is not None:
-        payload["presence"] = presence
 
-    if snap_id is not None:
-        payload["id"] = snap_id
-
-    if revision is not None:
-        payload["revision"] = revision
-
-    s = validation_sets.Snap.unmarshal(payload)
-
-    assert repr(s) == "<Snap: 'set-1'>"
-    assert s.name == payload["name"]
-    assert s.snap_id == payload.get("id")
-    assert s.presence == payload.get("presence")
-    assert s.revision == payload.get("revision")
-    assert s.marshal() == payload
+@pytest.fixture()
+def fake_snap(fake_snap_data):
+    return validation_sets.Snap.unmarshal(fake_snap_data)
 
 
-@pytest.mark.parametrize("revision", ("42", None))
-def test_build_assertion(revision):
-    payload = {
+@pytest.fixture()
+def fake_editable_build_assertion_data(fake_snap_data):
+    return {
         "account-id": "account-id-1",
-        "authority-id": "authority-id-1",
         "name": "validation-set-1",
-        "sequence": "1",
+        "revision": "revision-1",
+        "sequence": 1,
+        "snaps": [fake_snap_data],
+    }
+
+
+@pytest.fixture()
+def fake_editable_build_assertion(fake_editable_build_assertion_data):
+    return validation_sets.EditableBuildAssertion.unmarshal(
+        fake_editable_build_assertion_data
+    )
+
+
+@pytest.fixture()
+def fake_build_assertion_data(fake_snap_data):
+    return {
+        "account-id": "account-id-1",
+        "name": "validation-set-1",
+        "revision": "revision-1",
+        "sequence": 1,
+        "snaps": [fake_snap_data],
+        "authority-id": "authority-id-1",
         "series": "16",
-        "snaps": [validation_sets.Snap(name="snap-name").marshal()],
+        "sign-key-sha3-384": "sign-key-1",
         "timestamp": "2020-10-29T16:36:56Z",
         "type": "validation-set",
     }
 
-    if revision is not None:
-        payload["revision"] = revision
 
-    s = validation_sets.BuildAssertion.unmarshal(payload)
-
-    assert repr(s) == "<BuildAssertion: 'validation-set-1'>"
-    assert s.account_id == payload["account-id"]
-    assert s.authority_id == payload["authority-id"]
-    assert s.name == payload["name"]
-    assert s.sequence == payload.get("sequence")
-    assert s.series == payload.get("series")
-    assert s.snaps == [validation_sets.Snap(name="snap-name")]
-    assert s.timestamp == "2020-10-29T16:36:56Z"
-
-    if revision is None:
-        payload["revision"] = "0"
-
-    assert s.marshal() == payload
+@pytest.fixture()
+def fake_build_assertion(fake_build_assertion_data):
+    return validation_sets.BuildAssertion.unmarshal(fake_build_assertion_data)
 
 
-def test_validation_sets():
-    payload = {
-        "assertions": [
+@pytest.mark.parametrize(
+    ("input_dict", "expected"),
+    [
+        pytest.param({}, {}, id="empty"),
+        pytest.param(
+            {False: False, True: True},
+            {"False": "False", "True": "True"},
+            id="boolean values",
+        ),
+        pytest.param(
+            {0: 0, None: None, "dict": {}, "list": [], "str": ""},
+            ({"0": "0", None: None, "dict": {}, "list": [], "str": ""}),
+            id="none-like values",
+        ),
+        pytest.param(
+            {10: 10, 20.0: 20.0, "30": "30", True: True},
+            {"10": "10", "20.0": "20.0", "30": "30", "True": "True"},
+            id="scalar values",
+        ),
+        pytest.param(
+            {"foo": {"bar": [1, 2.0], "baz": {"qux": True}}},
+            {"foo": {"bar": ["1", "2.0"], "baz": {"qux": "True"}}},
+            id="nested data structures",
+        ),
+    ],
+)
+def test_cast_dict_scalars_to_strings(input_dict, expected):
+    actual = validation_sets.cast_dict_scalars_to_strings(input_dict)
+
+    assert actual == expected
+
+
+def test_ignore_sign_key(fake_build_assertion):
+    """Ignore the sign key when unmarshalling."""
+    assert not fake_build_assertion.sign_key_sha3_384
+
+
+def test_editable_build_assertion_marshal_as_str(fake_editable_build_assertion):
+    """Cast all scalars to string when marshalling."""
+    data = fake_editable_build_assertion.marshal_scalars_as_strings()
+
+    assert data == {
+        "account-id": "account-id-1",
+        "name": "validation-set-1",
+        "revision": "revision-1",
+        "sequence": "1",
+        "snaps": [
             {
-                "headers": {
-                    "account-id": "account-id-1",
-                    "authority-id": "authority-id-1",
-                    "name": "validation-set-1",
-                    "revision": "1",
-                    "sequence": "1",
-                    "series": "16",
-                    "snaps": [validation_sets.Snap(name="snap-name-1").marshal()],
-                    "timestamp": "2020-10-29T16:36:56Z",
-                    "type": "validation-set",
-                }
+                "id": "snap-id",
+                "name": "snap-name",
+                "presence": "required",
+                "revision": "42",
             },
-            {
-                "headers": {
-                    "account-id": "account-id-1",
-                    "authority-id": "authority-id-1",
-                    "name": "validation-set-1",
-                    "revision": "3",
-                    "sequence": "1",
-                    "series": "16",
-                    "snaps": [validation_sets.Snap(name="snap-name-2").marshal()],
-                    "timestamp": "2020-10-29T16:36:56Z",
-                    "type": "validation-set",
-                },
-            },
-        ]
+        ],
     }
 
-    s = validation_sets.ValidationSets.unmarshal(payload)
 
-    assert repr(s) == "<ValidationSets: assertions 2>"
-    assert s.assertions[0] == validation_sets.BuildAssertion.unmarshal(
-        {
-            "account-id": "account-id-1",
-            "authority-id": "authority-id-1",
-            "name": "validation-set-1",
-            "revision": "1",
-            "sequence": "1",
-            "series": "16",
-            "snaps": [validation_sets.Snap(name="snap-name-1").marshal()],
-            "timestamp": "2020-10-29T16:36:56Z",
-            "type": "validation-set",
-        },
-    )
+def test_build_assertion_marshal_as_str(fake_build_assertion):
+    """Cast all scalars to string when marshalling."""
+    data = fake_build_assertion.marshal_scalars_as_strings()
 
-    assert s.assertions[1] == validation_sets.BuildAssertion.unmarshal(
-        {
-            "account-id": "account-id-1",
-            "authority-id": "authority-id-1",
-            "name": "validation-set-1",
-            "revision": "3",
-            "sequence": "1",
-            "series": "16",
-            "snaps": [validation_sets.Snap(name="snap-name-2").marshal()],
-            "timestamp": "2020-10-29T16:36:56Z",
-            "type": "validation-set",
-        }
-    )
-
-    assert s.marshal() == payload
+    assert data == {
+        "account-id": "account-id-1",
+        "authority-id": "authority-id-1",
+        "name": "validation-set-1",
+        "revision": "revision-1",
+        "sequence": "1",
+        "series": "16",
+        "snaps": [
+            {
+                "id": "snap-id",
+                "name": "snap-name",
+                "presence": "required",
+                "revision": "42",
+            },
+        ],
+        "timestamp": "2020-10-29T16:36:56Z",
+        "type": "validation-set",
+    }

--- a/tests/spread/store/basic-workflow/task.yaml
+++ b/tests/spread/store/basic-workflow/task.yaml
@@ -1,6 +1,4 @@
-summary: Test the store workflow
-
-manual: true
+summary: Test the store workflow to register, upload, and release a snap
 
 environment:
   # use a core22 snap with components but no component hooks
@@ -9,10 +7,6 @@ environment:
   SNAPCRAFT_STORE_CREDENTIALS/ubuntu_one: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"
   SNAPCRAFT_STORE_CREDENTIALS/legacy: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_LEGACY})"
   SNAPCRAFT_STORE_CREDENTIALS/candid: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_CANDID})"
-  STORE_DASHBOARD_URL: https://dashboard.staging.snapcraft.io
-  STORE_API_URL: https://api.staging.snapcraft.io
-  STORE_UPLOAD_URL: https://storage.staging.snapcraftcontent.com
-  UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com
 
 prepare: |
   if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then

--- a/tests/spread/store/validation-sets/editor.sh
+++ b/tests/spread/store/validation-sets/editor.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+validation_set_file="$1"
+
+# flip-flop between two valid revisions of `test-snapcraft-assertions` in the staging store: 1 and 2
+if grep -q "^  revision:.*1" "$validation_set_file"; then
+  (( revision=2 ))
+else
+  (( revision=1 ))
+fi
+
+sed -i "s/  revision:.*/  revision: $revision/g" "$validation_set_file"

--- a/tests/spread/store/validation-sets/task.yaml
+++ b/tests/spread/store/validation-sets/task.yaml
@@ -1,0 +1,41 @@
+summary: test the validation-set commands
+
+environment:
+  SNAPCRAFT_ASSERTION_KEY: "$(HOST: echo ${SNAPCRAFT_ASSERTION_KEY})"
+  SNAPCRAFT_STORE_CREDENTIALS: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"
+
+prepare: |
+  if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then
+    ERROR "No credentials set in env SNAPCRAFT_STORE_CREDENTIALS"
+  fi
+
+  if [[ -z "$SNAPCRAFT_ASSERTION_KEY" ]]; then
+    ERROR "No gpg key set in env SNAPCRAFT_ASSERTION_KEY"
+  fi
+
+  # setup snap gpg dir
+  mkdir -p "$HOME/.snap/gnupg"
+  chmod 700 "$HOME/.snap/gnupg"
+
+  # import a registered key
+  echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode > store-key.txt
+  gpg --homedir "$HOME/.snap/gnupg" --import store-key.txt
+  rm -f store-key.txt
+
+  snap install yq
+
+execute: |
+  # ensure snapcraft is logged in and can access the store
+  snapcraft whoami
+
+  # snapcraft will use a fake file editor
+  export EDITOR="$PWD/editor.sh"
+
+  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name testspreadkey
+
+  snapcraft list-validation-sets | MATCH testset
+
+restore: |
+  rm -rf "$HOME/.snap/gnupg"
+
+  snap remove --purge yq

--- a/tests/unit/commands/test_validation_sets.py
+++ b/tests/unit/commands/test_validation_sets.py
@@ -32,63 +32,71 @@ from tests.unit.store.utils import FakeResponse
 # Fixtures #
 ############
 
-
-@pytest.fixture
-def validation_sets_payload():
-    return validation_sets.ValidationSets.unmarshal(
+VALIDATION_SET_DATA = {
+    "assertions": [
         {
-            "assertions": [
-                {
-                    "headers": {
-                        "account-id": "AccountIDXXXOfTheRequestingUserX",
-                        "authority-id": "AccountIDXXXOfTheRequestingUserX",
-                        "name": "certification-x1",
-                        "revision": "222",
-                        "sequence": "9",
-                        "series": "16",
-                        "sign-key-sha3-384": "XSignXKeyXHashXXXXXXXXXXX",
-                        "snaps": [
-                            {
-                                "id": "XXSnapIDForXSnapName1XXXXXXXXXXX",
-                                "name": "snap-name-1",
-                                "presence": "optional",
-                            },
-                            {
-                                "id": "XXSnapIDForXSnapName2XXXXXXXXXXX",
-                                "name": "snap-name-2",
-                            },
-                        ],
-                        "timestamp": "2020-10-29T16:36:56Z",
-                        "type": "validation-set",
-                    }
-                },
-            ]
-        }
+            "headers": {
+                "account-id": "AccountIDXXXOfTheRequestingUserX",
+                "authority-id": "AccountIDXXXOfTheRequestingUserX",
+                "name": "certification-x1",
+                "revision": "222",
+                "sequence": "9",
+                "series": "16",
+                "sign-key-sha3-384": "XSignXKeyXHashXXXXXXXXXXX",
+                "snaps": [
+                    {
+                        "id": "XXSnapIDForXSnapName1XXXXXXXXXXX",
+                        "name": "snap-name-1",
+                        "presence": "optional",
+                        "revision": "10",
+                    },
+                    {
+                        "id": "XXSnapIDForXSnapName2XXXXXXXXXXX",
+                        "name": "snap-name-2",
+                    },
+                ],
+                "timestamp": "2020-10-29T16:36:56Z",
+                "type": "validation-set",
+            }
+        },
+    ]
+}
+
+
+@pytest.fixture
+def fake_validation_sets():
+    return validation_sets.ValidationSets.unmarshal(VALIDATION_SET_DATA)
+
+
+@pytest.fixture()
+def fake_build_assertion():
+    return validation_sets.BuildAssertion.unmarshal(
+        VALIDATION_SET_DATA["assertions"][0]["headers"]
     )
 
 
 @pytest.fixture
-def fake_dashboard_post_validation_sets(validation_sets_payload, mocker):
+def fake_dashboard_post_validation_sets(fake_validation_sets, mocker):
     return mocker.patch.object(
-        StoreClientCLI, "post_validation_sets", return_value=validation_sets_payload
+        StoreClientCLI, "post_validation_sets", return_value=fake_validation_sets
     )
 
 
 @pytest.fixture
-def fake_dashboard_post_validation_sets_build_assertion(
-    validation_sets_payload, mocker
-):
+def fake_dashboard_post_validation_sets_build_assertion(fake_validation_sets, mocker):
     return mocker.patch.object(
         StoreClientCLI,
         "post_validation_sets_build_assertion",
-        return_value=validation_sets_payload.assertions[0],
+        return_value=validation_sets.BuildAssertion.unmarshal(
+            VALIDATION_SET_DATA["assertions"][0]["headers"]
+        ),
     )
 
 
 @pytest.fixture
-def fake_dashboard_get_validation_sets(validation_sets_payload, mocker):
+def fake_dashboard_get_validation_sets(fake_validation_sets, mocker):
     return mocker.patch.object(
-        StoreClientCLI, "get_validation_sets", return_value=validation_sets_payload
+        StoreClientCLI, "get_validation_sets", return_value=fake_validation_sets
     )
 
 
@@ -104,19 +112,22 @@ def fake_snap_sign(mocker):
 
 @pytest.fixture
 def edit_return_value():
-    return {
-        "account-id": "AccountIDXXXOfTheRequestingUserX",
-        "name": "certification-x1",
-        "sequence": "9",
-        "snaps": [
-            {
-                "id": "XXSnapIDForXSnapName1XXXXXXXXXXX",
-                "name": "snap-name-1",
-                "presence": "required",
-            },
-            {"id": "XXSnapIDForXSnapName2XXXXXXXXXXX", "name": "snap-name-2"},
-        ],
-    }
+    return validation_sets.EditableBuildAssertion.unmarshal(
+        {
+            "account-id": "AccountIDXXXOfTheRequestingUserX",
+            "name": "certification-x1",
+            "sequence": "9",
+            "snaps": [
+                {
+                    "id": "XXSnapIDForXSnapName1XXXXXXXXXXX",
+                    "name": "snap-name-1",
+                    "presence": "required",
+                    "revision": "10",
+                },
+                {"id": "XXSnapIDForXSnapName2XXXXXXXXXXX", "name": "snap-name-2"},
+            ],
+        }
+    )
 
 
 @pytest.fixture
@@ -137,12 +148,13 @@ EXPECTED_BUILD_ASSERTION_CALL = call(
     validation_sets={
         "account-id": "AccountIDXXXOfTheRequestingUserX",
         "name": "certification-x1",
-        "sequence": "9",
+        "sequence": 9,
         "snaps": [
             {
                 "name": "snap-name-1",
                 "id": "XXSnapIDForXSnapName1XXXXXXXXXXX",
                 "presence": "required",
+                "revision": 10,
             },
             {"name": "snap-name-2", "id": "XXSnapIDForXSnapName2XXXXXXXXXXX"},
         ],
@@ -150,13 +162,12 @@ EXPECTED_BUILD_ASSERTION_CALL = call(
 )
 
 EXPECTED_SIGNED_VALIDATION_SETS = (
-    '{{"account-id": "AccountIDXXXOfTheRequestingUserX", "authority-id": '
-    '"AccountIDXXXOfTheRequestingUserX", "name": "certification-x1", '
-    '"revision": "222", "sequence": "9", "snaps": [{{"name": "snap-name-1", '
-    '"id": "XXSnapIDForXSnapName1XXXXXXXXXXX", "presence": "optional"}}, '
+    '{{"account-id": "AccountIDXXXOfTheRequestingUserX", "name": "certification-x1", '
+    '"revision": "222", "sequence": "9", "snaps": [{{"name": "snap-name-1", "id": '
+    '"XXSnapIDForXSnapName1XXXXXXXXXXX", "presence": "optional", "revision": "10"}}, '
     '{{"name": "snap-name-2", "id": "XXSnapIDForXSnapName2XXXXXXXXXXX"}}], '
-    '"timestamp": "2020-10-29T16:36:56Z", "type": "validation-set", '
-    '"series": "16"}}\n\nSIGNED{key_name}'
+    '"authority-id": "AccountIDXXXOfTheRequestingUserX", "series": "16", "timestamp": '
+    '"2020-10-29T16:36:56Z", "type": "validation-set"}}\n\nSIGNED{key_name}'
 )
 
 
@@ -176,8 +187,8 @@ def test_edit_validation_sets_with_no_changes_to_existing_set(
     emitter,
 ):
     # Make it look like there were no edits.
-    edit_return_value["sequence"] = 9
-    edit_return_value["snaps"][0]["presence"] = "optional"
+    edit_return_value.sequence = 9
+    edit_return_value.snaps[0].presence = "optional"
     fake_edit_validation_sets.return_value = edit_return_value
 
     cmd = commands.StoreEditValidationSetsCommand(None)
@@ -203,7 +214,8 @@ def test_edit_validation_sets_with_no_changes_to_existing_set(
 @pytest.mark.usefixtures("memory_keyring", "fake_edit_validation_sets")
 @pytest.mark.parametrize("key_name", [None, "general", "main"])
 def test_edit_validation_sets_with_changes_to_existing_set(
-    validation_sets_payload,
+    fake_validation_sets,
+    fake_build_assertion,
     fake_dashboard_get_validation_sets,
     fake_dashboard_post_validation_sets_build_assertion,
     fake_dashboard_post_validation_sets,
@@ -232,11 +244,11 @@ def test_edit_validation_sets_with_changes_to_existing_set(
             signed_validation_sets=EXPECTED_SIGNED_VALIDATION_SETS.format(
                 key_name=key_name
             ).encode()
-        )
+        ),
     ]
     assert fake_snap_sign.mock_calls == [
         call(
-            validation_sets_payload.assertions[0].marshal(),
+            fake_build_assertion.marshal_scalars_as_strings(),
             key_name=key_name,
         )
     ]
@@ -244,7 +256,8 @@ def test_edit_validation_sets_with_changes_to_existing_set(
 
 @pytest.mark.usefixtures("memory_keyring", "fake_edit_validation_sets")
 def test_edit_validation_sets_with_errors_to_amend(
-    validation_sets_payload,
+    fake_validation_sets,
+    fake_build_assertion,
     fake_dashboard_get_validation_sets,
     fake_dashboard_post_validation_sets_build_assertion,
     fake_dashboard_post_validation_sets,
@@ -260,7 +273,7 @@ def test_edit_validation_sets_with_errors_to_amend(
                 ).encode(),
             )
         ),
-        validation_sets_payload.assertions[0],
+        fake_build_assertion,
     ]
     confirm_mock = mocker.patch("snapcraft.utils.confirm_with_user", return_value=True)
 
@@ -291,7 +304,7 @@ def test_edit_validation_sets_with_errors_to_amend(
     ]
     assert fake_snap_sign.mock_calls == [
         call(
-            validation_sets_payload.assertions[0].marshal(),
+            fake_build_assertion.marshal_scalars_as_strings(),
             key_name=None,
         )
     ]
@@ -300,7 +313,7 @@ def test_edit_validation_sets_with_errors_to_amend(
 
 @pytest.mark.usefixtures("memory_keyring", "fake_edit_validation_sets")
 def test_edit_validation_sets_with_errors_not_amended(
-    validation_sets_payload,
+    fake_validation_sets,
     fake_dashboard_get_validation_sets,
     fake_dashboard_post_validation_sets_build_assertion,
     fake_dashboard_post_validation_sets,
@@ -344,20 +357,52 @@ def test_edit_validation_sets_with_errors_not_amended(
 
 def test_edit_yaml_error_retry(mocker, tmp_path, monkeypatch):
     monkeypatch.setenv("EDITOR", "faux-vi")
-
     tmp_file = tmp_path / "validation_sets_template"
     confirm_mock = mocker.patch("snapcraft.utils.confirm_with_user", return_value=True)
-    data_write = [
-        "{good: yaml}",
-        "{{bad yaml {{",
-    ]
+    expected_edited_assertion = validation_sets.EditableBuildAssertion.unmarshal(
+        {
+            "account-id": "test",
+            "name": "test",
+            "sequence": 1,
+            "snaps": [{"name": "core22"}],
+        }
+    )
+    good_yaml = "{'account-id': 'test', 'name': 'test', 'sequence': 1, 'snaps': [{'name': 'core22'}]}"
+    bad_yaml = f"badyaml}} {good_yaml}"
+    data_write = [good_yaml, bad_yaml]
 
     def side_effect(*args, **kwargs):
         tmp_file.write_text(data_write.pop(), encoding="utf-8")
 
     subprocess_mock = mocker.patch("subprocess.run", side_effect=side_effect)
 
-    assert edit_validation_sets(tmp_file) == {"good": "yaml"}
+    assert edit_validation_sets(tmp_file) == expected_edited_assertion
+    assert confirm_mock.mock_calls == [call("Do you wish to amend the validation set?")]
+    assert subprocess_mock.mock_calls == [call(["faux-vi", tmp_file], check=True)] * 2
+
+
+def test_edit_pydantic_error_retry(mocker, tmp_path, monkeypatch):
+    monkeypatch.setenv("EDITOR", "faux-vi")
+    tmp_file = tmp_path / "validation_sets_template"
+    confirm_mock = mocker.patch("snapcraft.utils.confirm_with_user", return_value=True)
+    expected_edited_assertion = validation_sets.EditableBuildAssertion.unmarshal(
+        {
+            "account-id": "test",
+            "name": "test",
+            "sequence": 1,
+            "snaps": [{"name": "core22"}],
+        }
+    )
+    good_yaml = "{'account-id': 'test', 'name': 'test', 'sequence': 1, 'snaps': [{'name': 'core22'}]}"
+    bad_yaml = "{'invalid-field': 'test'}"
+    data_write = [good_yaml, bad_yaml]
+
+    def side_effect(*args, **kwargs):
+        tmp_file.write_text(data_write.pop(), encoding="utf-8")
+
+    subprocess_mock = mocker.patch("subprocess.run", side_effect=side_effect)
+
+    assert edit_validation_sets(tmp_file) == expected_edited_assertion
     assert confirm_mock.mock_calls == [call("Do you wish to amend the validation set?")]
     assert subprocess_mock.mock_calls == [call(["faux-vi", tmp_file], check=True)] * 2
 

--- a/tests/unit/parts/plugins/test_kernel.py
+++ b/tests/unit/parts/plugins/test_kernel.py
@@ -1919,7 +1919,7 @@ _finalize_install_cmd = [
         # but snapd expects modules/ and firmware/
         mv ${CRAFT_PART_INSTALL}/lib/modules ${CRAFT_PART_INSTALL}/
         # remove symlinks modules/*/build and modules/*/source
-        rm ${CRAFT_PART_INSTALL}/modules/*/build ${CRAFT_PART_INSTALL}/modules/*/source
+        rm -f ${CRAFT_PART_INSTALL}/modules/*/build ${CRAFT_PART_INSTALL}/modules/*/source
         # if there is firmware dir, move it to snap root
         # this could have been from stage packages or from kernel build
         [ -d ${CRAFT_PART_INSTALL}/lib/firmware ] && mv ${CRAFT_PART_INSTALL}/lib/firmware ${CRAFT_PART_INSTALL}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Snapcraft 8.4 is delayed due to https://github.com/canonical/snapcraft/pull/4884 and https://forum.snapcraft.io/t/kde-global-auto-connect-qt-common-themes/40878/15.

In the interim, we need an 8.3.2 release.

This PR cherry-picks 2 hotfixes and 2 test updates from `main`.  The test updates will fix the failing CI in https://github.com/canonical/snapcraft/pull/4946.