### PR TITLE
fix(remotebuild): parse '--build-for' and '--platform'

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -56,7 +56,8 @@ snaps.
 
 The legacy remote builder was deprecated because of its design. It retrieves
 and tarballs remote sources and modifies the project's ``snapcraft.yaml``
-file to point to the local tarballs.
+file to point to the local tarballs. This caused many unexpected failures that
+could not be reproduced locally.
 
 Choosing a remote-builder
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,36 +85,43 @@ Current
 ``--platform`` and ``--build-for``
 **********************************
 
-If  ``--platform`` or ``--build-for`` are provided, Snapcraft will:
+.. note::
+   ``--platform`` and ``--build-for`` behave differently than they do for
+   :ref:`lifecycle commands<reference-lifecycle-commands>`.
 
-#. parse the project metadata for ``platforms`` or ``architectures`` keywords
-#. create a build plan
-#. filter the build plan with whichever of ``--build-for`` or ``--platform``
-   was specified
+``--platform`` or ``--build-for`` can only be provided when the ``platforms``
+and ``architectures`` keywords are not defined in the project metadata
+(`[12]`_).
 
-``--build-for`` and ``--platform`` are mutually exclusive keywords.
+These keywords are mutually exclusive and must be a single debian architecture.
+A list of comma-separated architectures is not supported (`[11]`_).
 
-If a ``--build-for`` or ``--platform`` is provided that does not exist in the
-project metadata, Snapcraft will fail (`[1]`_).
-
-The ``--platform`` keyword applies to ``core22`` projects because Snapcraft
-will convert ``architectures`` entries to a ``platforms`` object by using the
-``build-for`` entry of the ``architectures`` entry as the platform name.
+``core22`` snaps can only use ``--build-for``. ``core24`` and newer snaps
+can use ``--platform`` or ``--build-for``.
 
 Project platforms and architectures
 ***********************************
 
 The ``snapcraft.yaml`` file is always parsed by the new remote builder.
 
+If the project metadata contains a ``platforms`` or ``architectures`` entry,
+Snapcraft will request a build for each unique ``build-for`` architecture.
+
+.. note::
+
+   Launchpad does not support cross-compiling (`[13]`_).
+
+.. note::
+
+    Launchpad does not support building multiple snaps on the same
+    ``build-on`` architecture (`[14]`_).
+
 If the project metadata does not contain a ``platforms`` or ``architectures``
 entry and no ``--build-for`` or ``--platform`` are passed, Snapcraft will
-request a build for the host's architecture.
+request a build on, and for, the host's architecture.
 
 The remote builder does not work for ``core20`` snaps because it cannot parse
 the ``run-on`` keyword in a ``core20`` architecture entry (`[2]`_).
-
-The remote builder does not work as expected for most ``platform`` definitions
-because Launchpad does not properly parse the entry (`[3]`_).
 
 Legacy
 ^^^^^^
@@ -164,9 +172,7 @@ Launchpad is not able to parse this notation (`[9]`_).
 .. _`Launchpad account`: https://launchpad.net/+login
 .. _`Launchpad`: https://launchpad.net/
 .. _`build farm`: https://launchpad.net/builders
-.. _`[1]`: https://github.com/canonical/snapcraft/issues/4881
 .. _`[2]`: https://github.com/canonical/snapcraft/issues/4842
-.. _`[3]`: https://github.com/canonical/snapcraft/issues/4858
 .. _`[4]`: https://github.com/canonical/snapcraft/issues/4341
 .. _`[5]`: https://bugs.launchpad.net/snapcraft/+bug/1885150
 .. _`[6]`: https://github.com/canonical/snapcraft/issues/4144
@@ -174,3 +180,7 @@ Launchpad is not able to parse this notation (`[9]`_).
 .. _`[8]`: https://bugs.launchpad.net/snapcraft/+bug/2007789
 .. _`[9]`: https://bugs.launchpad.net/snapcraft/+bug/2042167
 .. _`[10]`: https://github.com/canonical/snapcraft/issues/4885
+.. _`[11]`: https://github.com/canonical/snapcraft/issues/4990
+.. _`[12]`: https://github.com/canonical/snapcraft/issues/4992
+.. _`[13]`: https://github.com/canonical/snapcraft/issues/4996
+.. _`[14]`: https://github.com/canonical/snapcraft/issues/4995

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -5,6 +5,8 @@ Snapcraft commands
 
 .. include:: commands/toc.rst
 
+.. _reference-lifecycle-commands:
+
 Lifecycle
 ---------
 Lifecycle commands can take an optional parameter ``<part-name>``. When a part

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -54,6 +54,7 @@ APP_METADATA = AppMetadata(
     source_ignore_patterns=["*.snap"],
     project_variables=["version", "grade"],
     mandatory_adoptable_fields=["version", "summary", "description"],
+    docs_url="https://canonical-snapcraft.readthedocs-hosted.com/en/{version}",
 )
 
 

--- a/tests/spread/core24/remote-build/snaps/platforms/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/platforms/snapcraft.yaml
@@ -7,16 +7,20 @@ description: Test snap for remote build
 grade: stable
 confinement: strict
 
+# This does not test:
+# - multiple artefacts on the same build-on (#4995)
+# - cross-compiling (#4996)
+
 platforms:
   # implicit build-on and build-for
   amd64:
   # implicit build-for
-  armhf:
+  arm64:
     build-on: [arm64]
   # fully defined
-  arm64:
-    build-on: [amd64, arm64]
-    build-for: [arm64]
+  armhf:
+    build-on: [armhf]
+    build-for: [armhf]
 
 parts:
   my-part:

--- a/tests/spread/core24/remote-build/task.yaml
+++ b/tests/spread/core24/remote-build/task.yaml
@@ -8,9 +8,8 @@ systems:
 environment:
   LAUNCHPAD_TOKEN: "$(HOST: echo ${LAUNCHPAD_TOKEN})"
   SNAP: no-platforms
-  # launchpad can't parse `platforms` (https://github.com/canonical/snapcraft/issues/4858)
-  #SNAP/all: all
-  #SNAP/platforms: platforms
+  SNAP/all: all
+  SNAP/platforms: platforms
   SNAP/no_platforms: no-platforms
   CREDENTIALS_FILE: "$HOME/.local/share/snapcraft/launchpad-credentials"
   CREDENTIALS_FILE/new_credentials: "$HOME/.local/share/snapcraft/launchpad-credentials"

--- a/tests/unit/parts/test_lifecycle.py
+++ b/tests/unit/parts/test_lifecycle.py
@@ -25,13 +25,14 @@ import pydantic
 import pytest
 from craft_cli import EmitterMode, emit
 from craft_parts import Action, Features, ProjectInfo, Step, callbacks
+from craft_platforms import DebianArchitecture
 from craft_providers.bases.ubuntu import BuilddBaseAlias
 
 from snapcraft import errors
 from snapcraft.elf import ElfFile
 from snapcraft.models import MANDATORY_ADOPTABLE_FIELDS, Project
 from snapcraft.parts import lifecycle as parts_lifecycle
-from snapcraft.parts import set_global_environment
+from snapcraft.parts import set_global_environment, yaml_utils
 from snapcraft.parts.plugins import KernelPlugin, MatterSdkPlugin
 from snapcraft.parts.update_metadata import update_project_metadata
 from snapcraft.utils import get_host_architecture
@@ -146,7 +147,9 @@ def test_snapcraft_yaml_load(new_dir, snapcraft_yaml, filename, mocker):
         ),
     )
 
-    project = Project.unmarshal(yaml_data)
+    arch = DebianArchitecture.from_host().value
+    applied_yaml = yaml_utils.apply_yaml(yaml_data, arch, arch)
+    project = Project.unmarshal(applied_yaml)
 
     if filename == "build-aux/snap/snapcraft.yaml":
         assets_dir = Path("build-aux/snap")
@@ -198,7 +201,9 @@ def test_lifecycle_run_with_components(
         ),
     )
 
-    project = Project.unmarshal(yaml_data)
+    arch = DebianArchitecture.from_host().value
+    applied_yaml = yaml_utils.apply_yaml(yaml_data, arch, arch)
+    project = Project.unmarshal(applied_yaml)
 
     assert mock_run_command.mock_calls == [
         call(
@@ -247,7 +252,9 @@ def test_lifecycle_run_no_components(new_dir, snapcraft_yaml, mocker):
         ),
     )
 
-    project = Project.unmarshal(yaml_data)
+    arch = DebianArchitecture.from_host().value
+    applied_yaml = yaml_utils.apply_yaml(yaml_data, arch, arch)
+    project = Project.unmarshal(applied_yaml)
 
     assert mock_run_command.mock_calls == [
         call(


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

 * '--build-for' and '--platform' can only be used when 'platforms' and 'architectures' are not defined in the project metadata
* '--platform' cannot be used for core22 snaps
* Add links to documentation for remote-build errors
* Update remote-build documentation

Creates #4992
Fixes #4858 
Fixes #4881
(CRAFT-3070)