### PR TITLE
fix: allow parallel installations of signed snapcraft snaps

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -30,7 +30,7 @@ craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
 craft-platforms==0.1.1
-craft-providers==2.0.1
+craft-providers==2.0.3
 craft-store==3.0.2
 cryptography==43.0.1
 cssutils==2.11.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -25,7 +25,7 @@ craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
 craft-platforms==0.1.1
-craft-providers==2.0.1
+craft-providers==2.0.3
 craft-store==3.0.2
 cryptography==43.0.1
 cssutils==2.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
 craft-platforms==0.1.1
-craft-providers==2.0.1
+craft-providers==2.0.3
 craft-store==3.0.2
 cryptography==43.0.1
 distro==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ install_requires = [
     "craft-grammar>=2.0.1,<3.0.0",
     "craft-parts~=2.1",
     "craft-platforms~=0.1",
-    "craft-providers~=2.0",
+    "craft-providers>=2.0.3,<3.0.0",
     "craft-store>=3.0.2,<4.0.0",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.
     "gnupg",

--- a/snapcraft_legacy/internal/build_providers/_snap.py
+++ b/snapcraft_legacy/internal/build_providers/_snap.py
@@ -170,11 +170,7 @@ class _SnapManager:
 
             if not snap_revision.startswith("x") and snap_channel:
                 switch_cmd = [
-                    "snap",
-                    "switch",
-                    self.snap_instance_name,
-                    "--channel",
-                    snap_channel,
+                    "snap", "switch", self.snap_name, "--channel", snap_channel
                 ]
 
             if snap_revision.startswith("x"):

--- a/snapcraft_legacy/internal/repo/snaps.py
+++ b/snapcraft_legacy/internal/repo/snaps.py
@@ -179,7 +179,13 @@ class SnapPackage:
         # We write an empty assertions file for dangerous installs to
         # have a consistent interface.
         if self.has_assertions():
-            assertions.append(["snap-declaration", "snap-name={}".format(self.name)])
+            assertions.append(
+                [
+                    "snap-declaration",
+                    # use the snap name without any alias
+                    f"snap-name={self.name.partition('_')[0]}"
+                ]
+            )
             assertions.append(
                 [
                     "snap-revision",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Fixes a bug where parallel installations of snapcraft would not work if the snapcraft snap was signed.

I recommend reviewing by commit as the refactor commit is noisy.

Fixes #4683
Fixes #4927
(CRAFT-3259)