### PR TITLE
feat: allow specifying components when using edit-validation-sets

### DIFF
--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -48,6 +48,12 @@ _VALIDATIONS_SETS_SNAPS_TEMPLATE = textwrap.dedent(
                        # the provided name.
     #    presence: [required|optional|invalid]  # Optional, defaults to required.
     #    revision: <n> # The revision of the snap. Optional.
+    #    components: # Constraints to apply to the snap's components. Optional.
+    #      <component-name>: [required|optional|invalid] # Short form for specifying the component's presence.
+    #      <component-name>: # Long form that allows specifying the component's revision.
+    #        presence: [required|optional|invalid] # Presence of the component. Required.
+    #        revision: <n> # The revision of the component, required if the snap's revision is given.
+                           # Otherwise, not allowed.
 """
 )
 

--- a/snapcraft_legacy/storeapi/v2/validation_sets.py
+++ b/snapcraft_legacy/storeapi/v2/validation_sets.py
@@ -56,6 +56,16 @@ def _to_string(
 
     return data
 
+Presence = Literal["required", "optional", "invalid"]
+
+class Component(models.CraftBaseModel):
+    """Represent a Component in a Validation Set."""
+
+    presence: Presence
+    """Component presence"""
+
+    revision: int | None = None
+    """Component revision"""
 
 class Snap(models.CraftBaseModel):
     """Represent a Snap in a Validation Set."""
@@ -66,12 +76,14 @@ class Snap(models.CraftBaseModel):
     id: SnapId | None = None
     """Snap ID"""
 
-    presence: Literal["required", "optional", "invalid"] | None = None
+    presence: Presence | None = None
     """Snap presence"""
 
     revision: int | None = None
     """Snap revision"""
 
+    components: dict[str, Presence | Component] | None = None
+    """Snap components"""
 
 class EditableBuildAssertion(models.CraftBaseModel):
     """Subset of a build assertion that can be edited by the user.

--- a/tests/legacy/unit/store/v2/test_validation_sets.py
+++ b/tests/legacy/unit/store/v2/test_validation_sets.py
@@ -26,6 +26,13 @@ def fake_snap_data():
         "id": "snap-id",
         "presence": "required",
         "revision": 42,
+        "components": {
+            "component-with-revision": {
+                "presence": "required",
+                "revision": 10,
+            },
+            "component-without-revision": "invalid",
+        },
     }
 
 
@@ -125,6 +132,13 @@ def test_editable_build_assertion_marshal_as_str(fake_editable_build_assertion):
                 "name": "snap-name",
                 "presence": "required",
                 "revision": "42",
+                "components": {
+                    "component-with-revision": {
+                        "presence": "required",
+                        "revision": "10",
+                    },
+                    "component-without-revision": "invalid",
+                },
             },
         ],
     }
@@ -147,6 +161,13 @@ def test_build_assertion_marshal_as_str(fake_build_assertion):
                 "name": "snap-name",
                 "presence": "required",
                 "revision": "42",
+                "components": {
+                    "component-with-revision": {
+                        "presence": "required",
+                        "revision": "10",
+                    },
+                    "component-without-revision": "invalid",
+                },
             },
         ],
         "timestamp": "2020-10-29T16:36:56Z",

--- a/tests/unit/commands/test_validation_sets.py
+++ b/tests/unit/commands/test_validation_sets.py
@@ -54,6 +54,28 @@ VALIDATION_SET_DATA = {
                         "id": "XXSnapIDForXSnapName2XXXXXXXXXXX",
                         "name": "snap-name-2",
                     },
+                    {
+                        "id": "XXSnapIDForXSnapName3XXXXXXXXXXX",
+                        "name": "snap-name-3",
+                        "presence": "optional",
+                        "revision": "1",
+                        "components": {
+                            "comp-name-1": {
+                                "presence": "required",
+                                "revision": "11",
+                            },
+                        },
+                    },
+                    {
+                        "id": "XXSnapIDForXSnapName4XXXXXXXXXXX",
+                        "name": "snap-name-4",
+                        "presence": "optional",
+                        "components": {
+                            "comp-name-1": "required",
+                            "comp-name-2": "optional",
+                            "comp-name-3": "invalid",
+                        },
+                    },
                 ],
                 "timestamp": "2020-10-29T16:36:56Z",
                 "type": "validation-set",
@@ -125,6 +147,28 @@ def edit_return_value():
                     "revision": "10",
                 },
                 {"id": "XXSnapIDForXSnapName2XXXXXXXXXXX", "name": "snap-name-2"},
+                {
+                    "id": "XXSnapIDForXSnapName3XXXXXXXXXXX",
+                    "name": "snap-name-3",
+                    "presence": "optional",
+                    "revision": "1",
+                    "components": {
+                        "comp-name-1": {
+                            "presence": "required",
+                            "revision": "11",
+                        },
+                    },
+                },
+                {
+                    "id": "XXSnapIDForXSnapName4XXXXXXXXXXX",
+                    "name": "snap-name-4",
+                    "presence": "optional",
+                    "components": {
+                        "comp-name-1": "required",
+                        "comp-name-2": "optional",
+                        "comp-name-3": "invalid",
+                    },
+                },
             ],
         }
     )
@@ -157,6 +201,28 @@ EXPECTED_BUILD_ASSERTION_CALL = call(
                 "revision": 10,
             },
             {"name": "snap-name-2", "id": "XXSnapIDForXSnapName2XXXXXXXXXXX"},
+            {
+                "id": "XXSnapIDForXSnapName3XXXXXXXXXXX",
+                "name": "snap-name-3",
+                "presence": "optional",
+                "revision": 1,
+                "components": {
+                    "comp-name-1": {
+                        "presence": "required",
+                        "revision": 11,
+                    },
+                },
+            },
+            {
+                "id": "XXSnapIDForXSnapName4XXXXXXXXXXX",
+                "name": "snap-name-4",
+                "presence": "optional",
+                "components": {
+                    "comp-name-1": "required",
+                    "comp-name-2": "optional",
+                    "comp-name-3": "invalid",
+                },
+            },
         ],
     }
 )
@@ -165,7 +231,9 @@ EXPECTED_SIGNED_VALIDATION_SETS = (
     '{{"account-id": "AccountIDXXXOfTheRequestingUserX", "name": "certification-x1", '
     '"revision": "222", "sequence": "9", "snaps": [{{"name": "snap-name-1", "id": '
     '"XXSnapIDForXSnapName1XXXXXXXXXXX", "presence": "optional", "revision": "10"}}, '
-    '{{"name": "snap-name-2", "id": "XXSnapIDForXSnapName2XXXXXXXXXXX"}}], '
+    '{{"name": "snap-name-2", "id": "XXSnapIDForXSnapName2XXXXXXXXXXX"}}, '
+    '{{"name": "snap-name-3", "id": "XXSnapIDForXSnapName3XXXXXXXXXXX", "presence": "optional", "revision": "1", "components": {{"comp-name-1": {{"presence": "required", "revision": "11"}}}}}}, '
+    '{{"name": "snap-name-4", "id": "XXSnapIDForXSnapName4XXXXXXXXXXX", "presence": "optional", "components": {{"comp-name-1": "required", "comp-name-2": "optional", "comp-name-3": "invalid"}}}}], '
     '"authority-id": "AccountIDXXXOfTheRequestingUserX", "series": "16", "timestamp": '
     '"2020-10-29T16:36:56Z", "type": "validation-set"}}\n\nSIGNED{key_name}'
 )


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Hello! This should enable using `edit-validation-sets` with components. Let me know if I'm missing any testing. I don't see any tests that specifically test the allowed format of validation sets, so I don't know if that is something that we need/want to be added.