### PR TITLE
build(deps): bump craft-archives

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -25,7 +25,7 @@ codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
 craft-application==4.2.7
-craft-archives @ git+https://github.com/canonical/craft-archives@work/CRAFT-3538-noble-key-conflict
+craft-archives==2.0.1
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.2

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -25,7 +25,7 @@ codespell==2.3.0
 colorama==0.4.6
 coverage==7.6.1
 craft-application==4.2.7
-craft-archives==2.0.0
+craft-archives @ git+https://github.com/canonical/craft-archives@work/CRAFT-3538-noble-key-conflict
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
 craft-application==4.2.7
-craft-archives==2.0.0
+craft-archives @ git+https://github.com/canonical/craft-archives@work/CRAFT-3538-noble-key-conflict
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
 craft-application==4.2.7
-craft-archives @ git+https://github.com/canonical/craft-archives@work/CRAFT-3538-noble-key-conflict
+craft-archives==2.0.1
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 craft-application==4.2.7
-craft-archives==2.0.0
+craft-archives @ git+https://github.com/canonical/craft-archives@work/CRAFT-3538-noble-key-conflict
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.1.7
 craft-application==4.2.7
-craft-archives @ git+https://github.com/canonical/craft-archives@work/CRAFT-3538-noble-key-conflict
+craft-archives==2.0.1
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.2

--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -9,6 +9,7 @@ environment:
   SNAP/test_multi_keys: test-multi-keys
   SNAP/test_foreign_armhf: test-foreign-armhf
   SNAP/test_foreign_i386: test-foreign-i386
+  SNAP/test_key_conflict: test-key-conflict
 
 prepare: |
   # Remove the currently installed "gpg" and "dirmngr" packages to ensure that

--- a/tests/spread/core24/package-repositories/test-key-conflict/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-key-conflict/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: test-key-conflict
+version: '1.0'
+summary: test package repos with keys already present on the system
+description: test package repos with keys already present on the system
+confinement: strict
+base: core24
+platforms:
+  amd64:
+
+package-repositories:
+  # In core24 this pair of url + suite is already listed in
+  # /etc/apt/sources.list.d/ubuntu.sources. Add it here to make sure this setup
+  # is working.
+  - type: apt
+    url: http://archive.ubuntu.com/ubuntu
+    suites: [noble]
+    components: [main, universe]
+    architectures: [i386]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    key-server: keyserver.ubuntu.com
+
+parts:
+  mypart:
+    plugin: nil
+    stage-packages:
+      - zlib1g:i386 # To ensure the package-repo is setup correctly
+      - hello       # there is no hello:i386 in the archives
+
+apps:
+  test-key-conflict:
+    command: usr/bin/hello -g hello

--- a/tests/spread/core24/package-repositories/test-key-conflict/snapcraft.yaml
+++ b/tests/spread/core24/package-repositories/test-key-conflict/snapcraft.yaml
@@ -8,7 +8,7 @@ platforms:
   amd64:
 
 package-repositories:
-  # In core24 this pair of url + suite is already listed in
+  # In core24+ this pair of url + suite is already listed in
   # /etc/apt/sources.list.d/ubuntu.sources. Add it here to make sure this setup
   # is working.
   - type: apt
@@ -18,12 +18,21 @@ package-repositories:
     architectures: [i386]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
     key-server: keyserver.ubuntu.com
+  # This ports.ubuntu.com repo is not affected by the bug, but add it here to
+  # ensure that a different repo with the same key-id still works.
+  - type: apt
+    url: http://ports.ubuntu.com/ubuntu-ports
+    suites: [noble]
+    architectures: [armhf]
+    components: [main]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
 
 parts:
   mypart:
     plugin: nil
     stage-packages:
       - zlib1g:i386 # To ensure the package-repo is setup correctly
+      - zlib1g:armhf
       - hello       # there is no hello:i386 in the archives
 
 apps:


### PR DESCRIPTION
This update fixes LP#2083013, where some package-repositories declarations could conflict with default sources present in Noble.

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
