### PR TITLE
feat: support standard and kernel-modules

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -572,7 +572,7 @@ class Component(models.CraftBaseModel):
 
     summary: SummaryStr
     description: str
-    type: Literal["test"]
+    type: Literal["test", "kernel-modules", "standard"]
     version: VersionStr | None = None
     hooks: dict[str, Hook] | None = None
 

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -2600,16 +2600,17 @@ class TestComponents:
 
         assert test_project.components == components
 
+    @pytest.mark.parametrize("component_type", ["test", "kernel-modules", "standard"])
     def test_component_type_valid(
-        self, project, project_yaml_data, stub_component_data
+        self, component_type, project, project_yaml_data, stub_component_data
     ):
         component = {"foo": stub_component_data}
-        component["foo"]["type"] = "test"
+        component["foo"]["type"] = component_type
 
         test_project = project.unmarshal(project_yaml_data(components=component))
 
         assert test_project.components
-        assert test_project.components["foo"].type == "test"
+        assert test_project.components["foo"].type == component_type
 
     def test_component_type_invalid(
         self, project, project_yaml_data, stub_component_data


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Adds support for `standard` and `kernel-modules` component types.

(CRAFT-3520)
Fixes #5089