### PR TITLE
Dependency updates for 7.5.6

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -91,7 +91,7 @@ pytz==2023.3
 pyxdg==0.28
 PyYAML==6.0.2
 raven==6.10.0
-requests==2.30.0
+requests==2.32.3
 requests-toolbelt==1.0.0
 requests-unixsocket2==0.4.2
 ruff==0.0.220

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -13,9 +13,9 @@ colorama==0.4.6
 coverage==7.2.5
 craft-archives==1.1.3
 craft-cli==1.2.0
-craft-grammar==1.1.1
-craft-parts==1.19.7
-craft-providers==1.20.2
+craft-grammar==1.1.2
+craft-parts==1.19.8
+craft-providers==1.20.4
 craft-store==2.5.0
 cryptography==40.0.2
 Deprecated==1.2.14
@@ -93,7 +93,7 @@ PyYAML==6.0.2
 raven==6.10.0
 requests==2.30.0
 requests-toolbelt==1.0.0
-requests-unixsocket==0.3.0
+requests-unixsocket2==0.4.2
 ruff==0.0.220
 SecretStorage==3.3.3
 simplejson==3.19.2
@@ -116,7 +116,7 @@ types-setuptools==67.7.0.2
 types-tabulate==0.9.0.20240106
 types-urllib3==1.26.25.14
 typing_extensions==4.5.0
-urllib3==1.26.19
+urllib3==2.2.3
 venusian==3.0.0
 virtualenv==20.23.0
 wadllib==1.3.6
@@ -125,6 +125,6 @@ wrapt==1.15.0
 ws4py==0.5.1
 zope.deprecation==5.0
 zope.interface==6.0
-python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz; sys.platform == "linux"
+python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz ; sys.platform == "linux"
 setuptools<66
 pyinstaller==4.10; sys.platform == "win32"

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -74,7 +74,7 @@ pyftpdlib==1.5.10
 pylint==2.17.7
 pylint-fixme-info==1.0.4
 pylint-pytest==1.1.8
-pylxd==2.3.4
+pylxd==2.3.5
 pymacaroons==0.13.0
 PyNaCl==1.5.0
 pyparsing==3.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pytz==2023.3
 pyxdg==0.28
 PyYAML==6.0.2
 raven==6.10.0
-requests==2.30.0
+requests==2.32.3
 requests-toolbelt==1.0.0
 requests-unixsocket2==0.4.2
 SecretStorage==3.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pycparser==2.21
 pydantic==1.10.7
 pydantic-yaml==0.11.2
 pyelftools==0.29
-pylxd==2.3.4
+pylxd==2.3.5
 pymacaroons==0.13.0
 PyNaCl==1.5.0
 pyparsing==3.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ charset-normalizer==3.1.0
 click==8.1.7
 craft-archives==1.1.3
 craft-cli==1.2.0
-craft-grammar==1.1.1
-craft-parts==1.19.7
-craft-providers==1.20.2
+craft-grammar==1.1.2
+craft-parts==1.19.8
+craft-providers==1.20.4
 craft-store==2.5.0
 cryptography==40.0.2
 Deprecated==1.2.14
@@ -55,7 +55,7 @@ PyYAML==6.0.2
 raven==6.10.0
 requests==2.30.0
 requests-toolbelt==1.0.0
-requests-unixsocket==0.3.0
+requests-unixsocket2==0.4.2
 SecretStorage==3.3.3
 simplejson==3.19.2
 six==1.16.0
@@ -66,9 +66,9 @@ toml==0.10.2
 types-Deprecated==1.2.9.20240311
 types-PyYAML==6.0.12.20240808
 typing_extensions==4.5.0
-urllib3==1.26.19
+urllib3==2.2.3
 wadllib==1.3.6
 wrapt==1.15.0
 ws4py==0.5.1
 zipp==3.15.0
-python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz; sys.platform == "linux"
+python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz ; sys.platform == "linux"

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ install_requires = [
     "pyyaml",
     "raven",
     "requests-toolbelt",
-    "requests-unixsocket",
+    "requests-unixsocket2",
     "requests",
     # pin setuptools<66 (CRAFT-1598)
     "setuptools<66",
@@ -131,7 +131,6 @@ install_requires = [
     "toml",
     "tinydb",
     "typing-extensions",
-    "urllib3<2",  # requests-unixsocket does not yet work with urllib3 v2.0+
 ]
 
 try:

--- a/tests/legacy/fake_servers/snapd.py
+++ b/tests/legacy/fake_servers/snapd.py
@@ -53,7 +53,6 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
 
     def _handle_snap_file(self, parsed_url):
         self.send_response(200)
-        self.send_header("Content-Length", len(parsed_url))
         self.send_header("Content-type", "text/plain")
         self.end_headers()
         self.wfile.write(parsed_url.encode())

--- a/tests/spread/electron-builder/no-template/electron-builder-hello-world/package.json
+++ b/tests/spread/electron-builder/no-template/electron-builder-hello-world/package.json
@@ -17,9 +17,12 @@
   ],
   "author": "GitHub",
   "license": "CC0-1.0",
+  "resolutions": {
+    "minimatch": "9.0.5"
+  },
   "devDependencies": {
-    "electron": "latest",
-    "electron-builder": "latest",
-    "electron-installer-snap": "latest"
+    "electron": "31.3.1",
+    "electron-builder": "25.0.1",
+    "electron-installer-snap": "5.2.0"
   }
 }


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

This is a dependency update that pulls in new patch releases of internal dependencies and switches to requests-unixsocket2, which unlocks the third commit that updates requests.