### PR TITLE
docs: fix component type in the howto

### DIFF
--- a/docs/howto/code/components-organize/snapcraft.yaml
+++ b/docs/howto/code/components-organize/snapcraft.yaml
@@ -7,7 +7,7 @@ confinement: strict
 
 components:
   translations:
-    type: test
+    type: standard
     summary: Translations modules
     description: Translations modules
     version: "1.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Minor fix.  In #5174, I updated the type in `docs/howto/code/components/snapcraft.yaml` but not `docs/howto/code/components-organize/snapcraft.yaml`.