### PR TITLE
chore!: unregister registries commands

### DIFF
--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -59,8 +59,3 @@ Store validation sets
 ---------------------
 
 .. include:: commands/store-validation-sets-commands.rst
-
-Store registries
-----------------
-
-.. include:: commands/store-registries-commands.rst

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -428,4 +428,4 @@ zope-interface==7.1.1
 # pip
 # setuptools
 python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz ; sys.platform == "linux"
-pyinstaller==5.13.1; sys.platform == "win32"
+pyinstaller==5.13.1 ; sys.platform == "win32"

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -141,13 +141,6 @@ COMMAND_GROUPS = [
         ],
     ),
     craft_cli.CommandGroup(
-        "Store Registries",
-        [
-            commands.StoreEditRegistriesCommand,
-            commands.StoreListRegistriesCommand,
-        ],
-    ),
-    craft_cli.CommandGroup(
         "Other",
         [
             commands.LintCommand,

--- a/tests/spread/store/registries/task.yaml
+++ b/tests/spread/store/registries/task.yaml
@@ -1,5 +1,8 @@
 summary: test the registries commands
 
+# disabled until confdb commands are exposed (#5193)
+manual: true
+
 environment:
   SNAPCRAFT_ASSERTION_KEY: "$(HOST: echo ${SNAPCRAFT_ASSERTION_KEY})"
   SNAPCRAFT_STORE_CREDENTIALS: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"

--- a/tests/unit/commands/test_registries.py
+++ b/tests/unit/commands/test_registries.py
@@ -17,10 +17,11 @@
 """Unit tests for registries commands."""
 
 import sys
+from argparse import Namespace
 
 import pytest
 
-from snapcraft import application, const
+from snapcraft import application, commands, const
 
 
 @pytest.fixture
@@ -36,19 +37,17 @@ def mock_edit_assertion(mocker):
 @pytest.mark.usefixtures("memory_keyring")
 @pytest.mark.parametrize("output_format", const.OUTPUT_FORMATS)
 @pytest.mark.parametrize("name", [None, "test"])
-def test_list_registries(mocker, mock_list_assertions, output_format, name):
+def test_list_registries(mock_list_assertions, output_format, name):
     """Test `snapcraft list-registries`."""
-    cmd = ["snapcraft", "list-registries", "--format", output_format]
-    if name:
-        cmd.extend(["--name", name])
-    mocker.patch.object(sys, "argv", cmd)
-
     app = application.create_app()
-    app.run()
+    cmd = commands.StoreListRegistriesCommand(app.app_config)
+
+    cmd.run(Namespace(format=output_format, name=name))
 
     mock_list_assertions.assert_called_once_with(name=name, output_format=output_format)
 
 
+@pytest.mark.skip("Needs the 'list-confdb' command exposed (#5183).")
 @pytest.mark.usefixtures("memory_keyring")
 @pytest.mark.parametrize("name", [None, "test"])
 def test_list_registries_default_format(mocker, mock_list_assertions, name):
@@ -74,7 +73,11 @@ def test_edit_registries(key_name, mocker, mock_edit_assertion):
     mocker.patch.object(sys, "argv", cmd)
 
     app = application.create_app()
-    app.run()
+
+    cmd = commands.StoreEditRegistriesCommand(app.app_config)
+    cmd.run(
+        Namespace(account_id="test-account-id", name="test-name", key_name=key_name)
+    )
 
     mock_edit_assertion.assert_called_once_with(
         name="test-name", account_id="test-account-id", key_name=key_name


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Unregister the `list-registries` and `edit-registries` commands in preparation for renaming them to `list-confdb` and `edit-confdb`.

I retained as many tests as possible to prevent code rot.

(CRAFT-3785)