### PR TITLE
extensions: simplifies the platform plug

### DIFF
--- a/extensions/desktop/command-chain/Makefile
+++ b/extensions/desktop/command-chain/Makefile
@@ -6,6 +6,7 @@ GPU_WRAPPER :=
 scripts = hooks-configure-fonts desktop-launch run $(GPU_WRAPPER)
 
 *:
+	sed -e "s/%PLATFORM_PLUG%/$${PLATFORM_PLUG:?}/" -i desktop-launch hooks-configure-fonts
 	install -D -m755 "$@" "$(BIN_DIR)"/"$@"
 
 install: $(scripts)

--- a/extensions/desktop/command-chain/desktop-launch
+++ b/extensions/desktop/command-chain/desktop-launch
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-set -- "${SNAP}/gnome-platform/command-chain/desktop-launch" "$@"
+set -- "${SNAP}/%PLATFORM_PLUG%/command-chain/desktop-launch" "$@"
 # shellcheck source=/dev/null
 source "${SNAP}/snap/command-chain/run"

--- a/extensions/desktop/command-chain/hooks-configure-fonts
+++ b/extensions/desktop/command-chain/hooks-configure-fonts
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-set -- "${SNAP}/gnome-platform/command-chain/hooks-configure-fonts" "$@"
+set -- "${SNAP}/%PLATFORM_PLUG%/command-chain/hooks-configure-fonts" "$@"
 # shellcheck source=/dev/null
 source "${SNAP}/snap/command-chain/run"

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -330,6 +330,7 @@ class GNOME(Extension):
                     "source": str(source),
                     "plugin": "make",
                     "build-snaps": [sdk_snap],
+                    "make-parameters": ["PLATFORM_PLUG=gnome-platform"],
                     **gpu_opts,
                 },
             }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

This PR simplifies the desktop command chain approach, also adds support for separate Platform plug which was also used previously.

Better to merge this before #5092 