### PR TITLE
fix: use correct type for `build-on` and `build-for` in build plans

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1222,8 +1222,8 @@ class SnapcraftBuildPlanner(models.BuildPlanner):
                 )
 
         for platform_entry, platform in self.platforms.items():
-            for build_for in platform.build_for or [SnapArch(platform_entry)]:
-                for build_on in platform.build_on or [SnapArch(platform_entry)]:
+            for build_for in platform.build_for or [SnapArch(platform_entry).value]:
+                for build_on in platform.build_on or [SnapArch(platform_entry).value]:
                     build_infos.append(
                         BuildInfo(
                             platform=platform_entry,

--- a/tests/spread/core24/platforms/snaps/implicit-build-for/expected-snaps.txt
+++ b/tests/spread/core24/platforms/snaps/implicit-build-for/expected-snaps.txt
@@ -1,0 +1,1 @@
+implicit-build-for_1.0_riscv64.snap

--- a/tests/spread/core24/platforms/snaps/implicit-build-for/snap/snapcraft.yaml
+++ b/tests/spread/core24/platforms/snaps/implicit-build-for/snap/snapcraft.yaml
@@ -1,0 +1,15 @@
+name: implicit-build-for
+version: "1.0"
+summary: test
+description: |
+  Use the platform name implicitly for the `build-for`.
+confinement: strict
+base: core24
+
+platforms:
+  riscv64:
+    build-on: [amd64]
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/platforms/task.yaml
+++ b/tests/spread/core24/platforms/task.yaml
@@ -9,6 +9,7 @@ environment:
   SNAP/env_var_all: env-var-all
   SNAP/env_var_match: env-var-match
   SNAP/env_var_no_match: env-var-no-match
+  SNAP/implicit_build_for: implicit-build-for
   SNAP/multiple_build_for: multiple-build-for
   SNAP/platform_all: platform-all
   SNAP/platform_match: platform-match

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -2070,6 +2070,37 @@ class TestApplyRootPackages:
         ),
         pytest.param(
             {
+                "s390x": {
+                    "build-on": "s390x",
+                },
+                "riscv64": {
+                    "build-on": ["amd64", "riscv64"],
+                },
+            },
+            [
+                BuildInfo(
+                    build_on="s390x",
+                    build_for="s390x",
+                    base=BaseName(name="ubuntu", version="24.04"),
+                    platform="s390x",
+                ),
+                BuildInfo(
+                    build_on="amd64",
+                    build_for="riscv64",
+                    base=BaseName(name="ubuntu", version="24.04"),
+                    platform="riscv64",
+                ),
+                BuildInfo(
+                    build_on="riscv64",
+                    build_for="riscv64",
+                    base=BaseName(name="ubuntu", version="24.04"),
+                    platform="riscv64",
+                ),
+            ],
+            id="implicit_build_for",
+        ),
+        pytest.param(
+            {
                 "arm64": {
                     "build-on": ["arm64", "armhf"],
                     "build-for": ["arm64"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

* Fixes an issue where the wrong type was used when creating a build plan.
* Adds a unit test and spread test for a failure described in https://forum.snapcraft.io/t/building-snaps/41982