### PR TITLE
tests: update spread tests in hotfix/7.5

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   cla-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   cla-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - if: steps.decisions.outputs.PUBLISH == 'true'
         name: Checkout Snapcraft
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch all of history so Snapcraft can determine its own version from git.
           fetch-depth: 0

--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -24,7 +24,7 @@ jobs:
           path: ${{ steps.snapcraft.outputs.snap }}
 
   kernel-plugins:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: [snap-build]
     strategy:
       fail-fast: false
@@ -47,4 +47,4 @@ jobs:
           name: snap
       - name: Kernel plugin test
         run: |
-          spread google:ubuntu-22.04-64:tests/spread/plugin/${{ matrix.type }}/kernel
+          spread google:ubuntu-22.04-64:tests/spread/plugins/${{ matrix.type }}/kernel

--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build snap
         uses: snapcore/action-build@v1
         id: snapcraft
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
@@ -37,12 +37,12 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
       - name: Checkout snapcraft
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
       - name: Download snap artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snap
       - name: Kernel plugin test

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout snapcraft
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -17,7 +17,7 @@ jobs:
         uses: snapcore/action-build@v1
 
       - name: Upload snapcraft snap
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snap
           path: ${{ steps.build-snapcraft.outputs.snap }}
@@ -44,13 +44,13 @@ jobs:
 
     steps:
       - name: Checkout snapcraft
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Download snapcraft snap
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snap
           path: tests
@@ -94,14 +94,14 @@ jobs:
 
       - if: steps.decisions.outputs.RUN == 'true'
         name: Checkout snapcraft
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
       - if: steps.decisions.outputs.RUN == 'true'
         name: Download snapcraft snap
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: snap
           path: tests

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -27,7 +27,7 @@ jobs:
           sudo snap install --dangerous --classic ${{ steps.build-snapcraft.outputs.snap }}
 
   integration-spread-tests:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: build
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
@@ -70,7 +70,7 @@ jobs:
           done
 
   integration-spread-tests-store:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: build
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -57,11 +57,11 @@ jobs:
             tox_python: py310
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python version ${{ matrix.python_version }} on ${{ matrix.platform }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install dependencies
@@ -87,7 +87,7 @@ jobs:
           files: coverage*.xml
       - name: Upload test results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.platform }}
           path: results/

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Tox environments
         run: tox run-parallel --parallel auto --parallel-no-spinner --parallel-live -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }} --notest
       - name: Test with tox
-        run: tox run --skip-pkg-install --result-json results/tox-${{ matrix.platform }}.json -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }}
+        run: tox run --skip-pkg-install --result-json results/tox-${{ matrix.platform }}-${{ matrix.python_version }}.json -e test-${{ matrix.tox_python }},test-legacy-${{ matrix.tox_python }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
         with:
@@ -89,5 +89,5 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.platform }}
+          name: test-results-${{ matrix.platform }}-${{ matrix.python_version }}
           path: results/

--- a/spread.yaml
+++ b/spread.yaml
@@ -313,11 +313,6 @@ suites:
    systems:
      - ubuntu-22.04*
 
- tests/spread/core24/:
-   summary: core24 tests
-   systems:
-     - ubuntu-22.04*
-
  # General, core suite
  tests/spread/general/:
    summary: tests of snapcraft core functionality

--- a/spread.yaml
+++ b/spread.yaml
@@ -339,10 +339,11 @@ suites:
  tests/spread/general/hooks/:
    summary: tests of snapcraft hook functionality
 
- tests/spread/core-devel/:
-   summary: tests of devel base snaps
-   environment:
-     SNAPCRAFT_BUILD_ENVIRONMENT: ""
+# 'build-base: devel' fails due to an issue with the 24.10 buildd image (#4921)
+# tests/spread/core-devel/:
+#   summary: tests of devel base snaps
+#   environment:
+#     SNAPCRAFT_BUILD_ENVIRONMENT: ""
 
  # General, core suite
  tests/spread/cross-compile/:

--- a/tests/spread/core22/package-repositories/test-multi-keys/snap/snapcraft.yaml
+++ b/tests/spread/core22/package-repositories/test-multi-keys/snap/snapcraft.yaml
@@ -14,10 +14,6 @@ parts:
     stage-packages:
       - test-ppa
       - puppet-tools-release # Comes from the Puppet repo
-    override-build: |
-      craftctl default
-      # This file comes from the puppet-tools-release package.
-      test -f ${CRAFT_PART_INSTALL}/usr/share/doc/puppet-tools-release/bill-of-materials
 
 apps:
     test-ppa:

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/electron-builder.yml
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/electron-builder.yml
@@ -1,4 +1,5 @@
 snap:
+ base: core18
  confinement: strict
  buildPackages:
  - jq

--- a/tests/spread/electron-builder/no-template/task.yaml
+++ b/tests/spread/electron-builder/no-template/task.yaml
@@ -12,7 +12,7 @@ environment:
   SNAPCRAFT_BUILD_INFO: "1"
 
 prepare: |
-  snap install node --classic
+  snap install node --classic --channel "19/stable"
 
 restore: |
   snap remove node

--- a/tests/spread/plugins/craft-parts/build-and-run-hello/flutter-hello/lib/main.dart
+++ b/tests/spread/plugins/craft-parts/build-and-run-hello/flutter-hello/lib/main.dart
@@ -100,7 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
           ],
         ),

--- a/tests/spread/plugins/v1/flutter/run/task.yaml
+++ b/tests/spread/plugins/v1/flutter/run/task.yaml
@@ -3,7 +3,8 @@ summary: Build and run a basic snap using the flutter plugin and extension
 kill-timeout: 30m
 
 environment:
-  FLUTTER/dev: dev
+  # fails due to upstream bug: https://github.com/flutter/flutter/issues/133881
+  # FLUTTER/dev: dev
   FLUTTER/master: master
   FLUTTER/beta: beta
   FLUTTER/stable: stable

--- a/tests/spread/plugins/v1/flutter/snaps/flutter_hello/lib/main.dart
+++ b/tests/spread/plugins/v1/flutter/snaps/flutter_hello/lib/main.dart
@@ -100,7 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
           ],
         ),

--- a/tests/spread/plugins/v1/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
+++ b/tests/spread/plugins/v1/ruby/snaps/ruby-bundle-install/snap/snapcraft.yaml
@@ -16,6 +16,8 @@ parts:
     plugin: ruby
     source: .
     use-bundler: true
-    ruby-version: "2.6.10" # bundler requires ruby >= 2.6.0
+    ruby-version: "3.3.4" # bundler requires ruby >= 3.0.0
     build-environment:
       - BUNDLE_GEMFILE: "$SNAPCRAFT_PART_SRC/Gemfile"
+    build-packages:
+      - libyaml-dev

--- a/tox.ini
+++ b/tox.ini
@@ -81,8 +81,9 @@ env_dir = {work_dir}/linting
 runner = ignore_env_name_mismatch
 
 [shellcheck]
-find = git ls-files
-filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
+find = git ls-files --empty-directory --deduplicate
+filter = file --mime-type -Nnf- | grep shellscript$ | cut -f1 -d:
+spread_filter = grep -E "^tests/spread/.*(spread|task)\.yaml$"
 
 [testenv:lint-{black,ruff,docstyle,isort,shellcheck,codespell,yaml}]
 description = Lint the source code
@@ -92,6 +93,7 @@ allowlist_externals =
     shellcheck: bash, xargs
 commands_pre =
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
+    shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]spread_filter} > {env_tmp_dir}/spread_shellcheck_files'
 commands =
     black: black --check --diff {tty:--color} {posargs} .
     ruff: ruff --diff --respect-gitignore setup.py snapcraft tests tools
@@ -99,7 +101,7 @@ commands =
     isort: isort --check snapcraft snapcraft_legacy tests setup.py tools
     docstyle: pydocstyle snapcraft
     shellcheck: xargs -ra {env_tmp_dir}/shellcheck_files shellcheck
-    shellcheck: python3 tools/spread-shellcheck.py spread.yaml tests/spread/
+    shellcheck: xargs -ra {env_tmp_dir}/spread_shellcheck_files python3 tools/spread-shellcheck.py spread.yaml
     codespell: codespell --toml {tox_root}/pyproject.toml {posargs}
     yaml: yamllint {posargs} .
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

6 cherry-picks and 6 new commits to repair CI and spread tests in `hotfix/7.5`.

The readthedocs CI failure is expected as Snapcraft 7 predates readthedocs integration.

Unblocks #4950 and #4936
Unblocks CRAFT-3189