### PR TITLE
remote-build: add "Pending" as a possible status output

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -257,6 +257,7 @@ class RemoteBuildCommand(ExtensibleCommand):
                 building: set[str] = set()
                 succeeded: set[str] = set()
                 uploading: set[str] = set()
+                pending: set[str] = set()
                 not_building: set[str] = set()
                 for arch, build_state in states.items():
                     if build_state.is_running:
@@ -265,6 +266,8 @@ class RemoteBuildCommand(ExtensibleCommand):
                         succeeded.add(arch)
                     elif build_state == BuildState.UPLOADING:
                         uploading.add(arch)
+                    elif build_state == BuildState.PENDING:
+                        pending.add(arch)
                     else:
                         not_building.add(arch)
                 progress_parts: list[str] = []
@@ -276,6 +279,8 @@ class RemoteBuildCommand(ExtensibleCommand):
                     progress_parts.append("Uploading: " + ",".join(sorted(uploading)))
                 if succeeded:
                     progress_parts.append("Succeeded: " + ", ".join(sorted(succeeded)))
+                if pending:
+                    progress_parts.append("Pending: " + ", ".join(sorted(pending)))
                 emit.progress("; ".join(progress_parts))
         except TimeoutError:
             if build_id:

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -743,6 +743,7 @@ def test_monitor_build(mocker, emitter, snapcraft_yaml, base, fake_services):
                 {"amd64": launchpad.models.BuildState.PENDING},
                 {"amd64": launchpad.models.BuildState.BUILDING},
                 {"amd64": launchpad.models.BuildState.UPLOADING},
+                {"amd64": launchpad.models.BuildState.SUPERSEDED},
                 {"amd64": launchpad.models.BuildState.SUCCESS},
             ]
         ],
@@ -774,9 +775,10 @@ def test_monitor_build(mocker, emitter, snapcraft_yaml, base, fake_services):
     mock_fetch_artifacts.assert_called_once()
     mock_cleanup.assert_called_once()
 
-    emitter.assert_progress("Stopped: amd64")
+    emitter.assert_progress("Pending: amd64")
     emitter.assert_progress("Building: amd64")
     emitter.assert_progress("Uploading: amd64")
+    emitter.assert_progress("Stopped: amd64")
     emitter.assert_progress("Succeeded: amd64")
 
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Currently, remote-build status goes from "Uploading" to "Stopped".
`BuildState` has a PENDING state that is set but not checked for. Going
from "Uploading" to "Pending" improves status messages significantly.
The output could also say "Needs building" to match the web view, but
"Pending" is more in line with the other single-word outputs.
