### PR TITLE
build(deps): bump craft-parts to 1.33.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,7 +17,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.33.1
 craft-providers==1.24.2
 craft-store==2.6.2
 cryptography==42.0.8

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -15,7 +15,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.33.1
 craft-providers==1.24.2
 craft-store==2.6.2
 cryptography==42.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts==1.33.0
+craft-parts==1.33.1
 craft-providers==1.24.2
 craft-store==2.6.2
 cryptography==42.0.8

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ install_requires = [
     "craft-archives",
     "craft-cli>=2.6.0",
     "craft-grammar",
-    "craft-parts>=1.33.0",
+    "craft-parts>=1.33.1",
     "craft-providers>=1.24.2",
     "craft-store",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.


### PR DESCRIPTION
Craft Parts 1.33.1 fixes the npm plugin to be stateless.

- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
