### PR TITLE
feat(snap): add git as craft.git to snapcraft

### DIFF
--- a/snap/local/craft.git
+++ b/snap/local/craft.git
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+GIT_EXEC_PATH="${SNAP}/usr/lib/git-core" exec "${SNAP}/usr/lib/git-core/git" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,14 +68,8 @@ parts:
     build-attributes:
       - enable-patchelf
     prime:
-      - "-usr/bin"
-      - "-usr/share/doc"
-      - "-usr/share/man"
-      # perl is part of the core22 / core24
-      - "-usr/share/perl"
-      - "-usr/lib/x86_64-linux-gnu/perl"
-      - "-usr/lib/x86_64-linux-gnu/libperl*"
-      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
+      - "usr/lib/git-core"
+      - "usr/share/git-core"
 
   patchelf:
     plugin: autotools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,29 @@ parts:
     stage:
       - snapcraft-completion
 
+  snapcraft-scripts:
+    source: snap/local
+    plugin: dump
+    organize:
+      craft.git: libexec/snapcraft/craft.git
+    stage:
+      - "libexec/"
+
+  git:
+    plugin: nil
+    stage-packages: [git]
+    build-attributes:
+      - enable-patchelf
+    prime:
+      - "-usr/bin"
+      - "-usr/share/doc"
+      - "-usr/share/man"
+      # perl is part of the core22 / core24
+      - "-usr/share/perl"
+      - "-usr/lib/x86_64-linux-gnu/perl"
+      - "-usr/lib/x86_64-linux-gnu/libperl*"
+      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
+
   patchelf:
     plugin: autotools
     source: https://github.com/canonical/patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,11 +70,10 @@ parts:
     prime:
       - "usr/lib/git-core"
       - "usr/share/git-core"
-      - "usr/lib/x86_64-linux-gnu"
-      # perl is part of the core22 / core24
-      - "-usr/lib/x86_64-linux-gnu/perl"
-      - "-usr/lib/x86_64-linux-gnu/libperl*"
-      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
+      - "usr/lib/x86_64-linux-gnu/libcurl-gnutls*"
+      - "usr/lib/x86_64-linux-gnu/libpsl*"
+      - "usr/lib/x86_64-linux-gnu/librtmp*"
+      - "usr/lib/x86_64-linux-gnu/libnghttp2*"
 
   patchelf:
     plugin: autotools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,6 +70,11 @@ parts:
     prime:
       - "usr/lib/git-core"
       - "usr/share/git-core"
+      - "usr/lib/x86_64-linux-gnu"
+      # perl is part of the core22 / core24
+      - "-usr/lib/x86_64-linux-gnu/perl"
+      - "-usr/lib/x86_64-linux-gnu/libperl*"
+      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
 
   patchelf:
     plugin: autotools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,6 +74,10 @@ parts:
       - "usr/lib/x86_64-linux-gnu/libpsl*"
       - "usr/lib/x86_64-linux-gnu/librtmp*"
       - "usr/lib/x86_64-linux-gnu/libnghttp2*"
+      - "usr/lib/x86_64-linux-gnu/libldap*"
+      - "usr/lib/x86_64-linux-gnu/liblber*"
+      - "usr/lib/x86_64-linux-gnu/libsasl2*"
+
 
   patchelf:
     plugin: autotools

--- a/tests/spread/core24/craftgit/snap/snapcraft.yaml
+++ b/tests/spread/core24/craftgit/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: craftgit-test
+base: core24
+version: '0.1'
+summary: Echo
+description: Just a dummy build to check if craft.git from package works
+confinement: strict
+
+parts:
+  craftgit-test:
+    plugin: nil
+    override-pull: |
+      echo "checking if craft.git from snap is available during pull"
+      which craft.git | grep "$SNAP/libexec/snapcraft/craft.git"
+      craft.git clone --depth 1 https://git.launchpad.net/ubuntu/+source/hello
+    override-build: |
+      echo "checking if craft.git from snap is available during build"
+      which craft.git | grep "$SNAP/libexec/snapcraft/craft.git"
+    override-stage: |
+      echo "checking if craft.git from snap is available during stage"
+      which craft.git | grep "$SNAP/libexec/snapcraft/craft.git"
+    override-prime: |
+      echo "checking if craft.git from snap is available during prime"
+      which craft.git | grep "$SNAP/libexec/snapcraft/craft.git"

--- a/tests/spread/core24/craftgit/task.yaml
+++ b/tests/spread/core24/craftgit/task.yaml
@@ -1,0 +1,8 @@
+summary: Pack a snap that uses craft.git
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  snapcraft pack


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

Adds a `git` binary as a `craft.git`, that'll be used by the `craft` libraries for the operation which require git client.

(CRAFT-3547)
