### PR TITLE
chore: fix small pyproject.yaml errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ extend-exclude = '''
 '''
 # Targeting future versions as well so we don't have black reformatting code
 # en masse later.
-target_version = ["py310", "py311"]
+target-version = ["py310", "py311"]
 
 [tool.mypy]
 python_version = "3.10"
@@ -81,7 +81,6 @@ lint.ignore = [
     "A003",  # Class attribute shadowing a python built-in (class attributes are seldom if ever referred to bare)
     "N818",  # Exception names ending with suffix `Error`
     "ANN002",  "ANN003",  # Missing type annotation for *args and **kwargs
-    "ANN101", "ANN102",  # Type annotations for `self` and `cls` in methods
     "ANN204",  # Missing type annotations for magic methods
     "ANN401",  # Disallowing `typing.Any`
     "B904",  # Within an except clause, always explicitly `raise` an exception `from` something.


### PR DESCRIPTION
There were two fully deprecated rules being selected for in Ruff's lint rules, as well as an invalid variable name for Black's config. This pull corrects both errors.

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Deleted lint rules: [ANN101](https://docs.astral.sh/ruff/rules/missing-type-self/), [ANN102](https://docs.astral.sh/ruff/rules/missing-type-cls/)