### PR TITLE
[draft] test credentials on 7.5

### DIFF
--- a/tests/spread/general/store/task.yaml
+++ b/tests/spread/general/store/task.yaml
@@ -57,22 +57,22 @@ execute: |
   export SNAPCRAFT_STORE_AUTH="${SPREAD_VARIANT}"
 
   # Who Am I?
-  snapcraft whoami
+  snapcraft whoami --verbosity=trace
 
   # Register
-  snapcraft register --yes "${snap_name}"
+  snapcraft register --yes "${snap_name}" --verbosity=trace
 
   # Take a look at registered snaps.
-  snapcraft list
+  snapcraft list --verbosity=trace
 
   # Push and Release
-  snapcraft upload "${snap_file}" --release edge
+  snapcraft upload "${snap_file}" --release edge --verbosity=trace
 
   # Show revisions
-  snapcraft list-revisions "${snap_name}"
+  snapcraft list-revisions "${snap_name}" --verbosity=trace
 
   # Release
-  snapcraft release "${snap_name}" 1 edge
+  snapcraft release "${snap_name}" 1 edge --verbosity=trace
 
   # Status
   snapcraft status "${snap_name}"


### PR DESCRIPTION
Snap store credentials are failing to refresh. This is a test to see if snapcraft 7.5 is able to refresh the credentials.