### PR TITLE
tests: add spread tests for registries

### DIFF
--- a/tests/spread/store/registries/editor.sh
+++ b/tests/spread/store/registries/editor.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+registries_file="$1"
+
+# flip-flop between 'access' being read and write
+if grep -q "^ *access:.*read" "$registries_file"; then
+  access="write"
+else
+  access="read"
+fi
+
+sed -i "s/^\([[:space:]]*\)access:.*/\1access: $access/g" "$registries_file"

--- a/tests/spread/store/registries/task.yaml
+++ b/tests/spread/store/registries/task.yaml
@@ -1,0 +1,44 @@
+summary: test the registries commands
+
+environment:
+  SNAPCRAFT_ASSERTION_KEY: "$(HOST: echo ${SNAPCRAFT_ASSERTION_KEY})"
+  SNAPCRAFT_STORE_CREDENTIALS: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"
+
+prepare: |
+  if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then
+    ERROR "No credentials set in env SNAPCRAFT_STORE_CREDENTIALS"
+  fi
+
+  if [[ -z "$SNAPCRAFT_ASSERTION_KEY" ]]; then
+    ERROR "No gpg key set in env SNAPCRAFT_ASSERTION_KEY"
+  fi
+
+  # setup snap gpg dir
+  mkdir -p "$HOME/.snap/gnupg"
+  chmod 700 "$HOME/.snap/gnupg"
+
+  # import a registered key
+  echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode > store-key.txt
+  gpg --homedir "$HOME/.snap/gnupg" --import store-key.txt
+  rm -f store-key.txt
+
+  snap install yq
+  # registries only available in edge
+  snap refresh snapd --edge
+
+execute: |
+  # ensure snapcraft is logged in and can access the store
+  snapcraft whoami
+
+  # snapcraft will use a fake file editor
+  export EDITOR="$PWD/editor.sh"
+
+  snapcraft edit-registries "$(snapcraft whoami | yq .id)" testset --key-name testspreadkey
+
+  snapcraft list-registries | MATCH testset
+
+restore: |
+  rm -rf "$HOME/.snap/gnupg"
+
+  snap remove --purge yq
+  snap refresh snapd --stable

--- a/tests/spread/store/registries/task.yaml
+++ b/tests/spread/store/registries/task.yaml
@@ -18,9 +18,7 @@ prepare: |
   chmod 700 "$HOME/.snap/gnupg"
 
   # import a registered key
-  echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode > store-key.txt
-  gpg --homedir "$HOME/.snap/gnupg" --import store-key.txt
-  rm -f store-key.txt
+  gpg --homedir "$HOME/.snap/gnupg" --import <(echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode)
 
   snap install yq
   # registries only available in edge

--- a/tests/spread/store/validation-sets/task.yaml
+++ b/tests/spread/store/validation-sets/task.yaml
@@ -18,9 +18,7 @@ prepare: |
   chmod 700 "$HOME/.snap/gnupg"
 
   # import a registered key
-  echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode > store-key.txt
-  gpg --homedir "$HOME/.snap/gnupg" --import store-key.txt
-  rm -f store-key.txt
+  gpg --homedir "$HOME/.snap/gnupg" --import <(echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode)
 
   snap install yq
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Add a spread test for `edit-registries` and `list-registries`.

Fixes #5054
(CRAFT-3419)