### PR TITLE
feat(parts): capture error message from scriptlets

### DIFF
--- a/tests/spread/core22/scriptlets/scriptlet-failures/task.yaml
+++ b/tests/spread/core22/scriptlets/scriptlet-failures/task.yaml
@@ -5,7 +5,7 @@ restore: |
   rm -f ./*.snap
 
 execute: |
-  snapcraft_log="$(snapcraft build 2>&1 || true)"
+  snapcraft_log="$(snapcraft build || true)"
 
   echo "${snapcraft_log}" | NOMATCH "^should have failed set-version"
   echo "${snapcraft_log}" | NOMATCH "^should have failed build"


### PR DESCRIPTION
Update Craft Parts to a version that captures stderr from scriptlet execution.

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
