### PR TITLE
fix: override _run_inner instead of run to catch exceptions

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,7 +24,7 @@ click==8.1.7
 codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
-craft-application==4.2.2
+craft-application==4.2.3
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.0

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,7 +24,7 @@ click==8.1.7
 codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
-craft-application==4.1.2
+craft-application==4.2.2
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -19,7 +19,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==4.2.2
+craft-application==4.2.3
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -19,7 +19,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==4.1.2
+craft-application==4.2.2
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.17.1
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==4.1.2
+craft-application==4.2.2
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.17.1
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==4.2.2
+craft-application==4.2.3
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.0

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -209,13 +209,13 @@ class Snapcraft(Application):
         super()._pre_run(dispatcher)
 
     @override
-    def run(self) -> int:
+    def _run_inner(self) -> int:
         try:
-            return_code = super().run()
+            return_code = super()._run_inner()
         except craft_store.errors.NoKeyringError as err:
             self._emit_error(
                 craft_cli.errors.CraftError(
-                    f"craft-store error: {err}",
+                    f"{err}",
                     resolution=(
                         "Ensure the keyring is working or "
                         f"{store.constants.ENVIRONMENT_STORE_CREDENTIALS} "
@@ -227,9 +227,7 @@ class Snapcraft(Application):
             return_code = 1
         except craft_store.errors.CraftStoreError as err:
             self._emit_error(
-                craft_cli.errors.CraftError(
-                    f"craft-store error: {err}", resolution=err.resolution
-                ),
+                craft_cli.errors.CraftError(f"{err}", resolution=err.resolution),
                 cause=err,
             )
             return_code = 1

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -107,7 +107,8 @@ def test_snap_command_fallback(tmp_path, emitter, mocker, fake_services):
     )
 
 
-def test_core24_try_command(tmp_path, mocker, fake_services):
+@pytest.mark.usefixtures("emitter")
+def test_core24_try_command(tmp_path, fake_services):
     parsed_args = argparse.Namespace(parts=[], output=tmp_path)
     cmd = lifecycle.TryCommand({"app": APP_METADATA, "services": fake_services})
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -665,7 +665,7 @@ def test_known_core24(snapcraft_yaml, base, build_base, is_known_core24):
 )
 def test_store_error(mocker, capsys, message, resolution, expected_message):
     mocker.patch(
-        "snapcraft.application.Application.run",
+        "snapcraft.application.Application._run_inner",
         side_effect=craft_store.errors.CraftStoreError(message, resolution=resolution),
     )
 
@@ -673,12 +673,12 @@ def test_store_error(mocker, capsys, message, resolution, expected_message):
 
     assert return_code == 1
     _, err = capsys.readouterr()
-    assert f"craft-store error: {expected_message}" in err
+    assert expected_message in err
 
 
 def test_store_key_error(mocker, capsys):
     mocker.patch(
-        "snapcraft.application.Application.run",
+        "snapcraft.application.Application._run_inner",
         side_effect=craft_store.errors.NoKeyringError(),
     )
 
@@ -692,7 +692,7 @@ def test_store_key_error(mocker, capsys):
         # pylint: disable=[line-too-long]
         dedent(
             """\
-            craft-store error: No keyring found to store or retrieve credentials from.
+            No keyring found to store or retrieve credentials from.
             Recommended resolution: Ensure the keyring is working or SNAPCRAFT_STORE_CREDENTIALS is correctly exported into the environment
             For more information, check out: https://snapcraft.io/docs/snapcraft-authentication
         """


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
Fixes #4930 