### PR TITLE
bump craft-application, check parallel build count in project metadata

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,7 +24,7 @@ click==8.1.7
 codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
-craft-application==4.2.6
+craft-application==4.2.7
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -19,7 +19,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==4.2.6
+craft-application==4.2.7
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.17.1
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
-craft-application==4.2.6
+craft-application==4.2.7
 craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     "attrs",
     "catkin-pkg; sys_platform == 'linux'",
     "click",
-    "craft-application>=4.2.6,<5.0.0",
+    "craft-application>=4.2.7,<5.0.0",
     "craft-archives~=2.0",
     "craft-cli~=2.6",
     "craft-grammar>=2.0.1,<3.0.0",

--- a/tests/spread/core24-suites/environment/test-variables/task.yaml
+++ b/tests/spread/core24-suites/environment/test-variables/task.yaml
@@ -8,6 +8,7 @@ systems:
 
 environment:
   SNAP/test_variables: test-variables
+  SNAPCRAFT_PARALLEL_BUILD_COUNT: 5
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -35,7 +36,7 @@ execute: |
       "^SNAPCRAFT_PROJECT_GRADE=devel$" \
       "^SNAPCRAFT_PROJECT_NAME=variables$" \
       "^SNAPCRAFT_PROJECT_VERSION=1$" \
-      "^SNAPCRAFT_PARALLEL_BUILD_COUNT=[0-9]\+$" \
+      "^SNAPCRAFT_PARALLEL_BUILD_COUNT=5$" \
       "^SNAPCRAFT_PROJECT_DIR=${root}$" \
       "^SNAPCRAFT_PART_SRC=${root}/parts/hello/src$" \
       "^SNAPCRAFT_PART_SRC_WORK=${root}/parts/hello/src$" \
@@ -48,7 +49,7 @@ execute: |
       "^CRAFT_ARCH_TRIPLET_BUILD_ON=x86_64-linux-gnu$" \
       "^CRAFT_ARCH_BUILD_FOR=s390x$" \
       "^CRAFT_ARCH_TRIPLET_BUILD_FOR=s390x-linux-gnu$" \
-      "^CRAFT_PARALLEL_BUILD_COUNT=[0-9]\+$" \
+      "^CRAFT_PARALLEL_BUILD_COUNT=5$" \
       "^CRAFT_PROJECT_DIR=${root}$" \
       "^CRAFT_PART_NAME=hello$" \
       "^CRAFT_PART_SRC=${root}/parts/hello/src$" \


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Fixes https://github.com/canonical/snapcraft/issues/4785
(CRAFT-3526)