### PR TITLE
fix(docs): display examples correctly in RTD

### DIFF
--- a/snapcraft/commands/legacy.py
+++ b/snapcraft/commands/legacy.py
@@ -62,7 +62,8 @@ class StoreLegacyUploadMetadataCommand(LegacyAppCommand):
         If --force is used, it will force the local metadata into the Store,
         ignoring any possible conflict.
 
-        Examples:
+        Examples::
+
             snapcraft upload-metadata my-snap_0.1_amd64.snap
             snapcraft upload-metadata my-snap_0.1_amd64.snap --force
         """

--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -56,7 +56,8 @@ class StoreReleaseCommand(AppCommand):
             - <branch> is optional and dynamically creates a channel with a
               specific expiration date.
 
-        Examples:
+        Examples::
+
             snapcraft release my-snap 8 stable
             snapcraft release my-snap 8 stable/my-branch
             snapcraft release my-snap 9 beta,edge
@@ -120,7 +121,8 @@ class StoreCloseCommand(AppCommand):
         As such, closing the 'candidate' channel for a snap would make
         that snap begin to track the 'stable' channel.
 
-        Examples:
+        Examples::
+
             snapcraft close my-snap --channel beta
         """
     )

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Snapcraft Store Account management commands."""
+
 import itertools
 import operator
 import textwrap
@@ -431,7 +432,8 @@ class StoreListRevisionsCommand(AppCommand):
     help_msg = "List published revisions for <snap-name>"
     overview = textwrap.dedent(
         """
-        Examples:
+        Examples::
+
             snapcraft list-revisions my-snap
             snapcraft list-revisions my-snap --arch armhf
             snapcraft revisions my-snap

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Snapcraft Store Account management commands."""
-
 import itertools
 import operator
 import textwrap


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

Some of the commands auto-generated docs were not rendered correctly, this PR addresses that

Before:
![image](https://github.com/user-attachments/assets/cb14bc23-b412-4ef5-bd22-bfd7f2257dda)

After:
![image](https://github.com/user-attachments/assets/ca8a657c-473c-4679-badb-728d6cd4cfcb)

