### PR TITLE
chore: fix deprecation warnings

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -141,7 +141,7 @@ class Snapcraft(Application):
 
     @override
     def _configure_services(self, provider_name: str | None) -> None:
-        self.services.set_kwargs(
+        self.services.update_kwargs(
             "package",
             build_plan=self._build_plan,
             snapcraft_yaml_path=self._snapcraft_yaml_path,

--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -136,7 +136,9 @@ def _submit_validation_set(
     key_name: Optional[str],
     store_client: StoreClientCLI,
 ) -> None:
-    emit.debug(f"Posting assertion to build: {edited_validation_sets.json()}")
+    emit.debug(
+        f"Posting assertion to build: {edited_validation_sets.model_dump_json()}"
+    )
     build_assertion = store_client.post_validation_sets_build_assertion(
         validation_sets=edited_validation_sets.marshal()
     )
@@ -148,7 +150,7 @@ def _submit_validation_set(
     response = store_client.post_validation_sets(
         signed_validation_sets=signed_validation_sets
     )
-    emit.debug(f"Response: {response.json()}")
+    emit.debug(f"Response: {response.model_dump_json()}")
 
 
 def _generate_template(

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -87,7 +87,7 @@ def report(
             issues_by_result.setdefault(issue.result, []).append(issue)
 
     if json_output:
-        display(json.dumps([x.dict(exclude_none=True) for x in issues]))
+        display(json.dumps([x.model_dump(exclude_none=True) for x in issues]))
     else:
         # show issues by result
         for result, header in _lint_reports.items():

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -256,8 +256,8 @@ def test_base_linter_is_file_ignored():
 
     # The "test-path" Path must be ignored by the "main" filter and all categories.
     assert linter.is_file_ignored(Path("test-path"))
-    assert linter.is_file_ignored(Path("test-path", category="test-1"))
-    assert linter.is_file_ignored(Path("test-path", category="test-2"))
+    assert linter.is_file_ignored(Path("test-path"), category="test-1")
+    assert linter.is_file_ignored(Path("test-path"), category="test-2")
 
     # "test-1-path" is ignored by the "test-1" only
     assert not linter.is_file_ignored(Path("test-1-path"))

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -76,7 +76,7 @@ def test_metadata(
 ):
     project_path = new_dir / "snapcraft.yaml"
     snapcraft_yaml(filename=project_path)
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=Path("work"),
         cache_dir=new_dir,
@@ -122,7 +122,7 @@ def test_write_metadata(
     default_build_plan,
     new_dir,
 ):
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=Path("work"),
         cache_dir=new_dir,
@@ -163,7 +163,7 @@ def test_write_metadata_with_manifest(
     new_dir,
 ):
     monkeypatch.setenv("SNAPCRAFT_BUILD_INFO", "1")
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=Path("work"),
         cache_dir=new_dir,
@@ -180,7 +180,7 @@ def test_write_metadata_with_manifest(
     # This will be different every time due to started_at differing, we can check
     # that it's a valid manifest and compare some fields to snap.yaml.
     manifest_dict = yaml.safe_load((prime_dir / "snap" / "manifest.yaml").read_text())
-    manifest = models.Manifest.parse_obj(manifest_dict)
+    manifest = models.Manifest.model_validate(manifest_dict)
 
     assert manifest.snapcraft_version == __version__
     assert (
@@ -208,7 +208,7 @@ def test_write_metadata_with_project_hooks(
         shutil.move(new_dir / "snap" / "snapcraft.yaml", new_dir)
         shutil.rmtree(new_dir / "snap")
 
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=work_dir,
         cache_dir=new_dir,
@@ -257,7 +257,7 @@ def test_write_metadata_with_built_hooks(
     new_dir,
 ):
     work_dir = new_dir / "work"
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=work_dir,
         cache_dir=new_dir,
@@ -307,7 +307,7 @@ def test_write_metadata_with_project_gui(
     new_dir,
 ):
     work_dir = new_dir / "work"
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=work_dir,
         cache_dir=new_dir,
@@ -367,7 +367,7 @@ def test_update_project_parse_info(
 ):
     work_dir = Path("work").resolve()
 
-    default_factory.set_kwargs(
+    default_factory.update_kwargs(
         "lifecycle",
         work_dir=work_dir,
         cache_dir=new_dir,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Fixes a handful of deprecation warnings from libraries.