### PR TITLE
feat(registries): add `list-registries` command

### DIFF
--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -55,7 +55,12 @@ Store snap tracks
 
 .. include:: commands/store-snap-tracks-commands.rst
 
-Store assertions
+Store validation sets
+---------------------
+
+.. include:: commands/store-validation-sets-commands.rst
+
+Store registries
 ----------------
 
-.. include:: commands/store-assertions-commands.rst
+.. include:: commands/store-registries-commands.rst

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -55,7 +55,7 @@ Store snap tracks
 
 .. include:: commands/store-snap-tracks-commands.rst
 
-Store validation sets
----------------------
+Store assertions
+----------------
 
-.. include:: commands/store-validation-sets-commands.rst
+.. include:: commands/store-assertions-commands.rst

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -132,12 +132,13 @@ COMMAND_GROUPS = [
         ],
     ),
     craft_cli.CommandGroup(
-        "Store Validation Sets",
+        "Store Assertions",
         [
             commands.StoreEditValidationSetsCommand,
             commands.StoreLegacyListValidationSetsCommand,
             commands.StoreLegacyValidateCommand,
             commands.StoreLegacyGatedCommand,
+            commands.StoreListRegistriesCommand,
         ],
     ),
     craft_cli.CommandGroup(

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -132,12 +132,17 @@ COMMAND_GROUPS = [
         ],
     ),
     craft_cli.CommandGroup(
-        "Store Assertions",
+        "Store Validation Sets",
         [
             commands.StoreEditValidationSetsCommand,
             commands.StoreLegacyListValidationSetsCommand,
             commands.StoreLegacyValidateCommand,
             commands.StoreLegacyGatedCommand,
+        ],
+    ),
+    craft_cli.CommandGroup(
+        "Store Registries",
+        [
             commands.StoreListRegistriesCommand,
         ],
     ),

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -52,6 +52,7 @@ from .names import (
     StoreRegisterCommand,
 )
 from .plugins import ListPluginsCommand, PluginsCommand
+from .registries import StoreListRegistriesCommand
 from .remote import RemoteBuildCommand
 from .status import (
     StoreListRevisionsCommand,
@@ -92,6 +93,7 @@ __all__ = [
     "StoreLegacyUploadMetadataCommand",
     "StoreLegacyValidateCommand",
     "StoreListRevisionsCommand",
+    "StoreListRegistriesCommand",
     "StoreListTracksCommand",
     "StoreLoginCommand",
     "StoreLogoutCommand",

--- a/snapcraft/commands/registries.py
+++ b/snapcraft/commands/registries.py
@@ -1,0 +1,65 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft Store Registry Sets commands."""
+
+import argparse
+import textwrap
+
+import craft_application.commands
+from typing_extensions import override
+
+from snapcraft import const, services
+
+
+class StoreListRegistriesCommand(craft_application.commands.AppCommand):
+    """List registries."""
+
+    name = "list-registries"
+    help_msg = "List registries"
+    overview = textwrap.dedent(
+        """
+        List registries for the authenticated account.
+        """
+    )
+    _services: services.SnapcraftServiceFactory  # type: ignore[reportIncompatibleVariableOverride]
+
+    @override
+    def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
+        parser.add_argument(
+            "--name",
+            metavar="name",
+            required=False,
+            type=str,
+            help="Name of registry set to list",
+        )
+        parser.add_argument(
+            "--format",
+            type=str,
+            choices=[
+                const.OutputFormat.table.value,
+                const.OutputFormat.json.value,
+            ],
+            help="The output format (table | json)",
+            default=const.OutputFormat.table,
+        )
+
+    @override
+    def run(self, parsed_args: "argparse.Namespace"):
+        self._services.registries.list_assertions(
+            name=parsed_args.name,
+            output_format=parsed_args.format,
+        )

--- a/snapcraft/commands/registries.py
+++ b/snapcraft/commands/registries.py
@@ -32,7 +32,13 @@ class StoreListRegistriesCommand(craft_application.commands.AppCommand):
     help_msg = "List registries"
     overview = textwrap.dedent(
         """
-        List registries for the authenticated account.
+        List all registries for the authenticated account.
+
+        Shows the account ID, name, revision, and last modified date of each registry.
+
+        If a name is provided, only the registry with that name will be listed.
+
+        Use the ``edit-registries`` command create and edit registries.
         """
     )
     _services: services.SnapcraftServiceFactory  # type: ignore[reportIncompatibleVariableOverride]
@@ -44,7 +50,7 @@ class StoreListRegistriesCommand(craft_application.commands.AppCommand):
             metavar="name",
             required=False,
             type=str,
-            help="Name of registry set to list",
+            help="Name of the registry to list",
         )
         parser.add_argument(
             "--format",

--- a/snapcraft/const.py
+++ b/snapcraft/const.py
@@ -36,6 +36,22 @@ class SnapArch(str, enum.Enum):
 
 SUPPORTED_ARCHS = frozenset(arch.value for arch in SnapArch)
 
+
+class OutputFormat(str, enum.Enum):
+    """Output formats for snapcraft commands."""
+
+    json = "json"
+    table = "table"
+
+    def __str__(self) -> str:
+        """Stringify the value."""
+        return str(self.value)
+
+
+OUTPUT_FORMATS = frozenset(output_format.value for output_format in OutputFormat)
+"""Supported output formats for commands."""
+
+
 BASES = frozenset({"core", "core18", "core20", "core22", "core24", "devel"})
 """All bases recognized by snapcraft."""
 

--- a/snapcraft/models/__init__.py
+++ b/snapcraft/models/__init__.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Data models for snapcraft."""
 
+from .assertions import Assertion, RegistryAssertion
 from .manifest import Manifest
 from .project import (
     MANDATORY_ADOPTABLE_FIELDS,
@@ -35,6 +36,7 @@ from .project import (
 
 __all__ = [
     "MANDATORY_ADOPTABLE_FIELDS",
+    "Assertion",
     "App",
     "Architecture",
     "ArchitectureProject",
@@ -47,6 +49,7 @@ __all__ = [
     "Manifest",
     "Platform",
     "Project",
+    "RegistryAssertion",
     "SnapcraftBuildPlanner",
     "Socket",
 ]

--- a/snapcraft/models/assertions.py
+++ b/snapcraft/models/assertions.py
@@ -1,0 +1,42 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Models for assertion sets."""
+
+from typing import Any, Literal
+
+from craft_application import models
+
+
+class RegistryAssertion(models.CraftBaseModel):
+    """Data model for a registry assertion."""
+
+    account_id: str
+    authority_id: str
+    body: dict[str, Any] | str | None = None
+    body_length: str | None = None
+    name: str
+    revision: int = 0
+    sign_key_sha3_384: str | None = None
+    summary: str | None = None
+    timestamp: str
+    type: Literal["registry"]
+    views: dict[str, Any]
+
+
+# this will be a union for validation sets and registries once
+# validation sets are migrated from the legacy codebase
+Assertion = RegistryAssertion

--- a/snapcraft/services/assertions.py
+++ b/snapcraft/services/assertions.py
@@ -1,0 +1,105 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Abstract service class for assertions."""
+
+from __future__ import annotations
+
+import abc
+import json
+from typing import Any
+
+import craft_cli
+import tabulate
+from craft_application.services import base
+from typing_extensions import override
+
+from snapcraft import const, errors, models, store
+
+
+class AssertionService(base.AppService):
+    """Abstract service for interacting with assertions."""
+
+    @override
+    def setup(self) -> None:
+        """Application-specific service setup."""
+        self._store_client = store.StoreClientCLI()
+        super().setup()
+
+    @property
+    @abc.abstractmethod
+    def _assertion_type(self) -> str:
+        """The pluralized name of the assertion type."""
+
+    @abc.abstractmethod
+    def _get_assertions(self, name: str | None = None) -> list[models.Assertion]:
+        """Get assertions from the store.
+
+        :param name: The name of the assertion to retrieve. If not provided, all
+          assertions are retrieved.
+
+        :returns: A list of assertions.
+        """
+
+    @abc.abstractmethod
+    def _normalize_assertions(
+        self, assertions: list[models.Assertion]
+    ) -> tuple[list[str], list[list[Any]]]:
+        """Convert a list of assertion models to a tuple of headers and data.
+
+        :param assertions: A list of assertions to normalize.
+
+        :returns: A tuple containing the headers and normalized assertions.
+        """
+
+    def list_assertions(self, *, output_format: str, name: str | None = None) -> None:
+        """List assertions from the store.
+
+        :param output_format: The output format to render.
+        :param name: The name of the assertion to list. If not provided, all assertions
+          are listed.
+
+        :raises FeatureNotImplemented: If the output format is not supported.
+        """
+        assertions = self._get_assertions(name)
+
+        if assertions:
+            headers, normalized_assertions = self._normalize_assertions(assertions)
+            match output_format:
+                case const.OutputFormat.json:
+                    json_assertions = {
+                        self._assertion_type.lower(): [
+                            {
+                                header.lower(): value
+                                for header, value in zip(headers, assertion)
+                            }
+                            for assertion in normalized_assertions
+                        ]
+                    }
+                    craft_cli.emit.message(json.dumps(json_assertions, indent=4))
+                case const.OutputFormat.table:
+                    tabulated_sets = tabulate.tabulate(
+                        normalized_assertions,
+                        headers=headers,
+                        tablefmt="plain",
+                    )
+                    craft_cli.emit.message(tabulated_sets)
+                case _:
+                    raise errors.FeatureNotImplemented(
+                        msg=f"'--format {output_format}'",
+                    )
+        else:
+            craft_cli.emit.message(f"No {self._assertion_type} found.")

--- a/snapcraft/services/registries.py
+++ b/snapcraft/services/registries.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Abstract service class for assertions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import override
+
+from snapcraft import models
+from snapcraft.services import AssertionService
+
+
+class RegistriesService(AssertionService):
+    """Service for interacting with registries."""
+
+    @property
+    @override
+    def _assertion_type(self) -> str:
+        """The pluralized name of the assertion type."""
+        return "registries"
+
+    @override
+    def _get_assertions(self, name: str | None = None) -> list[models.Assertion]:
+        """Get assertions from the store.
+
+        :param name: The name of the assertion to retrieve. If not provided, all
+          assertions are retrieved.
+
+        :returns: A list of assertions.
+        """
+        return self._store_client.list_registries(name=name)
+
+    @override
+    def _normalize_assertions(
+        self, assertions: list[models.Assertion]
+    ) -> tuple[list[str], list[list[Any]]]:
+        """Convert a list of assertion models to a tuple of headers and data.
+
+        :param assertions: A list of assertions to normalize.
+
+        :returns: A tuple containing the headers and normalized assertions.
+        """
+        headers = ["Account ID", "Name", "Revision", "When"]
+        registries = [
+            [
+                assertion.account_id,
+                assertion.name,
+                assertion.revision,
+                assertion.timestamp[:10],
+            ]
+            for assertion in assertions
+        ]
+
+        return headers, registries

--- a/snapcraft/services/service_factory.py
+++ b/snapcraft/services/service_factory.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from craft_application import ServiceFactory
 
@@ -44,3 +45,10 @@ class SnapcraftServiceFactory(ServiceFactory):
     RemoteBuildClass: type[  # type: ignore[reportIncompatibleVariableOverride]
         services.RemoteBuild
     ] = services.RemoteBuild
+    RegistriesClass: type[  # type: ignore[reportIncompatibleVariableOverride]
+        services.RegistriesService
+    ] = services.RegistriesService
+
+    if TYPE_CHECKING:
+        # Allow static type check to report correct types for Snapcraft services
+        registries: services.RegistriesService = None  # type: ignore[assignment]

--- a/tests/unit/commands/test_registries.py
+++ b/tests/unit/commands/test_registries.py
@@ -1,0 +1,60 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+import pytest
+
+from snapcraft import application, const
+
+
+@pytest.fixture
+def mock_list_assertions(mocker):
+    return mocker.patch(
+        "snapcraft.services.registries.RegistriesService.list_assertions"
+    )
+
+
+@pytest.mark.usefixtures("memory_keyring")
+@pytest.mark.parametrize("output_format", const.OUTPUT_FORMATS)
+@pytest.mark.parametrize("name", [None, "test"])
+def test_list_registries(mocker, mock_list_assertions, output_format, name):
+    """Test `snapcraft list-registries`."""
+    cmd = ["snapcraft", "list-registries", "--format", output_format]
+    if name:
+        cmd.extend(["--name", name])
+    mocker.patch.object(sys, "argv", cmd)
+
+    app = application.create_app()
+    app.run()
+
+    mock_list_assertions.assert_called_once_with(name=name, output_format=output_format)
+
+
+@pytest.mark.usefixtures("memory_keyring")
+@pytest.mark.parametrize("name", [None, "test"])
+def test_list_registries_default_format(mocker, mock_list_assertions, name):
+    """Default format is 'table'."""
+    """Test `snapcraft list-registries`."""
+    cmd = ["snapcraft", "list-registries"]
+    if name:
+        cmd.extend(["--name", name])
+    mocker.patch.object(sys, "argv", cmd)
+
+    app = application.create_app()
+    app.run()
+
+    mock_list_assertions.assert_called_once_with(name=name, output_format="table")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -531,6 +531,48 @@ def remote_build_service(default_factory, mocker):
 
 
 @pytest.fixture()
+def registries_service(default_factory, mocker):
+    from snapcraft.application import APP_METADATA
+    from snapcraft.services import RegistriesService
+
+    service = RegistriesService(app=APP_METADATA, services=default_factory)
+    service._store_client = mocker.patch(
+        "snapcraft.store.StoreClientCLI", autospec=True
+    )
+
+    return service
+
+
+@pytest.fixture()
+def fake_registry_assertion_data():
+    """Returns a dictionary of assertion data with required fields."""
+    from snapcraft.models import RegistryAssertion
+
+    def _assertion_data(**kwargs) -> dict[str, Any]:
+        return {
+            "account_id": "test-account-id",
+            "authority_id": "test-authority-id",
+            "name": "test-registry",
+            "timestamp": "2024-01-01T10:20:30Z",
+            "type": "registry",
+            "views": {
+                "wifi-setup": {
+                    "rules": [
+                        {
+                            "access": "read-write",
+                            "request": "ssids",
+                            "storage": "wifi.ssids",
+                        }
+                    ]
+                }
+            },
+            **kwargs,
+        }
+
+    return RegistryAssertion.unmarshal(_assertion_data())
+
+
+@pytest.fixture()
 def fake_services(
     default_factory, lifecycle_service, package_service, remote_build_service
 ):

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -14,22 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Snapcraft services."""
 
-from snapcraft.services.assertions import AssertionService
-from snapcraft.services.lifecycle import Lifecycle
-from snapcraft.services.package import Package
-from snapcraft.services.provider import Provider
-from snapcraft.services.registries import RegistriesService
-from snapcraft.services.remotebuild import RemoteBuild
-from snapcraft.services.service_factory import SnapcraftServiceFactory
+"""Tests for Assertion models."""
 
-__all__ = [
-    "AssertionService",
-    "Lifecycle",
-    "Package",
-    "Provider",
-    "RegistriesService",
-    "RemoteBuild",
-    "SnapcraftServiceFactory",
-]
+
+def test_assertion_defaults(fake_registry_assertion_data, check):
+    """Test default values of the RegistryAssertion model."""
+    check.equal(fake_registry_assertion_data.body, None)
+    check.equal(fake_registry_assertion_data.body_length, None)
+    check.equal(fake_registry_assertion_data.sign_key_sha3_384, None)
+    check.equal(fake_registry_assertion_data.summary, None)
+    check.equal(fake_registry_assertion_data.revision, 0)

--- a/tests/unit/services/test_assertions.py
+++ b/tests/unit/services/test_assertions.py
@@ -1,0 +1,121 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the abstract assertions service."""
+
+import textwrap
+from typing import Any
+
+import pytest
+from craft_application.models import CraftBaseModel
+from typing_extensions import override
+
+from snapcraft import const, errors
+
+
+class FakeAssertion(CraftBaseModel):
+    """Fake assertion model."""
+
+    test_field_1: str
+    test_field_2: int
+
+
+@pytest.fixture
+def mock_assertion_service(default_factory):
+    from snapcraft.application import APP_METADATA
+    from snapcraft.services import AssertionService
+
+    class FakeAssertionService(AssertionService):
+        @property
+        @override
+        def _assertion_type(self) -> str:
+            return "fake-assertions"
+
+        @override
+        def _get_assertions(  # type: ignore[override]
+            self, name: str | None = None
+        ) -> list[FakeAssertion]:
+            return [
+                FakeAssertion(test_field_1="test-value-1", test_field_2=0),
+                FakeAssertion(test_field_1="test-value-2", test_field_2=100),
+            ]
+
+        @override
+        def _normalize_assertions(  # type: ignore[override]
+            self, assertions: list[FakeAssertion]
+        ) -> tuple[list[str], list[list[Any]]]:
+            headers = ["test-field-1", "test-field-2"]
+            assertion_data = [
+                [
+                    assertion.test_field_1,
+                    assertion.test_field_2,
+                ]
+                for assertion in assertions
+            ]
+            return headers, assertion_data
+
+    return FakeAssertionService(app=APP_METADATA, services=default_factory)
+
+
+def test_list_assertions_table(mock_assertion_service, emitter):
+    """List assertions as a table."""
+    mock_assertion_service.list_assertions(
+        output_format=const.OutputFormat.table, name="test-registry"
+    )
+
+    emitter.assert_message(
+        textwrap.dedent(
+            """\
+            test-field-1      test-field-2
+            test-value-1                 0
+            test-value-2               100"""
+        )
+    )
+
+
+def test_list_assertions_json(mock_assertion_service, emitter):
+    """List assertions as json."""
+    mock_assertion_service.list_assertions(
+        output_format=const.OutputFormat.json, name="test-registry"
+    )
+
+    emitter.assert_message(
+        textwrap.dedent(
+            """\
+            {
+                "fake-assertions": [
+                    {
+                        "test-field-1": "test-value-1",
+                        "test-field-2": 0
+                    },
+                    {
+                        "test-field-1": "test-value-2",
+                        "test-field-2": 100
+                    }
+                ]
+            }"""
+        )
+    )
+
+
+def test_list_assertions_unknown_format(mock_assertion_service):
+    """Error for unknown formats."""
+    expected = "Command or feature not implemented: '--format unknown'"
+
+    with pytest.raises(errors.FeatureNotImplemented, match=expected):
+        mock_assertion_service.list_assertions(
+            output_format="unknown", name="test-registry"
+        )

--- a/tests/unit/services/test_registries.py
+++ b/tests/unit/services/test_registries.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the registries service."""
+
+
+def test_registries_service_type(registries_service):
+    assert registries_service._assertion_type == "registries"
+
+
+def test_get_assertions(registries_service):
+    registries_service._get_assertions("test-registry")
+
+    registries_service._store_client.list_registries.assert_called_once_with(
+        name="test-registry"
+    )
+
+
+def test_normalize_assertions_empty(registries_service, check):
+    headers, registries = registries_service._normalize_assertions([])
+
+    check.equal(headers, ["Account ID", "Name", "Revision", "When"])
+    check.equal(registries, [])
+
+
+def test_normalize_assertions(fake_registry_assertion_data, registries_service, check):
+    registries = [
+        fake_registry_assertion_data,
+        fake_registry_assertion_data.copy(
+            update={
+                "account_id": "test-account-id-2",
+                "name": "test-registry-2",
+                "revision": 100,
+                "timestamp": "2024-12-31",
+            }
+        ),
+    ]
+
+    headers, normalized_registries = registries_service._normalize_assertions(
+        registries
+    )
+
+    check.equal(headers, ["Account ID", "Name", "Revision", "When"])
+    check.equal(
+        normalized_registries,
+        [
+            ["test-account-id", "test-registry", 0, "2024-01-01"],
+            ["test-account-id-2", "test-registry-2", 100, "2024-12-31"],
+        ],
+    )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Add support for the `list-registries` command.

Fixes #5001 
(CRAFT-3295)