### PR TITLE
fix(remotebuild): error early for multiple artifacts per build-on

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -117,6 +117,7 @@ pyramid==2.0.2
 pyRFC3339==1.1
 pyspelling==2.10
 pytest==8.3.2
+pytest-check==2.4.1
 pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-subprocess==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ dev_requires = [
     "pyramid",
     "pytest",
     "pytest-cov",
+    "pytest-check",
     "pytest-mock",
     "pytest-subprocess",
     "tox>=4.5",

--- a/tests/spread/core24/remote-build/snaps/platforms/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/platforms/snapcraft.yaml
@@ -8,7 +8,6 @@ grade: stable
 confinement: strict
 
 # This does not test:
-# - multiple artefacts on the same build-on (#4995)
 # - cross-compiling (#4996)
 
 platforms:

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -858,6 +858,7 @@ def test_platform_core22_error(
     ],
 )
 def test_multiple_artifacts_per_build_on(
+    check,
     base,
     build_info,
     error_messages,
@@ -879,12 +880,12 @@ def test_multiple_artifacts_per_build_on(
 
     _, err = capsys.readouterr()
 
-    assert (
-        "Remote build does not support building multiple snaps on the same architecture"
-        in err
+    check.is_in(
+        "Remote build does not support building multiple snaps on the same architecture",
+        err,
     )
     for message in error_messages:
-        assert message in err
+        check.is_in(message, err)
 
 
 ########################

--- a/tests/unit/commands/test_remote.py
+++ b/tests/unit/commands/test_remote.py
@@ -769,6 +769,124 @@ def test_platform_core22_error(
     assert "Use '--build-for' instead." in err
 
 
+@pytest.mark.parametrize(
+    ("base", "build_info", "error_messages"),
+    [
+        pytest.param(
+            "core22",
+            {
+                "architectures": [
+                    {"build-on": "amd64", "build-for": "amd64"},
+                    {"build-on": ["amd64", "riscv64"], "build-for": "riscv64"},
+                ],
+            },
+            ["Building on 'amd64' will create snaps for 'amd64' and 'riscv64'."],
+            id="core22-simple",
+        ),
+        pytest.param(
+            "core22",
+            {
+                "architectures": [
+                    {"build-on": "amd64", "build-for": "amd64"},
+                    {"build-on": ["amd64", "riscv64"], "build-for": "riscv64"},
+                    {"build-on": "s390x", "build-for": "s390x"},
+                    {"build-on": "s390x", "build-for": "ppc64el"},
+                ],
+            },
+            [
+                "Building on 'amd64' will create snaps for 'amd64' and 'riscv64'.",
+                "Building on 's390x' will create snaps for 'ppc64el' and 's390x'.",
+            ],
+            id="core22-complex",
+        ),
+        pytest.param(
+            "core24",
+            {
+                "platforms": {
+                    "platform1": {"build-on": "amd64", "build-for": "amd64"},
+                    "platform2": {
+                        "build-on": ["amd64", "riscv64"],
+                        "build-for": "riscv64",
+                    },
+                },
+            },
+            ["Building on 'amd64' will create snaps for 'amd64' and 'riscv64'."],
+            id="core24-simple",
+        ),
+        pytest.param(
+            "core24",
+            {
+                "platforms": {
+                    "platform1": {"build-on": "amd64", "build-for": "riscv64"},
+                    "identical-platform": {"build-on": "amd64", "build-for": "riscv64"},
+                },
+            },
+            # this will show 'riscv64' twice because the platform name is different
+            ["Building on 'amd64' will create snaps for 'riscv64' and 'riscv64'."],
+            id="core24-same-architectures-different-platform-name",
+        ),
+        pytest.param(
+            "core24",
+            {
+                "platforms": {
+                    "amd64": None,
+                    "riscv64": {"build-on": "amd64", "build-for": "riscv64"},
+                },
+            },
+            ["Building on 'amd64' will create snaps for 'amd64' and 'riscv64'."],
+            id="core24-shorthand",
+        ),
+        pytest.param(
+            "core24",
+            {
+                "platforms": {
+                    "platform1": {"build-on": "amd64", "build-for": "amd64"},
+                    "platform2": {
+                        "build-on": ["amd64", "s390x"],
+                        "build-for": "riscv64",
+                    },
+                    "s390x": None,
+                    "platform4": {"build-on": "s390x", "build-for": "riscv64"},
+                },
+            },
+            [
+                "Building on 'amd64' will create snaps for 'amd64' and 'riscv64'.",
+                "Building on 's390x' will create snaps for 'riscv64', 'riscv64', and 's390x'.",
+            ],
+            id="core24-complex",
+        ),
+    ],
+)
+def test_multiple_artifacts_per_build_on(
+    base,
+    build_info,
+    error_messages,
+    capsys,
+    mocker,
+    snapcraft_yaml,
+    fake_services,
+    mock_confirm,
+    mock_remote_builder_fake_build_process,
+):
+    """Error when multiple artifacts will be produced on one build-on architecture."""
+    snapcraft_yaml(**{"base": base, **build_info})
+    mocker.patch.object(sys, "argv", ["snapcraft", "remote-build"])
+    mocker.patch(
+        "craft_application.services.remotebuild.RemoteBuildService.start_builds"
+    )
+    app = application.create_app()
+    assert app.run() == os.EX_CONFIG
+
+    _, err = capsys.readouterr()
+
+    assert (
+        "Remote build does not support building multiple snaps on the same architecture"
+        in err
+    )
+    for message in error_messages:
+        assert message in err
+
+
 ########################
 # Remote builder tests #
 ########################


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Launchpad cannot build multiple artifacts on the same build-on architecture and will fail with an esoteric error. 

Snapcraft now checks for the scenario and fails with an informative error before the build begins.

Fixes #4995
(CRAFT-3279)