### PR TITLE
 ci: make snapcraft.yaml render as YAML in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -45,7 +45,7 @@ body:
         If possible, please paste your snapcraft.yaml contents. This
         will be automatically formatted into code, so no need for
         backticks.
-      render: shell
+      render: yaml
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
See: https://github.com/canonical/rockcraft/pull/684

- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
