### PR TITLE
chore: update references from snapcore to canonical

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-- [ ] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
+- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
 - [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
 - [ ] Have you successfully run `tox run -m lint`?
 - [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - if: steps.decisions.outputs.PUBLISH == 'true'
-        uses: snapcore/action-build@v1
+        uses: canonical/action-build@v1
         name: Build Snapcraft Snap
         id: build
         with:
@@ -54,7 +54,7 @@ jobs:
 
       - name: Publish feature branch to edge/${{ steps.vars.outputs.branch }}
         if: steps.decisions.outputs.PUBLISH == 'true'
-        uses: snapcore/action-publish@v1
+        uses: canonical/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:

--- a/.github/workflows/spread-scheduled.yaml
+++ b/.github/workflows/spread-scheduled.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build snap
-        uses: snapcore/action-build@v1
+        uses: canonical/action-build@v1
         id: snapcraft
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Build snapcraft snap
         id: build-snapcraft
-        uses: snapcore/action-build@v1
+        uses: canonical/action-build@v1
 
       - name: Upload snapcraft snap
         uses: actions/upload-artifact@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tests/spread/tools/snapd-testing-tools"]
 	path = tests/spread/tools/snapd-testing-tools
-	url = https://github.com/snapcore/snapd-testing-tools.git
+	url = https://github.com/canonical/snapd-testing-tools.git
 [submodule "docs/sphinx-resources"]
 	path = docs/sphinx-resources
 	url = https://github.com/canonical/sphinx-docs-starter-pack.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       name: store
       workspaces:
         use: snaps
-      if: head_repo = "snapcore/snapcraft"
+      if: head_repo = "canonical/snapcraft"
       script:
         - ./runtests.sh spread "google:ubuntu-18.04-64:tests/spread/general/store"
 
@@ -56,23 +56,23 @@ jobs:
         RISK: "stable"
       script:
         - cd docker
-        - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
-        - docker run snapcore/snapcraft:${RISK} snapcraft --version
+        - docker build --no-cache -f ${RISK}.Dockerfile --tag canonical/snapcraft:${RISK} .
+        - docker run canonical/snapcraft:${RISK} snapcraft --version
     - env:
         RISK: "edge"
       script:
         - cd docker
-        - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
-        - docker run snapcore/snapcraft:${RISK} snapcraft --version
+        - docker build --no-cache -f ${RISK}.Dockerfile --tag canonical/snapcraft:${RISK} .
+        - docker run canonical/snapcraft:${RISK} snapcraft --version
     - env:
         RISK: "beta"
       script:
         - cd docker
-        - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
-        - docker run snapcore/snapcraft:${RISK} snapcraft --version
+        - docker build --no-cache -f ${RISK}.Dockerfile --tag canonical/snapcraft:${RISK} .
+        - docker run canonical/snapcraft:${RISK} snapcraft --version
     - env:
         RISK: "candidate"
       script:
         - cd docker
-        - docker build --no-cache -f ${RISK}.Dockerfile --tag snapcore/snapcraft:${RISK} .
-        - docker run snapcore/snapcraft:${RISK} snapcraft --version
+        - docker build --no-cache -f ${RISK}.Dockerfile --tag canonical/snapcraft:${RISK} .
+        - docker run canonical/snapcraft:${RISK} snapcraft --version

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,7 +7,7 @@ We want to make sure everyone develops using a consistent base, to ensure that t
 Clone the snapcraft repository and its submodules and make it your working directory:
 
 ```shell
-git clone https://github.com/snapcore/snapcraft.git --recurse-submodules
+git clone https://github.com/canonical/snapcraft.git --recurse-submodules
 cd snapcraft
 ```
 
@@ -105,7 +105,7 @@ To download the snap, find the relevant CI job run for the PR under review and l
 
 We'd love the help!
 
-- Submit pull requests against [snapcraft](https://github.com/snapcore/snapcraft/pulls)
+- Submit pull requests against [snapcraft](https://github.com/canonical/snapcraft/pulls)
 - Make sure to read the [contribution guide](CONTRIBUTING.md)
 - Find us under the snapcraft category of the forum https://forum.snapcraft.io
 - Discuss with us using IRC in #snapcraft on Freenode.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![snapcraft](https://snapcraft.io/snapcraft/badge.svg)](https://snapcraft.io/snapcraft)
 [![Build Status][travis-image]][travis-url]
 [![Documentation Status](https://readthedocs.com/projects/canonical-snapcraft/badge/?version=latest)](https://canonical-snapcraft.readthedocs-hosted.com/en/latest/?badge=latest)
-[![Scheduled spread tests](https://github.com/snapcore/snapcraft/actions/workflows/spread-scheduled.yaml/badge.svg?branch=main)](https://github.com/snapcore/snapcraft/actions/workflows/spread-scheduled.yaml)
+[![Scheduled spread tests](https://github.com/canonical/snapcraft/actions/workflows/spread-scheduled.yaml/badge.svg?branch=main)](https://github.com/canonical/snapcraft/actions/workflows/spread-scheduled.yaml)
 [![Coverage Status][codecov-image]][codecov-url]
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
@@ -29,8 +29,8 @@ Learn about the latest features by following Snapcraft on
 We love contributors. Read the [hacking guide](HACKING.md) if you're interested in helping out.
 
 
-[travis-image]: https://travis-ci.org/snapcore/snapcraft.svg?branch=master
-[travis-url]: https://travis-ci.org/snapcore/snapcraft
+[travis-image]: https://travis-ci.org/canonical/snapcraft.svg?branch=master
+[travis-url]: https://travis-ci.org/canonical/snapcraft
 
-[codecov-image]: https://codecov.io/github/snapcore/snapcraft/coverage.svg?branch=master
-[codecov-url]: https://codecov.io/github/snapcore/snapcraft?branch=master
+[codecov-image]: https://codecov.io/github/canonical/snapcraft/coverage.svg?branch=master
+[codecov-url]: https://codecov.io/github/canonical/snapcraft?branch=master

--- a/TESTING.md
+++ b/TESTING.md
@@ -151,7 +151,7 @@ It's possible to select only one of the suites using `--test-name`, for example:
 
 ## Spread tests for the snapcraft snap
 
-[Spread](https://github.com/snapcore/spread) is a system to distribute tests and execute them in different backends, in parallel. We are currently using spread only to run the integration suite using the installed snapcraft snap from the edge channel.
+[Spread](https://github.com/canonical/spread) is a system to distribute tests and execute them in different backends, in parallel. We are currently using spread only to run the integration suite using the installed snapcraft snap from the edge channel.
 
 To run them, first, download the spread binary:
 

--- a/debian/control
+++ b/debian/control
@@ -3,9 +3,9 @@ Section: utils
 Priority: extra
 Maintainer: Snapcraft Team <snapcraft@lists.snapcraft.io>
 Build-Depends: debhelper
-Homepage: https://github.com/snapcore/snapcraft
-Vcs-Git: https://github.com/snapcore/snapcraft.git
-Vcs-Browser: https://github.com/snapcore/snapcraft
+Homepage: https://github.com/canonical/snapcraft
+Vcs-Git: https://github.com/canonical/snapcraft.git
+Vcs-Browser: https://github.com/canonical/snapcraft
 Standards-Version: 4.1.3
 
 Package: snapcraft

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Snapcraft
 Upstream-Contact: Snapcraft Team <snapcraft@lists.snapcraft.io>
-Source: https://github.com/snapcore/snapcraft
+Source: https://github.com/canonical/snapcraft
 
 Files: *
 Copyright: 2015-2017 Canonical Ltd

--- a/docs/explanation/architectures.rst
+++ b/docs/explanation/architectures.rst
@@ -239,4 +239,4 @@ architectures supported by Launchpad.
 The second cause is the same :ref:`as above<build-plan-error>` - not enclosing
 a list of multiple architectures with brackets.
 
-.. _`issue 4340`: https://github.com/snapcore/snapcraft/issues/4340
+.. _`issue 4340`: https://github.com/canonical/snapcraft/issues/4340

--- a/extensions/desktop/common/desktop-exports
+++ b/extensions/desktop/common/desktop-exports
@@ -3,7 +3,7 @@
 # Launcher common exports for any desktop app
 # This is not used with the gnome extension for
 # core22 and later, please see
-# https://github.com/snapcore/snapcraft-desktop-integration
+# https://github.com/canonical/snapcraft-desktop-integration
 ###########################################################
 
 # Note: We avoid using `eval` because we don't want to expand variable names

--- a/extensions/desktop/common/fonts
+++ b/extensions/desktop/common/fonts
@@ -3,7 +3,7 @@
 ###########################################################
 # This is not used with the gnome extension for
 # core22 and later, please see
-# https://github.com/snapcore/snapcraft-desktop-integration
+# https://github.com/canonical/snapcraft-desktop-integration
 ###########################################################
 
 set -e

--- a/extensions/desktop/common/init
+++ b/extensions/desktop/common/init
@@ -3,7 +3,7 @@
 # Launcher init
 # This is not used with the gnome extension for
 # core22 and later, please see
-# https://github.com/snapcore/snapcraft-desktop-integration
+# https://github.com/canonical/snapcraft-desktop-integration
 ###########################################################
 
 # shellcheck disable=SC2034

--- a/extensions/desktop/common/mark-and-exec
+++ b/extensions/desktop/common/mark-and-exec
@@ -3,7 +3,7 @@
 # Mark update and exec binary
 # This is not used with the gnome extension for
 # core22 and later, please see
-# https://github.com/snapcore/snapcraft-desktop-integration
+# https://github.com/canonical/snapcraft-desktop-integration
 ###########################################################
 
 # shellcheck disable=SC2154

--- a/extensions/desktop/gnome/launcher-specific
+++ b/extensions/desktop/gnome/launcher-specific
@@ -3,7 +3,7 @@
 # GTK launcher specific part
 # This is not used with the gnome extension for
 # core22 and later, please see
-# https://github.com/snapcore/snapcraft-desktop-integration
+# https://github.com/canonical/snapcraft-desktop-integration
 ###########################################################
 
 # shellcheck disable=SC2154

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def recursive_data_files(directory, install_directory):
 name = "snapcraft"
 description = "Publish your app for Linux users for desktop, cloud, and IoT."
 author_email = "snapcraft@lists.snapcraft.io"
-url = "https://github.com/snapcore/snapcraft"
+url = "https://github.com/canonical/snapcraft"
 license_ = "GPL v3"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ license: GPL-3.0
 assumes:
   - snapd2.43
 
-# https://github.com/snapcore/snapcraft/issues/4187
+# https://github.com/canonical/snapcraft/issues/4187
 environment:
   PATH: "$SNAP/libexec/snapcraft:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   LD_LIBRARY_PATH: "$SNAP/none"
@@ -56,7 +56,7 @@ parts:
 
   patchelf:
     plugin: autotools
-    source: https://github.com/snapcore/patchelf
+    source: https://github.com/canonical/patchelf
     source-type: git
     source-branch: '0.9+snapcraft'
     autotools-configure-parameters:

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -204,7 +204,7 @@ class KDENeon(Extension):
         """
         # We can change this to the lightweight command-chain when
         # the content snap includes the desktop-launch from
-        # https://github.com/snapcore/snapcraft-desktop-integration
+        # https://github.com/canonical/snapcraft-desktop-integration
         source = get_extensions_data_dir() / "desktop" / "kde-neon"
 
         if self.kde_snaps.builtin:

--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -277,7 +277,7 @@ class KDENeon6(Extension):
     def get_parts_snippet(self) -> Dict[str, Any]:
         # We can change this to the lightweight command-chain when
         # the content snap includes the desktop-launch from
-        # https://github.com/snapcore/snapcraft-desktop-integration
+        # https://github.com/canonical/snapcraft-desktop-integration
         source = get_extensions_data_dir() / "desktop" / "kde-neon-6"
 
         if self.kde_snaps.kf6_builtin:

--- a/snapcraft_legacy/internal/errors.py
+++ b/snapcraft_legacy/internal/errors.py
@@ -351,7 +351,7 @@ class MissingGadgetError(SnapcraftError):
         "file\n"
         "in the root of your snapcraft project\n\n"
         "Read more about gadget snaps and the gadget.yaml on:\n"
-        "https://github.com/snapcore/snapd/wiki/Gadget-snap"
+        "https://snapcraft.io/docs/the-gadget-snap"
     )
 
 

--- a/snapcraft_legacy/internal/meta/slots.py
+++ b/snapcraft_legacy/internal/meta/slots.py
@@ -170,7 +170,7 @@ class ContentSlot(Slot):
 
         # Content directories may be nested under "source",
         # but they cannot be in both places according to snapd:
-        # https://github.com/snapcore/snapd/blob/master/interfaces/builtin/content.go#L81
+        # https://github.com/canonical/snapd/blob/6341e63d82dabb39a0a834fb956fa26dc06a2788/interfaces/builtin/content.go#L81
         if "source" in slot_dict:
             source_data = slot_dict["source"]
             slot.use_source_key = True

--- a/tools/brew_install_from_source.py
+++ b/tools/brew_install_from_source.py
@@ -47,8 +47,8 @@ def main():
 def download_snapcraft_source(dest_dir):
     dest_file = os.path.join(dest_dir, "snapcraft-0.1.tar.gz")
     branch_source = "https://github.com/{}/archive/{}.tar.gz".format(
-        os.environ.get("TRAVIS_PULL_REQUEST_SLUG") or "snapcore/snapcraft",
-        os.environ.get("TRAVIS_PULL_REQUEST_BRANCH") or "master",
+        os.environ.get("TRAVIS_PULL_REQUEST_SLUG") or "canonical/snapcraft",
+        os.environ.get("TRAVIS_PULL_REQUEST_BRANCH") or "main",
     )
     print("Downloading branch source from {}".format(branch_source))
     urllib.request.urlretrieve(branch_source, dest_file)  # noqa S310

--- a/tools/retry_autopkgtest.sh
+++ b/tools/retry_autopkgtest.sh
@@ -53,5 +53,5 @@ for testrun in "${tests[@]}"; do
     [ -z "$architecture" ] && architecture='amd64'
     [ -n "$testsuite" ] && testname="&testname=${testsuite}"
     echo "Launching tests for the ${release} release in the ${architecture} architecture..."
-    "${temp_dir}/retry-github-test" "https://api.github.com/repos/snapcore/snapcraft/pulls/${pr}" "https://autopkgtest.ubuntu.com/request.cgi?release=${release}&arch=${architecture}&package=snapcraft${testname}&ppa=snappy-dev%2Fsnapcraft-daily" "${temp_dir}/sec.txt"
+    "${temp_dir}/retry-github-test" "https://api.github.com/repos/canonical/snapcraft/pulls/${pr}" "https://autopkgtest.ubuntu.com/request.cgi?release=${release}&arch=${architecture}&package=snapcraft${testname}&ppa=snappy-dev%2Fsnapcraft-daily" "${temp_dir}/sec.txt"
 done


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

All repositories in the snapcore project have been migrated to canonical.

I believe any code related to Travis CI is outdated and can be removed, but that should be a separate PR.