### PR TITLE
build(deps): bump craft-store to 3.0.2

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -31,7 +31,7 @@ craft-grammar==2.0.1
 craft-parts==2.1.1
 craft-platforms==0.1.1
 craft-providers==2.0.1
-craft-store==3.0.1
+craft-store==3.0.2
 cryptography==43.0.1
 cssutils==2.11.1
 dict2css==0.3.0.post1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -26,7 +26,7 @@ craft-grammar==2.0.1
 craft-parts==2.1.1
 craft-platforms==0.1.1
 craft-providers==2.0.1
-craft-store==3.0.1
+craft-store==3.0.2
 cryptography==43.0.1
 cssutils==2.11.1
 dict2css==0.3.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ craft-grammar==2.0.1
 craft-parts==2.1.1
 craft-platforms==0.1.1
 craft-providers==2.0.1
-craft-store==3.0.1
+craft-store==3.0.2
 cryptography==43.0.1
 distro==1.9.0
 docutils==0.19

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ install_requires = [
     "craft-parts~=2.1",
     "craft-platforms~=0.1",
     "craft-providers~=2.0",
-    "craft-store>=3.0.1,<4.0.0",
+    "craft-store>=3.0.2,<4.0.0",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.
     "gnupg",
     "jsonschema==2.5.1",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,11 +140,12 @@ parts:
         -e 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/'
 
   libgit2:
-    source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz
-    source-checksum: sha256/17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327
+    source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.2.tar.gz
+    source-checksum: sha256/de384e29d7efc9330c6cdb126ebf88342b5025d920dcb7c645defad85195ea7f
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     build-attributes:
       - enable-patchelf
     prime:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -171,7 +171,7 @@ parts:
     build-environment:
         # Build PyNaCl from source since the wheel files interact
         # strangely with classic snaps. Well, build it all from source.
-        - "PIP_NO_BINARY": ":all"
+        - "PIP_NO_BINARY": ":all:"
         # Use base image's libsodium for PyNaCl.
         - "SODIUM_INSTALL": "system"
         - "CFLAGS": "$(pkg-config python-3.10 yaml-0.1 --cflags)"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Pending a craft-store release (https://github.com/canonical/craft-store/actions/runs/11130571185)

Cherry-picks #5061, which requires this fix for core20 spread tests to pass.

Fixes #5077
(CRAFT-3514)