### PR TITLE
fix: allow parallel installations of signed snapcraft snaps (7.5)

### DIFF
--- a/snapcraft_legacy/internal/build_providers/_snap.py
+++ b/snapcraft_legacy/internal/build_providers/_snap.py
@@ -170,11 +170,7 @@ class _SnapManager:
 
             if not snap_revision.startswith("x") and snap_channel:
                 switch_cmd = [
-                    "snap",
-                    "switch",
-                    self.snap_instance_name,
-                    "--channel",
-                    snap_channel,
+                    "snap", "switch", self.snap_name, "--channel", snap_channel
                 ]
 
             if snap_revision.startswith("x"):

--- a/snapcraft_legacy/internal/repo/snaps.py
+++ b/snapcraft_legacy/internal/repo/snaps.py
@@ -179,7 +179,13 @@ class SnapPackage:
         # We write an empty assertions file for dangerous installs to
         # have a consistent interface.
         if self.has_assertions():
-            assertions.append(["snap-declaration", "snap-name={}".format(self.name)])
+            assertions.append(
+                [
+                    "snap-declaration",
+                    # use the snap name without any alias
+                    f"snap-name={self.name.partition('_')[0]}"
+                ]
+            )
             assertions.append(
                 [
                     "snap-revision",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Fixes a bug where parallel installations of snapcraft would not work if the snapcraft snap was signed.

Same as #5058, but for `hotfix/7.5`.

I recommend reviewing by commit as the refactor commit is noisy.

Builds on top of https://github.com/canonical/snapcraft/pull/5088
Fixes #4683
Fixes #4927
(CRAFT-3259)