### PR TITLE
docs(changelog): cherry-pick 8.3.3 and 8.3.4 release notes

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -129,6 +129,23 @@ Store
 For a complete list of changes, check out the `8.4.1`_ release on GitHub.
 
 
+8.3.4 (2024-Sep-13)
+-------------------
+
+Core
+====
+
+Plugins
+#######
+
+NPM
+"""
+* Fix a bug where NPM parts fail to build if the ``pull`` and ``build`` steps
+  did not occur in the same execution of Snapcraft.
+
+For a complete list of commits, check out the `8.3.4`_ release on GitHub.
+
+
 8.4.0 (2024-Sep-10)
 -------------------
 
@@ -1237,5 +1254,6 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _8.3.1: https://github.com/canonical/snapcraft/releases/tag/8.3.1
 .. _8.3.2: https://github.com/canonical/snapcraft/releases/tag/8.3.2
 .. _8.3.3: https://github.com/canonical/snapcraft/releases/tag/8.3.3
+.. _8.3.4: https://github.com/canonical/snapcraft/releases/tag/8.3.4
 .. _8.4.0: https://github.com/canonical/snapcraft/releases/tag/8.4.0
 .. _8.4.1: https://github.com/canonical/snapcraft/releases/tag/8.4.1

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -230,6 +230,27 @@ Documentation
 For a complete list of commits, check out the `8.4.0`_ release on GitHub.
 
 
+8.3.3 (2024-Aug-28)
+-------------------
+
+Core
+====
+
+* Improve detection and error messages when LXD is not installed or not
+  properly enabled.
+
+Bases
+#####
+
+core24
+""""""
+
+* Require Multipass >= ``1.14.1`` when using Multipass to build ``core24``
+  snaps.
+
+For a complete list of commits, check out the `8.3.3`_ release on GitHub.
+
+
 .. _7.5.6_changelog:
 
 7.5.6 (2024-Aug-15)
@@ -1215,5 +1236,6 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _8.3.0: https://github.com/canonical/snapcraft/releases/tag/8.3.0
 .. _8.3.1: https://github.com/canonical/snapcraft/releases/tag/8.3.1
 .. _8.3.2: https://github.com/canonical/snapcraft/releases/tag/8.3.2
+.. _8.3.3: https://github.com/canonical/snapcraft/releases/tag/8.3.3
 .. _8.4.0: https://github.com/canonical/snapcraft/releases/tag/8.4.0
 .. _8.4.1: https://github.com/canonical/snapcraft/releases/tag/8.4.1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Cherry-pick 8.3 changelog entries that landed after the `hotfix/8.4` was created.

This fixes a problem in the docs where `latest` has all changelog entries but `stable` is missing 8.3.3 and 8.3.4.

This will need to be done in the future whenever changelog entries are created for older releases.