### PR TITLE
build(deps): bump craft-store to 2.6.2

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -16,7 +16,7 @@ craft-cli==1.2.0
 craft-grammar==1.1.2
 craft-parts==1.19.8
 craft-providers==1.20.4
-craft-store==2.5.0
+craft-store==2.6.2
 cryptography==40.0.2
 Deprecated==1.2.14
 dill==0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ craft-cli==1.2.0
 craft-grammar==1.1.2
 craft-parts==1.19.8
 craft-providers==1.20.4
-craft-store==2.5.0
+craft-store==2.6.2
 cryptography==40.0.2
 Deprecated==1.2.14
 distro==1.8.0


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Snapcraft 7 is failing to build on non-amd64 architectures for the same reason that snapcraft 8 failed.  The fix is simply updating to the version of craft-store with the fix.

The error is:
```
RuntimeError: OpenSSL 3.0's legacy provider failed to load. This is a fatal error by default, but cryptography supports running without legacy algorithms by setting the environment variable CRYPTOGRAPHY_OPENSSL_NO_LEGACY. If you did not expect this error, you have likely made a mistake with your OpenSSL configuration.
```

Full logs [here](https://launchpadlibrarian.net/752714447/buildlog_snap_ubuntu_focal_ppc64el_snapcraft-7-hotfix_BUILDING.txt.gz).

There aren't any concerning [changes](https://canonical-craft-store.readthedocs-hosted.com/en/latest/changelog/) between 2.5.0 and 2.6.2, so I'm comfortable doing a minor version bump.