### PR TITLE
docs(changelog): add 8.4.4 and 7.5.8 release notes

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -68,6 +68,40 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+8.4.4 (2024-Oct-24)
+-------------------
+
+Core
+====
+
+Bases
+#####
+
+core24
+""""""
+
+* Fix a bug where ``CRAFT_PARALLEL_BUILD_COUNT`` was not evaluated in
+  ``snapcraft.yaml`` files (`#4785`_).
+
+* Fix a bug where ``package-repositories`` declarations could conflict with
+  default sources present in Noble (`LP#2083013`_).
+
+For a complete list of commits, check out the `8.4.4`_ release on GitHub.
+
+
+7.5.8 (2024-Oct-24)
+-------------------
+
+Core
+====
+
+* Fix a regression where Snapcraft would fail to run on some architectures due
+  to a ``cryptography`` dependency that attempted to load legacy algorithms
+  (`#5077`_).
+
+For a complete list of commits, check out the `7.5.8`_ release on GitHub.
+
+
 8.4.3 (2024-Oct-10)
 -------------------
 
@@ -1241,6 +1275,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _LP#2061603: https://bugs.launchpad.net/snapcraft/+bug/2061603
 .. _LP#2064639: https://bugs.launchpad.net/snapcraft/+bug/2064639
 .. _LP#2069783: https://bugs.launchpad.net/snapcraft/+bug/2069783
+.. _LP#2083013: https://bugs.launchpad.net/snapcraft/+bug/2083013
 
 .. _#4142: https://github.com/canonical/snapcraft/issues/4142
 .. _#4356: https://github.com/canonical/snapcraft/issues/4356
@@ -1266,6 +1301,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _#4780: https://github.com/canonical/snapcraft/issues/4780
 .. _#4781: https://github.com/canonical/snapcraft/issues/4781
 .. _#4783: https://github.com/canonical/snapcraft/issues/4783
+.. _#4785: https://github.com/canonical/snapcraft/issues/4785
 .. _#4791: https://github.com/canonical/snapcraft/issues/4791
 .. _#4798: https://github.com/canonical/snapcraft/issues/4798
 .. _#4804: https://github.com/canonical/snapcraft/issues/4804
@@ -1302,6 +1338,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 
 .. _7.5.6: https://github.com/canonical/snapcraft/releases/tag/7.5.6
 .. _7.5.7: https://github.com/canonical/snapcraft/releases/tag/7.5.7
+.. _7.5.8: https://github.com/canonical/snapcraft/releases/tag/7.5.8
 .. _8.0.0: https://github.com/canonical/snapcraft/releases/tag/8.0.0
 .. _8.0.1: https://github.com/canonical/snapcraft/releases/tag/8.0.1
 .. _8.0.2: https://github.com/canonical/snapcraft/releases/tag/8.0.2
@@ -1331,3 +1368,4 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 .. _8.4.1: https://github.com/canonical/snapcraft/releases/tag/8.4.1
 .. _8.4.2: https://github.com/canonical/snapcraft/releases/tag/8.4.2
 .. _8.4.3: https://github.com/canonical/snapcraft/releases/tag/8.4.3
+.. _8.4.4: https://github.com/canonical/snapcraft/releases/tag/8.4.4


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Adds release notes for 7.5.8 and 8.4.4.