### PR TITLE
chore(revert): add content interfaces for qt-common-themes

### DIFF
--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -51,8 +51,6 @@ class KDENeon6(Extension):
     It configures each application with the following plugs:
 
     \b
-    - Common GTK themes.
-    - Common Qt themes.
     - Common Icon Themes.
     - Common Sound Themes.
     - The Qt6 and KDE Frameworks 6 runtime libraries and utilities.
@@ -153,50 +151,15 @@ class KDENeon6(Extension):
             "compression": "lzo",
             "plugs": {
                 "desktop": {"mount-host-font-cache": False},
-                "gtk-2-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/data-dir/themes",
-                    "default-provider": "gtk-common-themes",
-                },
-                "kde-gtk2-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/data-dir/themes",
-                    "default-provider": "qt-common-themes",
-                },
-                "kde-gtk3-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/data-dir/themes",
-                    "default-provider": "qt-common-themes",
-                },
-                "gtk-3-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/data-dir/themes",
-                    "default-provider": "gtk-common-themes",
-                },
-                "qt-icon-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/data-dir/icons",
-                    "default-provider": "qt-common-themes",
-                },
                 "icon-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/icons",
                     "default-provider": "gtk-common-themes",
                 },
-                "qt-sound-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/data-dir/sounds",
-                    "default-provider": "qt-common-themes",
-                },
                 "sound-themes": {
                     "interface": "content",
                     "target": "$SNAP/data-dir/sounds",
                     "default-provider": "gtk-common-themes",
-                },
-                "qt-6-themes": {
-                    "interface": "content",
-                    "target": "$SNAP/kf6",
-                    "default-provider": "qt-common-themes",
                 },
                 platform_kf6_snap: {
                     "content": content_kf6_snap,

--- a/tests/unit/extensions/test_kde_neon_6.py
+++ b/tests/unit/extensions/test_kde_neon_6.py
@@ -121,50 +121,15 @@ def test_get_root_snippet(kde_neon_6_extension):
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
-            "gtk-2-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "gtk-common-themes",
-            },
-            "kde-gtk2-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "qt-common-themes",
-            },
-            "kde-gtk3-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "qt-common-themes",
-            },
-            "gtk-3-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "gtk-common-themes",
-            },
-            "qt-icon-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/icons",
-                "default-provider": "qt-common-themes",
-            },
             "icon-themes": {
                 "interface": "content",
                 "target": "$SNAP/data-dir/icons",
                 "default-provider": "gtk-common-themes",
             },
-            "qt-sound-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/sounds",
-                "default-provider": "qt-common-themes",
-            },
             "sound-themes": {
                 "interface": "content",
                 "target": "$SNAP/data-dir/sounds",
                 "default-provider": "gtk-common-themes",
-            },
-            "qt-6-themes": {
-                "interface": "content",
-                "target": "$SNAP/kf6",
-                "default-provider": "qt-common-themes",
             },
             "kf6-core22": {
                 "content": "kf6-core22-all",
@@ -193,50 +158,15 @@ def test_get_root_snippet_with_external_sdk(kde_neon_6_extension_with_build_snap
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
-            "gtk-2-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "gtk-common-themes",
-            },
-            "kde-gtk2-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "qt-common-themes",
-            },
-            "kde-gtk3-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "qt-common-themes",
-            },
-            "gtk-3-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/themes",
-                "default-provider": "gtk-common-themes",
-            },
-            "qt-icon-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/icons",
-                "default-provider": "qt-common-themes",
-            },
             "icon-themes": {
                 "interface": "content",
                 "target": "$SNAP/data-dir/icons",
                 "default-provider": "gtk-common-themes",
             },
-            "qt-sound-themes": {
-                "interface": "content",
-                "target": "$SNAP/data-dir/sounds",
-                "default-provider": "qt-common-themes",
-            },
             "sound-themes": {
                 "interface": "content",
                 "target": "$SNAP/data-dir/sounds",
                 "default-provider": "gtk-common-themes",
-            },
-            "qt-6-themes": {
-                "interface": "content",
-                "target": "$SNAP/kf6",
-                "default-provider": "qt-common-themes",
             },
             "kf6-core22": {
                 "content": "kf6-core22-all",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

This is a temporary revert of #4884 for `hotfix/8.4` to allow releasing snapcraft 8.4.

See the discussion in #4884 and [this forum post](https://forum.snapcraft.io/t/kde-global-auto-connect-qt-common-themes/40878) for context.