### PR TITLE
docker: add workflow to test image works

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file docker/Dockerfile --tag snapcraft:test
+    - name: Test the image works
+      run: docker run snapcraft:test snapcraft version


### PR DESCRIPTION
Add Docker image build and run to CI, because it is broken at the moment, and it is not clear since when.
```sh
root@04c0e0197e05:/workdir# snapcraft
/snap/bin/snapcraft: 3: exec: /snap/snapcraft/current/usr/bin/python3: not found
```

Seems like poured binaries are incompatible with system libs.
```sh
root@04c0e0197e05:/workdir# ldd snapcraft
ldd: ./snapcraft: No such file or directory
root@04c0e0197e05:/workdir# ldd `which snapcraft`
        not a dynamic executable
root@04c0e0197e05:/workdir# ldd /snap/snapcraft/current/usr/bin/python3
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.26' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.27' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/snapcraft/current/usr/bin/python3)
/snap/snapcraft/current/usr/bin/python3: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/snapcraft/current/usr/bin/python3)
        linux-vdso.so.1 =>  (0x00007f20bc07e000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f20bb400000)
        libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007f20bb000000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f20bac00000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f20ba800000)
        /snap/core22/current/lib64/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007f20bbe00000)
```
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
