### PR TITLE
fix(unsquashfs): fix Fatal Error when using unsquashfs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -130,7 +130,6 @@ parts:
         - python3-distutils
         - python3-pkg-resources
         - python3.10-minimal
-        - squashfs-tools
         - xdelta3
     build-attributes:
       - enable-patchelf
@@ -163,6 +162,26 @@ parts:
       # Disable site packages
       sed -i "${SNAPCRAFT_PART_INSTALL}/usr/lib/python3.10/site.py" \
         -e 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/'
+
+  squashfs-tools:
+    source: https://github.com/plougher/squashfs-tools
+    source-type: git
+    source-tag: "4.6.1"
+    after: ["snapcraft-libs"]
+    plugin: make
+    build-packages:
+      - help2man
+      - liblz4-dev
+      - liblzo2-dev
+    build-environment:
+      - CONFIG: "1"
+      - INSTALL_PREFIX: "${CRAFT_PART_INSTALL}/usr"
+      - LZMA_XZ_SUPPORT: "1"
+      - LZ4_SUPPORT: "1"
+      - LZO_SUPPORT: "1"
+      - XZ_SUPPORT: "1"
+    make-parameters:
+      - -C squashfs-tools
 
   libgit2:
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.2.tar.gz


### PR DESCRIPTION
When trying to push a big snap to the snap store, snapcraft fails with the error

    FATAL ERROR: Data queue size is too large

This is a bug in unsquashfs tool 4.5. But it has been fixed in 4.6.1, the current stable.

This patch builds squashfs-tools version 4.6.1 from the GIT repository, thus fixing this problem.

Fix https://github.com/canonical/snapcraft/issues/5132
Fix https://forum.snapcraft.io/t/fatal-error-data-queue-size-is-too-large/43875

- [X] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [~] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
