### PR TITLE
tests: fix validation sets spread test

### DIFF
--- a/tests/spread/store/validation-sets/editor.sh
+++ b/tests/spread/store/validation-sets/editor.sh
@@ -2,11 +2,11 @@
 
 validation_set_file="$1"
 
-# flip-flop between two valid revisions of `test-snapcraft-assertions` in the staging store: 1 and 2
-if grep -q "^  revision:.*1" "$validation_set_file"; then
-  (( revision=2 ))
+# flip-flop between 'hello-world' being optional or required
+if grep -q "^  presence:.*optional" "$validation_set_file"; then
+  presence="required"
 else
-  (( revision=1 ))
+  presence="optional"
 fi
 
-sed -i "s/  revision:.*/  revision: $revision/g" "$validation_set_file"
+sed -i "s/  presence:.*/  presence: $presence/g" "$validation_set_file"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

[Behind the scenes](https://github.com/canonical/snapcraft/pull/5074/files#diff-610b821ececc50adda118ec968fe837957ad1941ad14c938e7e61830d9b0d929R7-R17), I updated the validation sets spread test to use the `hello-world` snap.

This PR flip-flops the `presence` instead of the `revision`, which should make it a little more robust because it won't depend on a specific revision of the snap being accessible.

Fixes #5053
(CRAFT-3418)