### PR TITLE
build(deps): bump craft-parts 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,7 +17,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.33.1
 craft-providers==1.24.2
 craft-store==2.6.2
 cryptography==42.0.8

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.33.1
 craft-providers==1.24.2
 craft-store==2.6.2
 cryptography==42.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.33.1
 craft-providers==1.24.2
 craft-store==2.6.2
 cryptography==42.0.8

--- a/tests/spread/core24/npm-reentrant/hello.js
+++ b/tests/spread/core24/npm-reentrant/hello.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log('hello world');

--- a/tests/spread/core24/npm-reentrant/package-lock.json
+++ b/tests/spread/core24/npm-reentrant/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "npm-hello",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/tests/spread/core24/npm-reentrant/package.json
+++ b/tests/spread/core24/npm-reentrant/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "npm-hello",
+  "version": "1.0.0",
+  "description": "Testing grounds for snapcraft integration tests",
+  "bin": {
+    "npm-hello": "hello.js"
+  },
+  "scripts": {
+    "npm-hello": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "GPL-3.0"
+}

--- a/tests/spread/core24/npm-reentrant/snap/snapcraft.yaml
+++ b/tests/spread/core24/npm-reentrant/snap/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: npm-reentrant
+version: "1.0"
+summary: test the npm plugin
+description: Check that the npm plugin works across snapcraft calls
+
+confinement: strict
+grade: devel
+base: core24
+
+parts:
+  hello:
+    source: .
+    plugin: npm
+    npm-include-node: true
+    npm-node-version: 22.1.0

--- a/tests/spread/core24/npm-reentrant/task.yaml
+++ b/tests/spread/core24/npm-reentrant/task.yaml
@@ -1,0 +1,11 @@
+summary: Pull, then Build, a Node snap
+
+execute: |
+  snapcraft pull
+  snapcraft build
+  snapcraft pack
+  test -f npm-reentrant*.snap
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap


### PR DESCRIPTION
This new version fixes a bug on the npm plugin. The bug is caused by the plugin
having state that implicitly needs to be passed from the 'pull' step to the
'build' step. If both are done in a single Snapcraft 'run', then it works fine;
however, running first 'pull' and then 'build' separately trigger the issue -
a failure on the build step.

Ref: https://github.com/canonical/craft-parts/issues/844