### PR TITLE
fix(remotebuild): do not auto clean interrupted builds

### DIFF
--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -308,7 +308,7 @@ class RemoteBuildCommand(ExtensibleCommand):
                 emit.progress("Remote repository already exists.", permanent=True)
                 emit.progress("Cleaning up")
                 builder.cleanup()
-                return 75
+                return os.EX_TEMPFAIL
 
         try:
             returncode = self._monitor_and_complete(build_id, builds)
@@ -316,10 +316,13 @@ class RemoteBuildCommand(ExtensibleCommand):
             if confirm_with_user("Cancel builds?", default=True):
                 emit.progress("Cancelling builds.")
                 builder.cancel_builds()
-            returncode = 0
+                emit.progress("Cleaning up.")
+                builder.cleanup()
+            return os.EX_OK
         except Exception:  # noqa: BLE001 [blind-except]
             returncode = 1  # General error on any other exception
-        if returncode != 75:  # TimeoutError
+
+        if returncode != os.EX_TEMPFAIL:
             emit.progress("Cleaning up")
             builder.cleanup()
         return returncode


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Fixes a bug where the remote builder would ignore the user and always clean the launchpad project. 

Also drops some magic values in favor of constants.

(CRAFT-3140)
Fixes #4929