### PR TITLE
build(deps): switch to requests-unixsocket2, release 8.4.2

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -69,6 +69,45 @@ Changelog
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
 
+8.4.2 (2024-Oct-07)
+-------------------
+
+Core
+====
+
+* Fix a regression where Snapcraft would fail to run on some architectures due
+  to a ``cryptography`` dependency that attempted to load legacy algorithms
+  (`#5077`_).
+
+* Fix a regression where Snapcraft would fail to run in a container if it was
+  not running as a snap (`#5079`_).
+
+* Fix a bug where parallel installations of Snapcraft would not work if the
+  Snapcraft snap was installed from the store (`#4683`_, `#4927`_).
+
+Plugins
+#######
+
+Python
+""""""
+
+* Fix an issue where the ``python`` plugin would fail to build if the part
+  had no Python scripts.
+
+Remote build
+============
+
+* Fix a bug where the remote builder would ignore the user's response when a
+  build is interrupted and always clean the launchpad project (`#4929`_).
+
+Documentation
+=============
+
+* Update Rust plugin doc with recent changes to the Rust toolchain.
+
+For a complete list of commits, check out the `8.4.2`_ release on GitHub.
+
+
 7.5.7 (2024-Oct-03)
 -------------------
 
@@ -1234,6 +1273,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _#4908: https://github.com/canonical/snapcraft/issues/4908
 .. _#4909: https://github.com/canonical/snapcraft/issues/4909
 .. _#4927: https://github.com/canonical/snapcraft/issues/4927
+.. _#4929: https://github.com/canonical/snapcraft/issues/4929
 .. _#4930: https://github.com/canonical/snapcraft/issues/4930
 .. _#4941: https://github.com/canonical/snapcraft/issues/4941
 .. _#4942: https://github.com/canonical/snapcraft/issues/4942
@@ -1243,6 +1283,8 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _#4995: https://github.com/canonical/snapcraft/issues/4995
 .. _#5008: https://github.com/canonical/snapcraft/issues/5008
 .. _#5048: https://github.com/canonical/snapcraft/issues/5048
+.. _#5077: https://github.com/canonical/snapcraft/issues/5077
+.. _#5079: https://github.com/canonical/snapcraft/issues/5079
 
 .. _7.5.6: https://github.com/canonical/snapcraft/releases/tag/7.5.6
 .. _7.5.7: https://github.com/canonical/snapcraft/releases/tag/7.5.7
@@ -1273,3 +1315,4 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _8.3.4: https://github.com/canonical/snapcraft/releases/tag/8.3.4
 .. _8.4.0: https://github.com/canonical/snapcraft/releases/tag/8.4.0
 .. _8.4.1: https://github.com/canonical/snapcraft/releases/tag/8.4.1
+.. _8.4.2: https://github.com/canonical/snapcraft/releases/tag/8.4.2

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -68,6 +68,19 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+
+7.5.7 (2024-Oct-03)
+-------------------
+
+Core
+====
+
+* Fix a bug where parallel installations of Snapcraft would not work if the
+  Snapcraft snap was installed from the store (`#4683`_, `#4927`_).
+
+For a complete list of commits, check out the `7.5.7`_ release on GitHub.
+
+
 8.4.1 (2024-Sep-20)
 -------------------
 
@@ -1187,6 +1200,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _#4517: https://github.com/canonical/snapcraft/issues/4517
 .. _#4520: https://github.com/canonical/snapcraft/issues/4520
 .. _#4547: https://github.com/canonical/snapcraft/issues/4547
+.. _#4683: https://github.com/canonical/snapcraft/issues/4683
 .. _#4685: https://github.com/canonical/snapcraft/issues/4685
 .. _#4735: https://github.com/canonical/snapcraft/issues/4735
 .. _#4744: https://github.com/canonical/snapcraft/issues/4744
@@ -1219,6 +1233,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _#4890: https://github.com/canonical/snapcraft/issues/4890
 .. _#4908: https://github.com/canonical/snapcraft/issues/4908
 .. _#4909: https://github.com/canonical/snapcraft/issues/4909
+.. _#4927: https://github.com/canonical/snapcraft/issues/4927
 .. _#4930: https://github.com/canonical/snapcraft/issues/4930
 .. _#4941: https://github.com/canonical/snapcraft/issues/4941
 .. _#4942: https://github.com/canonical/snapcraft/issues/4942
@@ -1230,6 +1245,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _#5048: https://github.com/canonical/snapcraft/issues/5048
 
 .. _7.5.6: https://github.com/canonical/snapcraft/releases/tag/7.5.6
+.. _7.5.7: https://github.com/canonical/snapcraft/releases/tag/7.5.7
 .. _8.0.0: https://github.com/canonical/snapcraft/releases/tag/8.0.0
 .. _8.0.1: https://github.com/canonical/snapcraft/releases/tag/8.0.1
 .. _8.0.2: https://github.com/canonical/snapcraft/releases/tag/8.0.2

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,13 +24,13 @@ click==8.1.7
 codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
-craft-application==4.2.4
+craft-application==4.2.6
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
-craft-parts==2.1.1
+craft-parts==2.1.2
 craft-platforms==0.1.1
-craft-providers==2.0.3
+craft-providers==2.0.4
 craft-store==3.0.2
 cryptography==43.0.1
 cssutils==2.11.1
@@ -108,7 +108,7 @@ pyftpdlib==1.5.10
 pygit2==1.13.3
 Pygments==2.18.0
 pylint==3.2.7
-pylxd==2.3.4
+pylxd==2.3.5
 pymacaroons==0.13.0
 PyNaCl==1.5.0
 pyparsing==3.1.4
@@ -128,9 +128,9 @@ pyxdg==0.28
 PyYAML==6.0.2
 raven==6.10.0
 regex==2024.7.24
-requests==2.31.0
+requests==2.32.3
 requests-toolbelt==1.0.0
-requests-unixsocket==0.3.0
+requests-unixsocket2==0.4.2
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
 SecretStorage==3.3.3
@@ -182,7 +182,7 @@ types-toml==0.10.8.20240310
 types-urllib3==1.26.25.14
 typing_extensions==4.12.2
 uc-micro-py==1.0.3
-urllib3==1.26.20
+urllib3==2.2.3
 uvicorn==0.30.6
 validators==0.33.0
 venusian==3.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -19,13 +19,13 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==4.2.4
+craft-application==4.2.6
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
-craft-parts==2.1.1
+craft-parts==2.1.2
 craft-platforms==0.1.1
-craft-providers==2.0.3
+craft-providers==2.0.4
 craft-store==3.0.2
 cryptography==43.0.1
 cssutils==2.11.1
@@ -81,7 +81,7 @@ pydantic_yaml==1.3.0
 pyelftools==0.31
 pygit2==1.13.3
 Pygments==2.18.0
-pylxd==2.3.4
+pylxd==2.3.5
 pymacaroons==0.13.0
 PyNaCl==1.5.0
 pyparsing==3.1.4
@@ -94,9 +94,9 @@ pyxdg==0.28
 PyYAML==6.0.2
 raven==6.10.0
 regex==2024.7.24
-requests==2.31.0
+requests==2.32.3
 requests-toolbelt==1.0.0
-requests-unixsocket==0.3.0
+requests-unixsocket2==0.4.2
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
 SecretStorage==3.3.3
@@ -136,7 +136,7 @@ tinydb==4.8.0
 toml==0.10.2
 typing_extensions==4.12.2
 uc-micro-py==1.0.3
-urllib3==1.26.20
+urllib3==2.2.3
 uvicorn==0.30.6
 validators==0.33.0
 wadllib==1.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@ cffi==1.17.1
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==4.2.4
+craft-application==4.2.6
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
-craft-parts==2.1.1
+craft-parts==2.1.2
 craft-platforms==0.1.1
-craft-providers==2.0.3
+craft-providers==2.0.4
 craft-store==3.0.2
 cryptography==43.0.1
 distro==1.9.0
@@ -47,7 +47,7 @@ pydantic_core==2.20.1
 pydantic_yaml==1.3.0
 pyelftools==0.31
 pygit2==1.13.3
-pylxd==2.3.4
+pylxd==2.3.5
 pymacaroons==0.13.0
 PyNaCl==1.5.0
 pyparsing==3.1.4
@@ -58,9 +58,9 @@ pytz==2024.1
 pyxdg==0.28
 PyYAML==6.0.2
 raven==6.10.0
-requests==2.31.0
+requests==2.32.3
 requests-toolbelt==1.0.0
-requests-unixsocket==0.3.0
+requests-unixsocket2==0.4.2
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
 SecretStorage==3.3.3
@@ -72,7 +72,7 @@ tabulate==0.9.0
 tinydb==4.8.0
 toml==0.10.2
 typing_extensions==4.12.2
-urllib3==1.26.20
+urllib3==2.2.3
 validators==0.33.0
 wadllib==1.3.6
 wheel==0.44.0

--- a/setup.py
+++ b/setup.py
@@ -98,13 +98,13 @@ install_requires = [
     "attrs",
     "catkin-pkg; sys_platform == 'linux'",
     "click",
-    "craft-application>=4.2.4,<5.0.0",
+    "craft-application>=4.2.6,<5.0.0",
     "craft-archives~=2.0",
     "craft-cli~=2.6",
     "craft-grammar>=2.0.1,<3.0.0",
-    "craft-parts~=2.1",
+    "craft-parts>=2.1.2,<3.0.0",
     "craft-platforms~=0.1",
-    "craft-providers>=2.0.3,<3.0.0",
+    "craft-providers>=2.0.4,<3.0.0",
     "craft-store>=3.0.2,<4.0.0",
     "docutils<0.20",  # Frozen until we can update sphinx dependencies.
     "gnupg",
@@ -130,7 +130,7 @@ install_requires = [
     "pyyaml",
     "raven",
     "requests-toolbelt",
-    "requests-unixsocket",
+    "requests-unixsocket2",
     "requests",
     "simplejson",
     "snap-helpers",
@@ -138,7 +138,6 @@ install_requires = [
     "toml",
     "tinydb",
     "typing-extensions",
-    "urllib3<2",  # requests-unixsocket does not yet work with urllib3 v2.0+
     "validators>=0.28.3",
 ]
 

--- a/tests/legacy/fake_servers/snapd.py
+++ b/tests/legacy/fake_servers/snapd.py
@@ -53,7 +53,6 @@ class FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
 
     def _handle_snap_file(self, parsed_url):
         self.send_response(200)
-        self.send_header("Content-Length", len(parsed_url))
         self.send_header("Content-type", "text/plain")
         self.end_headers()
         self.wfile.write(parsed_url.encode())

--- a/tests/unit/parts/plugins/test_python_plugin.py
+++ b/tests/unit/parts/plugins/test_python_plugin.py
@@ -66,7 +66,7 @@ def test_get_build_commands(plugin, new_dir):
         f'PARTS_PYTHON_VENV_INTERP_PATH="{new_dir}/parts/my-part/install/bin/${{PARTS_PYTHON_INTERPRETER}}"',
         f"{new_dir}/parts/my-part/install/bin/pip install  -U pip setuptools wheel",
         f"[ -f setup.py ] || [ -f pyproject.toml ] && {new_dir}/parts/my-part/install/bin/pip install  -U .",
-        f'find "{new_dir}/parts/my-part/install" -type f -executable -print0 | xargs -0 \\\n'
+        f'find "{new_dir}/parts/my-part/install" -type f -executable -print0 | xargs --no-run-if-empty -0 \\\n'
         '    sed -i "1 s|^#\\!${PARTS_PYTHON_VENV_INTERP_PATH}.*$|#!/usr/bin/env ${PARTS_PYTHON_INTERPRETER}|"\n',
         dedent(
             f"""\


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Adds 8.4.2 release notes for next week.

Also adds 7.5.7 release notes, as we don't have a better solution for old releases at the moment.

Fixes [CVE-2024-35195](https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56)
Fixes #5079