### PR TITLE
fix(provider): forward proxy variables to core24 build environments

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==4.0.0
+craft-application==4.1.0
 craft-archives==2.0.0
 craft-cli==2.6.0
 craft-grammar==2.0.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -13,7 +13,7 @@ click==8.1.7
 codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
-craft-application==4.0.0
+craft-application==4.1.0
 craft-archives==2.0.0
 craft-cli==2.6.0
 craft-grammar==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.17.0
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==4.0.0
+craft-application==4.1.0
 craft-archives==2.0.0
 craft-cli==2.6.0
 craft-grammar==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ install_requires = [
     "attrs",
     "catkin-pkg; sys_platform == 'linux'",
     "click",
-    "craft-application~=4.0",
+    "craft-application~=4.1",
     "craft-archives~=2.0",
     "craft-cli~=2.6",
     "craft-grammar~=2.0",

--- a/snapcraft/const.py
+++ b/snapcraft/const.py
@@ -47,3 +47,13 @@ LEGACY_BASES = frozenset({"core20"})
 
 CURRENT_BASES = frozenset(BASES - ESM_BASES - LEGACY_BASES)
 """Bases handled by the current snapcraft codebase."""
+
+
+SNAPCRAFT_ENVIRONMENT_VARIABLES = frozenset(
+    {
+        "SNAPCRAFT_BUILD_INFO",
+        "SNAPCRAFT_IMAGE_INFO",
+        "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS",
+    }
+)
+"""Snapcraft-specific environment variables."""

--- a/snapcraft/services/provider.py
+++ b/snapcraft/services/provider.py
@@ -20,19 +20,16 @@ import os
 from craft_application import ProviderService
 from overrides import overrides
 
+from snapcraft.const import SNAPCRAFT_ENVIRONMENT_VARIABLES
+
 
 class Provider(ProviderService):
     """Snapcraft specialization of the Lifecycle Service."""
 
     @overrides
     def setup(self) -> None:
-        if build_info := os.getenv("SNAPCRAFT_BUILD_INFO"):
-            self.environment["SNAPCRAFT_BUILD_INFO"] = build_info
-        if image_info := os.getenv("SNAPCRAFT_IMAGE_INFO"):
-            self.environment["SNAPCRAFT_IMAGE_INFO"] = image_info
-        if experimental_extensions := os.getenv(
-            "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"
-        ):
-            self.environment["SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"] = (
-                experimental_extensions
-            )
+        """Add snapcraft environment variables to the build environment."""
+        super().setup()
+        for variable in SNAPCRAFT_ENVIRONMENT_VARIABLES:
+            if variable in os.environ:
+                self.environment[variable] = os.environ[variable]

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -16,15 +16,19 @@
 
 """Tests for the Snapcraft provider service."""
 
+from craft_application.services.provider import DEFAULT_FORWARD_ENVIRONMENT_VARIABLES
+
+from snapcraft.const import SNAPCRAFT_ENVIRONMENT_VARIABLES
+
 
 def test_provider(provider_service, monkeypatch):
-    monkeypatch.setenv("SNAPCRAFT_BUILD_INFO", "foo")
-    monkeypatch.setenv("SNAPCRAFT_IMAGE_INFO", "bar")
-    monkeypatch.setenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "baz")
-    provider_service.setup()
-    assert provider_service.environment["SNAPCRAFT_BUILD_INFO"] == "foo"
-    assert provider_service.environment["SNAPCRAFT_IMAGE_INFO"] == "bar"
-    assert (
-        provider_service.environment["SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"]
-        == "baz"
+    variables = SNAPCRAFT_ENVIRONMENT_VARIABLES | set(
+        DEFAULT_FORWARD_ENVIRONMENT_VARIABLES
     )
+    for variable in variables:
+        monkeypatch.setenv(variable, f"{variable}-test-value")
+
+    provider_service.setup()
+
+    for variable in variables:
+        assert provider_service.environment[variable] == f"{variable}-test-value"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

* Forward `http_proxy`, `https_proxy`, and `no_proxy` into core24 build environments
* Add a regression test
* Bump craft-application to 4.1.0