### PR TITLE
fix(remotebuild): parse comma-separated architectures

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -90,11 +90,11 @@ Current
    :ref:`lifecycle commands<reference-lifecycle-commands>`.
 
 ``--platform`` or ``--build-for`` can only be provided when the ``platforms``
-and ``architectures`` keywords are not defined in the project metadata
+or ``architectures`` keywords are not defined in the project metadata
 (`[12]`_).
 
-These keywords are mutually exclusive and must be a single debian architecture.
-A list of comma-separated architectures is not supported (`[11]`_).
+These keywords are mutually exclusive and must be a comma-separated list of
+debian architectures.
 
 ``core22`` snaps can only use ``--build-for``. ``core24`` and newer snaps
 can use ``--platform`` or ``--build-for``.
@@ -180,7 +180,6 @@ Launchpad is not able to parse this notation (`[9]`_).
 .. _`[8]`: https://bugs.launchpad.net/snapcraft/+bug/2007789
 .. _`[9]`: https://bugs.launchpad.net/snapcraft/+bug/2042167
 .. _`[10]`: https://github.com/canonical/snapcraft/issues/4885
-.. _`[11]`: https://github.com/canonical/snapcraft/issues/4990
 .. _`[12]`: https://github.com/canonical/snapcraft/issues/4992
 .. _`[13]`: https://github.com/canonical/snapcraft/issues/4996
 .. _`[14]`: https://github.com/canonical/snapcraft/issues/4995

--- a/tests/spread/core22/remote-build/snaps/build-for-arg/arguments.txt
+++ b/tests/spread/core22/remote-build/snaps/build-for-arg/arguments.txt
@@ -1,0 +1,1 @@
+--build-for amd64,s390x

--- a/tests/spread/core22/remote-build/snaps/build-for-arg/expected-snaps.txt
+++ b/tests/spread/core22/remote-build/snaps/build-for-arg/expected-snaps.txt
@@ -1,0 +1,2 @@
+test-snap-build-for-arg-core22_1.0_amd64.snap
+test-snap-build-for-arg-core22_1.0_s390x.snap

--- a/tests/spread/core22/remote-build/snaps/build-for-arg/snapcraft.yaml
+++ b/tests/spread/core22/remote-build/snaps/build-for-arg/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: test-snap-build-for-arg-core22
+base: core22
+version: "1.0"
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core22/remote-build/task.yaml
+++ b/tests/spread/core22/remote-build/task.yaml
@@ -8,6 +8,7 @@ environment:
   SNAP/all: all
   SNAP/no_architectures: no-architectures
   SNAP/architectures: architectures
+  SNAP/build_for_arg: build-for-arg
   SNAPCRAFT_REMOTE_BUILD_STRATEGY: disable-fallback
   CREDENTIALS_FILE: "$HOME/.local/share/snapcraft/launchpad-credentials"
   CREDENTIALS_FILE/new_credentials: "$HOME/.local/share/snapcraft/launchpad-credentials"
@@ -39,7 +40,13 @@ restore: |
 execute: |
   cd "./snaps/$SNAP"
 
-  snapcraft remote-build --launchpad-accept-public-upload
+  call_args=""
+  if [[ -e "arguments.txt" ]]; then
+    call_args=$(cat "arguments.txt")
+  fi
+  
+  # shellcheck disable=SC2086
+  snapcraft remote-build --launchpad-accept-public-upload $call_args
 
   find . -maxdepth 1 -name "*.snap" | MATCH ".snap"
 

--- a/tests/spread/core24/remote-build/snaps/build-for-arg/arguments.txt
+++ b/tests/spread/core24/remote-build/snaps/build-for-arg/arguments.txt
@@ -1,0 +1,1 @@
+--build-for amd64,s390x

--- a/tests/spread/core24/remote-build/snaps/build-for-arg/expected-snaps.txt
+++ b/tests/spread/core24/remote-build/snaps/build-for-arg/expected-snaps.txt
@@ -1,0 +1,2 @@
+test-snap-build-for-arg-core24_1.0_amd64.snap
+test-snap-build-for-arg-core24_1.0_s390x.snap

--- a/tests/spread/core24/remote-build/snaps/build-for-arg/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/build-for-arg/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: test-snap-build-for-arg-core24
+base: core24
+version: "1.0"
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/remote-build/snaps/platform-arg/arguments.txt
+++ b/tests/spread/core24/remote-build/snaps/platform-arg/arguments.txt
@@ -1,0 +1,1 @@
+--platform amd64,s390x

--- a/tests/spread/core24/remote-build/snaps/platform-arg/expected-snaps.txt
+++ b/tests/spread/core24/remote-build/snaps/platform-arg/expected-snaps.txt
@@ -1,0 +1,2 @@
+test-snap-platform-arg-core24_1.0_amd64.snap
+test-snap-platform-arg-core24_1.0_s390x.snap

--- a/tests/spread/core24/remote-build/snaps/platform-arg/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/platform-arg/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: test-snap-platform-arg-core24
+base: core24
+version: "1.0"
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/remote-build/task.yaml
+++ b/tests/spread/core24/remote-build/task.yaml
@@ -11,6 +11,8 @@ environment:
   SNAP/all: all
   SNAP/platforms: platforms
   SNAP/no_platforms: no-platforms
+  SNAP/platform_arg: platform-arg
+  SNAP/build_for_arg: build-for-arg
   CREDENTIALS_FILE: "$HOME/.local/share/snapcraft/launchpad-credentials"
   CREDENTIALS_FILE/new_credentials: "$HOME/.local/share/snapcraft/launchpad-credentials"
   CREDENTIALS_FILE/old_credentials: "$HOME/.local/share/snapcraft/provider/launchpad/credentials"
@@ -42,7 +44,13 @@ restore: |
 execute: |
   cd "./snaps/$SNAP"
 
-  snapcraft remote-build --launchpad-accept-public-upload
+  call_args=""
+  if [[ -e "arguments.txt" ]]; then
+    call_args=$(cat "arguments.txt")
+  fi
+  
+  # shellcheck disable=SC2086
+  snapcraft remote-build --launchpad-accept-public-upload $call_args
 
   find . -maxdepth 1 -name "*.snap" | MATCH ".snap"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Allow comma-separated values for `--build-for` and `--platform`.

Remote build spread tests are successful: https://github.com/canonical/snapcraft/actions/runs/10814283451/job/30000756052

Fixes #4990
(CRAFT-3271)