### PR TITLE
feat: add `edit-registries` command

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -143,6 +143,7 @@ COMMAND_GROUPS = [
     craft_cli.CommandGroup(
         "Store Registries",
         [
+            commands.StoreEditRegistriesCommand,
             commands.StoreListRegistriesCommand,
         ],
     ),

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -52,7 +52,7 @@ from .names import (
     StoreRegisterCommand,
 )
 from .plugins import ListPluginsCommand, PluginsCommand
-from .registries import StoreListRegistriesCommand
+from .registries import StoreEditRegistriesCommand, StoreListRegistriesCommand
 from .remote import RemoteBuildCommand
 from .status import (
     StoreListRevisionsCommand,
@@ -77,6 +77,7 @@ __all__ = [
     "SnapCommand",
     "StoreCloseCommand",
     "StoreEditValidationSetsCommand",
+    "StoreEditRegistriesCommand",
     "StoreExportLoginCommand",
     "StoreLegacyCreateKeyCommand",
     "StoreLegacyGatedCommand",

--- a/snapcraft/commands/registries.py
+++ b/snapcraft/commands/registries.py
@@ -29,7 +29,7 @@ class StoreListRegistriesCommand(craft_application.commands.AppCommand):
     """List registries."""
 
     name = "list-registries"
-    help_msg = "List registries"
+    help_msg = "List registries sets"
     overview = textwrap.dedent(
         """
         List all registries for the authenticated account.
@@ -68,4 +68,42 @@ class StoreListRegistriesCommand(craft_application.commands.AppCommand):
         self._services.registries.list_assertions(
             name=parsed_args.name,
             output_format=parsed_args.format,
+        )
+
+
+class StoreEditRegistriesCommand(craft_application.commands.AppCommand):
+    """Edit a registries set."""
+
+    name = "edit-registries"
+    help_msg = "Edit or create a registries set"
+    overview = textwrap.dedent(
+        """
+        Edit a registries set.
+
+        If the registries set does not exist, then a new registries set will be created.
+
+        The account ID of the authenticated account can be determined with the
+        ``snapcraft whoami`` command.
+
+        Use the ``list-registries`` command to view existing registries.
+        """
+    )
+    _services: services.SnapcraftServiceFactory  # type: ignore[reportIncompatibleVariableOverride]
+
+    @override
+    def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
+        parser.add_argument(
+            "account_id",
+            metavar="account-id",
+            help="The account ID of the registries set to edit",
+        )
+        parser.add_argument(
+            "name", metavar="name", help="Name of the registries set to edit"
+        )
+
+    @override
+    def run(self, parsed_args: "argparse.Namespace"):
+        self._services.registries.edit_assertion(
+            name=parsed_args.name,
+            account_id=parsed_args.account_id,
         )

--- a/snapcraft/services/__init__.py
+++ b/snapcraft/services/__init__.py
@@ -16,20 +16,20 @@
 
 """Snapcraft services."""
 
-from snapcraft.services.assertions import AssertionService
+from snapcraft.services.assertions import Assertion
 from snapcraft.services.lifecycle import Lifecycle
 from snapcraft.services.package import Package
 from snapcraft.services.provider import Provider
-from snapcraft.services.registries import RegistriesService
+from snapcraft.services.registries import Registries
 from snapcraft.services.remotebuild import RemoteBuild
 from snapcraft.services.service_factory import SnapcraftServiceFactory
 
 __all__ = [
-    "AssertionService",
+    "Assertion",
     "Lifecycle",
     "Package",
     "Provider",
-    "RegistriesService",
+    "Registries",
     "RemoteBuild",
     "SnapcraftServiceFactory",
 ]

--- a/snapcraft/services/assertions.py
+++ b/snapcraft/services/assertions.py
@@ -30,7 +30,7 @@ from typing_extensions import override
 from snapcraft import const, errors, models, store
 
 
-class AssertionService(base.AppService):
+class Assertion(base.AppService):
     """Abstract service for interacting with assertions."""
 
     @override
@@ -41,8 +41,8 @@ class AssertionService(base.AppService):
 
     @property
     @abc.abstractmethod
-    def _assertion_type(self) -> str:
-        """The pluralized name of the assertion type."""
+    def _assertion_name(self) -> str:
+        """The lowercase name of the assertion type."""
 
     @abc.abstractmethod
     def _get_assertions(self, name: str | None = None) -> list[models.Assertion]:
@@ -81,7 +81,7 @@ class AssertionService(base.AppService):
             match output_format:
                 case const.OutputFormat.json:
                     json_assertions = {
-                        self._assertion_type.lower(): [
+                        f"{self._assertion_name}s": [
                             {
                                 header.lower(): value
                                 for header, value in zip(headers, assertion)
@@ -102,4 +102,4 @@ class AssertionService(base.AppService):
                         msg=f"'--format {output_format}'",
                     )
         else:
-            craft_cli.emit.message(f"No {self._assertion_type} found.")
+            craft_cli.emit.message(f"No {self._assertion_name}s found.")

--- a/snapcraft/services/assertions.py
+++ b/snapcraft/services/assertions.py
@@ -19,15 +19,23 @@
 from __future__ import annotations
 
 import abc
+import io
 import json
+import os
+import pathlib
+import subprocess
+import tempfile
 from typing import Any
 
 import craft_cli
 import tabulate
+import yaml
+from craft_application.errors import CraftValidationError
 from craft_application.services import base
+from craft_application.util import safe_yaml_load
 from typing_extensions import override
 
-from snapcraft import const, errors, models, store
+from snapcraft import const, errors, models, store, utils
 
 
 class Assertion(base.AppService):
@@ -37,12 +45,18 @@ class Assertion(base.AppService):
     def setup(self) -> None:
         """Application-specific service setup."""
         self._store_client = store.StoreClientCLI()
+        self._editor_cmd = os.getenv("EDITOR", "vi")
         super().setup()
 
     @property
     @abc.abstractmethod
     def _assertion_name(self) -> str:
         """The lowercase name of the assertion type."""
+
+    @property
+    @abc.abstractmethod
+    def _editable_assertion_class(self) -> type[models.EditableAssertion]:
+        """The type of the editable assertion."""
 
     @abc.abstractmethod
     def _get_assertions(self, name: str | None = None) -> list[models.Assertion]:
@@ -63,6 +77,29 @@ class Assertion(base.AppService):
         :param assertions: A list of assertions to normalize.
 
         :returns: A tuple containing the headers and normalized assertions.
+        """
+
+    @abc.abstractmethod
+    def _generate_yaml_from_model(self, assertion: models.Assertion) -> str:
+        """Generate a multi-line yaml string from an existing assertion.
+
+        This string should contain only user-editable data.
+
+        :param assertion: The assertion to generate a yaml string from.
+
+        :returns: A multi-line yaml string.
+        """
+
+    @abc.abstractmethod
+    def _generate_yaml_from_template(self, name: str, account_id: str) -> str:
+        """Generate a multi-line yaml string of a default assertion.
+
+        This string should contain only user-editable data.
+
+        :param name: The name of the assertion.
+        :param account_id: The account ID of the authenticated user.
+
+        :returns: A multi-line yaml string.
         """
 
     def list_assertions(self, *, output_format: str, name: str | None = None) -> None:
@@ -103,3 +140,94 @@ class Assertion(base.AppService):
                     )
         else:
             craft_cli.emit.message(f"No {self._assertion_name}s found.")
+
+    def _edit_yaml_file(self, filepath: pathlib.Path) -> models.EditableAssertion:
+        """Edit a yaml file and unmarshal it to an editable assertion.
+
+        If the file is not valid, the user is prompted to amend it.
+
+        :param filepath: The path to the yaml file to edit.
+
+        :returns: The edited assertion.
+        """
+        while True:
+            craft_cli.emit.debug(f"Using {self._editor_cmd} to edit file.")
+            with craft_cli.emit.pause():
+                subprocess.run([self._editor_cmd, filepath], check=True)
+            try:
+                with filepath.open() as file:
+                    data = safe_yaml_load(file)
+                edited_assertion = self._editable_assertion_class.from_yaml_data(
+                    data=data,
+                    # filepath is only shown for pydantic errors and snapcraft should
+                    # not expose the temp file name
+                    filepath=pathlib.Path(self._assertion_name.replace(" ", "-")),
+                )
+                return edited_assertion
+            except (yaml.YAMLError, CraftValidationError) as err:
+                craft_cli.emit.message(f"{err!s}")
+                if not utils.confirm_with_user(
+                    f"Do you wish to amend the {self._assertion_name}?"
+                ):
+                    raise errors.SnapcraftError("operation aborted") from err
+
+    def _get_yaml_data(self, name: str, account_id: str) -> str:
+        craft_cli.emit.progress(
+            f"Requesting {self._assertion_name} '{name}' from the store."
+        )
+
+        if assertions := self._get_assertions(name=name):
+            yaml_data = self._generate_yaml_from_model(assertions[0])
+        else:
+            craft_cli.emit.progress(
+                f"Creating a new {self._assertion_name} because no existing "
+                f"{self._assertion_name} named '{name}' was found for the "
+                "authenticated account.",
+                permanent=True,
+            )
+            yaml_data = self._generate_yaml_from_template(
+                name=name, account_id=account_id
+            )
+
+        return yaml_data
+
+    @staticmethod
+    def _write_to_file(yaml_data: str) -> pathlib.Path:
+        with tempfile.NamedTemporaryFile() as temp_file:
+            filepath = pathlib.Path(temp_file.name)
+        craft_cli.emit.trace(f"Writing yaml data to temporary file '{filepath}'.")
+        filepath.write_text(yaml_data, encoding="utf-8")
+        return filepath
+
+    @staticmethod
+    def _remove_temp_file(filepath: pathlib.Path) -> None:
+        craft_cli.emit.trace(f"Removing temporary file '{filepath}'.")
+        filepath.unlink()
+
+    def edit_assertion(self, *, name: str, account_id: str) -> None:
+        """Edit, sign and upload an assertion.
+
+         If the assertion does not exist, a new assertion is created from a template.
+
+        :param name: The name of the assertion to edit.
+        :param account_id: The account ID associated with the registries set.
+        """
+        yaml_data = self._get_yaml_data(name=name, account_id=account_id)
+        yaml_file = self._write_to_file(yaml_data)
+        original_assertion = self._editable_assertion_class.unmarshal(
+            safe_yaml_load(io.StringIO(yaml_data))
+        )
+        edited_assertion = self._edit_yaml_file(yaml_file)
+
+        if edited_assertion == original_assertion:
+            craft_cli.emit.message("No changes made.")
+            self._remove_temp_file(yaml_file)
+            return
+
+        # TODO: build, sign, and push assertion (#5018)
+
+        self._remove_temp_file(yaml_file)
+        craft_cli.emit.message(f"Successfully edited {self._assertion_name} {name!r}.")
+        raise errors.FeatureNotImplemented(
+            f"Building, signing and uploading {self._assertion_name} is not implemented.",
+        )

--- a/snapcraft/services/registries.py
+++ b/snapcraft/services/registries.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Abstract service class for assertions."""
+"""Service class for registries."""
 
 from __future__ import annotations
 
@@ -23,39 +23,25 @@ from typing import Any
 from typing_extensions import override
 
 from snapcraft import models
-from snapcraft.services import AssertionService
+from snapcraft.services import Assertion
 
 
-class RegistriesService(AssertionService):
+class Registries(Assertion):
     """Service for interacting with registries."""
 
     @property
     @override
-    def _assertion_type(self) -> str:
-        """The pluralized name of the assertion type."""
-        return "registries"
+    def _assertion_name(self) -> str:
+        return "registries set"
 
     @override
     def _get_assertions(self, name: str | None = None) -> list[models.Assertion]:
-        """Get assertions from the store.
-
-        :param name: The name of the assertion to retrieve. If not provided, all
-          assertions are retrieved.
-
-        :returns: A list of assertions.
-        """
         return self._store_client.list_registries(name=name)
 
     @override
     def _normalize_assertions(
         self, assertions: list[models.Assertion]
     ) -> tuple[list[str], list[list[Any]]]:
-        """Convert a list of assertion models to a tuple of headers and data.
-
-        :param assertions: A list of assertions to normalize.
-
-        :returns: A tuple containing the headers and normalized assertions.
-        """
         headers = ["Account ID", "Name", "Revision", "When"]
         registries = [
             [

--- a/snapcraft/services/service_factory.py
+++ b/snapcraft/services/service_factory.py
@@ -46,9 +46,9 @@ class SnapcraftServiceFactory(ServiceFactory):
         services.RemoteBuild
     ] = services.RemoteBuild
     RegistriesClass: type[  # type: ignore[reportIncompatibleVariableOverride]
-        services.RegistriesService
-    ] = services.RegistriesService
+        services.Registries
+    ] = services.Registries
 
     if TYPE_CHECKING:
         # Allow static type check to report correct types for Snapcraft services
-        registries: services.RegistriesService = None  # type: ignore[assignment]
+        registries: services.Registries = None  # type: ignore[assignment]

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -527,6 +527,8 @@ class LegacyStoreClientCLI:
         if assertions := response.json().get("assertions"):
             for assertion_data in assertions:
                 emit.debug(f"Parsing assertion: {assertion_data}")
+                # move body into model
+                assertion_data["headers"]["body"] = assertion_data["body"]
                 assertion = models.RegistryAssertion.unmarshal(
                     assertion_data["headers"]
                 )

--- a/tests/unit/commands/test_registries.py
+++ b/tests/unit/commands/test_registries.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Unit tests for registries commands."""
+
 import sys
 
 import pytest
@@ -24,6 +26,11 @@ from snapcraft import application, const
 @pytest.fixture
 def mock_list_assertions(mocker):
     return mocker.patch("snapcraft.services.registries.Registries.list_assertions")
+
+
+@pytest.fixture
+def mock_edit_assertion(mocker):
+    return mocker.patch("snapcraft.services.registries.Registries.edit_assertion")
 
 
 @pytest.mark.usefixtures("memory_keyring")
@@ -56,3 +63,17 @@ def test_list_registries_default_format(mocker, mock_list_assertions, name):
     app.run()
 
     mock_list_assertions.assert_called_once_with(name=name, output_format="table")
+
+
+@pytest.mark.usefixtures("memory_keyring")
+def test_edit_registries(mocker, mock_edit_assertion):
+    """Test `snapcraft edit-registries`."""
+    cmd = ["snapcraft", "edit-registries", "test-account-id", "test-name"]
+    mocker.patch.object(sys, "argv", cmd)
+
+    app = application.create_app()
+    app.run()
+
+    mock_edit_assertion.assert_called_once_with(
+        name="test-name", account_id="test-account-id"
+    )

--- a/tests/unit/commands/test_registries.py
+++ b/tests/unit/commands/test_registries.py
@@ -23,9 +23,7 @@ from snapcraft import application, const
 
 @pytest.fixture
 def mock_list_assertions(mocker):
-    return mocker.patch(
-        "snapcraft.services.registries.RegistriesService.list_assertions"
-    )
+    return mocker.patch("snapcraft.services.registries.Registries.list_assertions")
 
 
 @pytest.mark.usefixtures("memory_keyring")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -533,9 +533,9 @@ def remote_build_service(default_factory, mocker):
 @pytest.fixture()
 def registries_service(default_factory, mocker):
     from snapcraft.application import APP_METADATA
-    from snapcraft.services import RegistriesService
+    from snapcraft.services import Registries
 
-    service = RegistriesService(app=APP_METADATA, services=default_factory)
+    service = Registries(app=APP_METADATA, services=default_factory)
     service._store_client = mocker.patch(
         "snapcraft.store.StoreClientCLI", autospec=True
     )
@@ -544,32 +544,34 @@ def registries_service(default_factory, mocker):
 
 
 @pytest.fixture()
-def fake_registry_assertion_data():
-    """Returns a dictionary of assertion data with required fields."""
+def fake_registry_assertion():
+    """Returns a fake registry assertion with required fields."""
     from snapcraft.models import RegistryAssertion
 
-    def _assertion_data(**kwargs) -> dict[str, Any]:
-        return {
-            "account_id": "test-account-id",
-            "authority_id": "test-authority-id",
-            "name": "test-registry",
-            "timestamp": "2024-01-01T10:20:30Z",
-            "type": "registry",
-            "views": {
-                "wifi-setup": {
-                    "rules": [
-                        {
-                            "access": "read-write",
-                            "request": "ssids",
-                            "storage": "wifi.ssids",
-                        }
-                    ]
-                }
-            },
-            **kwargs,
-        }
+    def _fake_registry_assertion(**kwargs) -> RegistryAssertion:
+        return RegistryAssertion.unmarshal(
+            {
+                "account_id": "test-account-id",
+                "authority_id": "test-authority-id",
+                "name": "test-registry",
+                "timestamp": "2024-01-01T10:20:30Z",
+                "type": "registry",
+                "views": {
+                    "wifi-setup": {
+                        "rules": [
+                            {
+                                "access": "read-write",
+                                "request": "ssids",
+                                "storage": "wifi.ssids",
+                            }
+                        ]
+                    }
+                },
+                **kwargs,
+            }
+        )
 
-    return RegistryAssertion.unmarshal(_assertion_data())
+    return _fake_registry_assertion
 
 
 @pytest.fixture()

--- a/tests/unit/services/test_assertions.py
+++ b/tests/unit/services/test_assertions.py
@@ -18,12 +18,51 @@
 
 import textwrap
 from typing import Any
+from unittest import mock
 
 import pytest
 from craft_application.models import CraftBaseModel
 from typing_extensions import override
 
 from snapcraft import const, errors
+
+
+@pytest.fixture(autouse=True)
+def mock_store_client(mocker):
+    """Mock the store client before it is initialized in the service's setup."""
+    return mocker.patch(
+        "snapcraft.store.StoreClientCLI",
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_editor(monkeypatch):
+    """Set a fake editor."""
+    return monkeypatch.setenv("EDITOR", "faux-vi")
+
+
+@pytest.fixture
+def mock_confirm_with_user(mocker, request):
+    """Mock the confirm_with_user function."""
+    return mocker.patch("snapcraft.utils.confirm_with_user", return_value=request.param)
+
+
+@pytest.fixture
+def mock_subprocess_run(mocker, tmp_path, request):
+    """Mock the subprocess.run function to write data to a file.
+
+    :param request: A list of strings to write to a file. Each time the subprocess.run
+      function is called, the last string in the list will be written to the file
+      and removed from the list.
+    """
+    data_write = request.param.copy()
+    tmp_file = tmp_path / "assertion-file"
+
+    def side_effect(*args, **kwargs):
+        tmp_file.write_text(data_write.pop(), encoding="utf-8")
+
+    subprocess_mock = mocker.patch("subprocess.run", side_effect=side_effect)
+    return subprocess_mock
 
 
 class FakeAssertion(CraftBaseModel):
@@ -43,6 +82,13 @@ def fake_assertion_service(default_factory):
         @override
         def _assertion_name(self) -> str:
             return "fake assertion"
+
+        @property
+        @override
+        def _editable_assertion_class(  # type: ignore[override]
+            self,
+        ) -> type[FakeAssertion]:
+            return FakeAssertion
 
         @override
         def _get_assertions(  # type: ignore[override]
@@ -67,7 +113,39 @@ def fake_assertion_service(default_factory):
             ]
             return headers, assertion_data
 
+        @override
+        def _generate_yaml_from_model(  # type: ignore[override]
+            self, assertion: FakeAssertion
+        ) -> str:
+            return textwrap.dedent(
+                """\
+                test-field-1: test-value-1
+                test-field-2: 0
+                """
+            )
+
+        @override
+        def _generate_yaml_from_template(self, name: str, account_id: str) -> str:
+            return textwrap.dedent(
+                """\
+                test-field-1: default-value-1
+                test-field-2: 0
+                """
+            )
+
     return FakeAssertionService(app=APP_METADATA, services=default_factory)
+
+
+@pytest.fixture
+def fake_edit_yaml_file(mocker, fake_assertion_service):
+    """Apply a fake edit to a yaml file."""
+    return mocker.patch.object(
+        fake_assertion_service,
+        "_edit_yaml_file",
+        return_value=FakeAssertion(
+            test_field_1="test-value-1-UPDATED", test_field_2=999
+        ),
+    )
 
 
 def test_list_assertions_table(fake_assertion_service, emitter):
@@ -119,3 +197,187 @@ def test_list_assertions_unknown_format(fake_assertion_service):
         fake_assertion_service.list_assertions(
             output_format="unknown", name="test-registry"
         )
+
+
+def test_edit_assertions_changes_made(
+    fake_edit_yaml_file, fake_assertion_service, emitter
+):
+    """Edit an assertion and make a valid change."""
+    expected = "Building, signing and uploading fake assertion is not implemented"
+    fake_assertion_service.setup()
+
+    with pytest.raises(errors.FeatureNotImplemented, match=expected):
+        fake_assertion_service.edit_assertion(
+            name="test-registry", account_id="test-account-id"
+        )
+
+    emitter.assert_message("Successfully edited fake assertion 'test-registry'.")
+
+
+def test_edit_assertions_no_changes_made(
+    fake_edit_yaml_file, fake_assertion_service, emitter, mocker
+):
+    """Edit an assertion but make no changes to the data."""
+    mocker.patch.object(
+        fake_assertion_service,
+        "_edit_yaml_file",
+        # make no changes to the fake assertion
+        return_value=FakeAssertion(test_field_1="test-value-1", test_field_2=0),
+    )
+    fake_assertion_service.setup()
+
+    fake_assertion_service.edit_assertion(
+        name="test-registry", account_id="test-account-id"
+    )
+
+    emitter.assert_message("No changes made.")
+
+
+@pytest.mark.parametrize("editor", [None, "faux-vi"])
+@pytest.mark.parametrize(
+    "mock_subprocess_run",
+    [
+        [
+            textwrap.dedent(
+                """\
+                test-field-1: test-value-1-UPDATED
+                test-field-2: 999
+                """
+            ),
+        ],
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mock_confirm_with_user", [True], indirect=True)
+def test_edit_yaml_file(
+    editor,
+    fake_assertion_service,
+    tmp_path,
+    mock_confirm_with_user,
+    mock_subprocess_run,
+    monkeypatch,
+):
+    """Successfully edit a yaml file with the correct editor."""
+    if editor:
+        monkeypatch.setenv("EDITOR", editor)
+        expected_editor = editor
+    else:
+        monkeypatch.delenv("EDITOR", raising=False)
+        # default is vi
+        expected_editor = "vi"
+    tmp_file = tmp_path / "assertion-file"
+    fake_assertion_service.setup()
+
+    edited_assertion = fake_assertion_service._edit_yaml_file(tmp_file)
+
+    assert edited_assertion == FakeAssertion(
+        test_field_1="test-value-1-UPDATED", test_field_2=999
+    )
+    mock_confirm_with_user.assert_not_called()
+    assert mock_subprocess_run.mock_calls == [
+        mock.call([expected_editor, tmp_file], check=True)
+    ]
+
+
+@pytest.mark.parametrize(
+    "mock_subprocess_run",
+    [
+        pytest.param(
+            [
+                textwrap.dedent(
+                    """\
+                    test-field-1: test-value-1-UPDATED
+                    test-field-2: 999
+                    """
+                ),
+                textwrap.dedent(
+                    """\
+                    bad yaml {{
+                    test-field-1: test-value-1
+                    test-field-2: 0
+                    """
+                ),
+            ],
+            id="invalid yaml syntax",
+        ),
+        pytest.param(
+            [
+                textwrap.dedent(
+                    """\
+                    test-field-1: test-value-1-UPDATED
+                    test-field-2: 999
+                    """
+                ),
+                textwrap.dedent(
+                    """\
+                    extra-field: not-allowed
+                    test-field-1: [wrong data type]
+                    test-field-2: 0
+                    """
+                ),
+            ],
+            id="invalid pydantic data",
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mock_confirm_with_user", [True], indirect=True)
+def test_edit_yaml_file_error_retry(
+    fake_assertion_service,
+    tmp_path,
+    mock_confirm_with_user,
+    mock_subprocess_run,
+):
+    """Edit a yaml file but encounter an error and retry."""
+    tmp_file = tmp_path / "assertion-file"
+    fake_assertion_service.setup()
+
+    edited_assertion = fake_assertion_service._edit_yaml_file(tmp_file)
+
+    assert edited_assertion == FakeAssertion(
+        test_field_1="test-value-1-UPDATED", test_field_2=999
+    )
+    assert mock_confirm_with_user.mock_calls == [
+        mock.call("Do you wish to amend the fake assertion?")
+    ]
+    assert (
+        mock_subprocess_run.mock_calls
+        == [mock.call(["faux-vi", tmp_file], check=True)] * 2
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_subprocess_run",
+    [
+        [
+            textwrap.dedent(
+                """\
+                bad yaml {{
+                test-field-1: test-value-1
+                test-field-2: 0
+                """
+            ),
+        ],
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mock_confirm_with_user", [False], indirect=True)
+def test_edit_error_no_retry(
+    fake_assertion_service,
+    tmp_path,
+    mock_confirm_with_user,
+    mock_subprocess_run,
+):
+    """Edit a yaml file and encounter an error but do not retry."""
+    tmp_file = tmp_path / "assertion-file"
+    fake_assertion_service.setup()
+
+    with pytest.raises(errors.SnapcraftError, match="operation aborted"):
+        fake_assertion_service._edit_yaml_file(tmp_file)
+
+    assert mock_confirm_with_user.mock_calls == [
+        mock.call("Do you wish to amend the fake assertion?")
+    ]
+    assert mock_subprocess_run.mock_calls == [
+        mock.call(["faux-vi", tmp_file], check=True)
+    ]

--- a/tests/unit/services/test_assertions.py
+++ b/tests/unit/services/test_assertions.py
@@ -34,15 +34,15 @@ class FakeAssertion(CraftBaseModel):
 
 
 @pytest.fixture
-def mock_assertion_service(default_factory):
+def fake_assertion_service(default_factory):
     from snapcraft.application import APP_METADATA
-    from snapcraft.services import AssertionService
+    from snapcraft.services import Assertion
 
-    class FakeAssertionService(AssertionService):
+    class FakeAssertionService(Assertion):
         @property
         @override
-        def _assertion_type(self) -> str:
-            return "fake-assertions"
+        def _assertion_name(self) -> str:
+            return "fake assertion"
 
         @override
         def _get_assertions(  # type: ignore[override]
@@ -70,9 +70,9 @@ def mock_assertion_service(default_factory):
     return FakeAssertionService(app=APP_METADATA, services=default_factory)
 
 
-def test_list_assertions_table(mock_assertion_service, emitter):
+def test_list_assertions_table(fake_assertion_service, emitter):
     """List assertions as a table."""
-    mock_assertion_service.list_assertions(
+    fake_assertion_service.list_assertions(
         output_format=const.OutputFormat.table, name="test-registry"
     )
 
@@ -86,9 +86,9 @@ def test_list_assertions_table(mock_assertion_service, emitter):
     )
 
 
-def test_list_assertions_json(mock_assertion_service, emitter):
+def test_list_assertions_json(fake_assertion_service, emitter):
     """List assertions as json."""
-    mock_assertion_service.list_assertions(
+    fake_assertion_service.list_assertions(
         output_format=const.OutputFormat.json, name="test-registry"
     )
 
@@ -96,7 +96,7 @@ def test_list_assertions_json(mock_assertion_service, emitter):
         textwrap.dedent(
             """\
             {
-                "fake-assertions": [
+                "fake assertions": [
                     {
                         "test-field-1": "test-value-1",
                         "test-field-2": 0
@@ -111,11 +111,11 @@ def test_list_assertions_json(mock_assertion_service, emitter):
     )
 
 
-def test_list_assertions_unknown_format(mock_assertion_service):
+def test_list_assertions_unknown_format(fake_assertion_service):
     """Error for unknown formats."""
     expected = "Command or feature not implemented: '--format unknown'"
 
     with pytest.raises(errors.FeatureNotImplemented, match=expected):
-        mock_assertion_service.list_assertions(
+        fake_assertion_service.list_assertions(
             output_format="unknown", name="test-registry"
         )

--- a/tests/unit/services/test_registries.py
+++ b/tests/unit/services/test_registries.py
@@ -18,7 +18,7 @@
 
 
 def test_registries_service_type(registries_service):
-    assert registries_service._assertion_type == "registries"
+    assert registries_service._assertion_name == "registries set"
 
 
 def test_get_assertions(registries_service):
@@ -36,16 +36,14 @@ def test_normalize_assertions_empty(registries_service, check):
     check.equal(registries, [])
 
 
-def test_normalize_assertions(fake_registry_assertion_data, registries_service, check):
+def test_normalize_assertions(fake_registry_assertion, registries_service, check):
     registries = [
-        fake_registry_assertion_data,
-        fake_registry_assertion_data.copy(
-            update={
-                "account_id": "test-account-id-2",
-                "name": "test-registry-2",
-                "revision": 100,
-                "timestamp": "2024-12-31",
-            }
+        fake_registry_assertion(),
+        fake_registry_assertion(
+            account_id="test-account-id-2",
+            name="test-registry-2",
+            revision=100,
+            timestamp="2024-12-31",
         ),
     ]
 

--- a/tests/unit/services/test_registries.py
+++ b/tests/unit/services/test_registries.py
@@ -16,9 +16,17 @@
 
 """Tests for the registries service."""
 
+import textwrap
+
+from snapcraft.models import EditableRegistryAssertion
+
 
 def test_registries_service_type(registries_service):
     assert registries_service._assertion_name == "registries set"
+
+
+def test_editable_assertion_class(registries_service):
+    assert registries_service._editable_assertion_class == EditableRegistryAssertion
 
 
 def test_get_assertions(registries_service):
@@ -58,4 +66,66 @@ def test_normalize_assertions(fake_registry_assertion, registries_service, check
             ["test-account-id", "test-registry", 0, "2024-01-01"],
             ["test-account-id-2", "test-registry-2", 100, "2024-12-31"],
         ],
+    )
+
+
+def test_generate_yaml_from_model(fake_registry_assertion, registries_service):
+    assertion = fake_registry_assertion(
+        summary="test-summary",
+        revision="10",
+        views={
+            "wifi-setup": {
+                "rules": [
+                    {
+                        "request": "test-request",
+                        "storage": "test-storage",
+                        "access": "read",
+                        "content": [
+                            {
+                                "request": "nested-request",
+                                "storage": "nested-storage",
+                                "access": "write",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+        body=(
+            "{\n  'storage': {\n    'schema': {\n      'wifi': {\n        "
+            "'values': 'any'\n      }\n    }\n  }\n}"
+        ),
+    )
+    yaml_data = registries_service._generate_yaml_from_model(assertion)
+
+    assert yaml_data == textwrap.dedent(
+        """\
+        account-id: test-account-id
+        name: test-registry
+        # summary: test-summary
+        # The revision for this registries set
+        # revision: 10
+        views:
+          wifi-setup:
+            rules:
+            - request: test-request
+              storage: test-storage
+              access: read
+              content:
+              - request: nested-request
+                storage: nested-storage
+                access: write
+
+        body: |-
+          {
+            'storage': {
+              'schema': {
+                'wifi': {
+                  'values': 'any'
+                }
+              }
+            }
+          }
+
+          """
     )

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -1101,6 +1101,11 @@ def test_list_registries(name, fake_client, list_registries_payload, check):
     check.is_instance(registries, list)
     for registry in registries:
         check.is_instance(registry, models.RegistryAssertion)
+        check.equal(
+            registry.body,
+            '{\n  "storage": {\n    "schema": {\n      "wifi": {\n        '
+            '"values": "any"\n      }\n    }\n  }\n}',
+        )
     check.equal(
         fake_client.request.mock_calls,
         [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Supports the first half of the `edit-registries` command where a user can retrieve and edit a registries set.

The second half will be implemented in #5018.

Builds on top of #5049, so ignore the first commit.

I broke this up into 2 commits to make reviewing easier.

Fixes #5020
(CRAFT-3333)