### PR TITLE
style: UK to US English

### DIFF
--- a/docs/explanation/components.rst
+++ b/docs/explanation/components.rst
@@ -36,7 +36,7 @@ When a part is built, the output is the default partition's install directory
 for that part.
 
 Each component has a partition. This means each component has its own install,
-stage, and prime directories. When a file is organised into a component's
+stage, and prime directories. When a file is organized into a component's
 partition, it is moved to the part's install directory for that component's
 partition.
 

--- a/docs/howto/code/basic/task.yaml
+++ b/docs/howto/code/basic/task.yaml
@@ -8,7 +8,7 @@ execute: |
 
   snapcraft pack
 
-  # assert artefacts were packed
+  # assert artifacts were packed
   if [ ! -e "hello-components_1.0_amd64.snap" ]; then
     echo "snap was not packed"
     exit 1

--- a/docs/howto/code/components-organize/task.yaml
+++ b/docs/howto/code/components-organize/task.yaml
@@ -10,7 +10,7 @@ execute: |
   snapcraft pack
   # [docs:pack-end]
 
-  # assert artefacts were packed
+  # assert artifacts were packed
   if [ ! -e "hello-components_1.0_amd64.snap" ] || [ ! -e "hello-components+translations_1.0.comp" ]; then
     echo "snap and components were not packed"
     exit 1

--- a/docs/howto/code/components/task.yaml
+++ b/docs/howto/code/components/task.yaml
@@ -10,7 +10,7 @@ execute: |
   snapcraft pack
   # [docs:pack-end]
 
-  # assert artefacts were packed
+  # assert artifacts were packed
   if [ ! -e "hello-components_1.0_amd64.snap" ] || [ ! -e "hello-components+translations_1.0.comp" ]; then
     echo "snap and components were not packed"
     exit 1

--- a/docs/howto/components.rst
+++ b/docs/howto/components.rst
@@ -46,16 +46,16 @@ Pack the snap with:
     :end-before: [docs:pack-end]
     :dedent: 2
 
-This will produce 2 artefacts, the snap and the component:
+This will produce 2 artifacts, the snap and the component:
 
 * ``hello-components_1.0_amd64.snap``
 * ``hello-components+translations_1.0.comp``
 
 The ``my-app`` and ``la`` files are staged, primed, and packed in the snap
-artefact. The component artefact has no payload. It is empty except for a
+artifact. The component artifact has no payload. It is empty except for a
 metadata file ``meta/component.yaml``.
 
-To move the ``la`` translation file to the ``component`` artefact, use the
+To move the ``la`` translation file to the ``component`` artifact, use the
 ``organize`` keyword for the ``translations`` part:
 
 .. literalinclude:: code/components-organize/snapcraft.yaml
@@ -72,7 +72,7 @@ Pack the snap again with:
     :end-before: [docs:pack-end]
     :dedent: 2
 
-This will produce two artefacts again but the component now contains the
+This will produce two artifacts again but the component now contains the
 ``la`` translation file.
 
 To upload the snap and the component to the store, specify the snap file

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -829,7 +829,7 @@ Remote builder
 * Add an exponential backoff to API retries with a maximum total delay of
   62 seconds (`canonical/craft-application#355`_).
 
-* Fix a bug where the remote builder would not fail if no artefacts were
+* Fix a bug where the remote builder would not fail if no artifacts were
   created (`#4783`_).
 
 For a complete list of commits, check out the `8.2.10`_ release on GitHub.

--- a/docs/reference/channels.rst
+++ b/docs/reference/channels.rst
@@ -22,7 +22,7 @@ In Snapcraft commands, a typical channel without a branch looks like this:
 Track
 -----
 
-The *track* represents the highest level of organisation for the snap's
+The *track* represents the highest level of organization for the snap's
 release. Typically, it signifies a major release. Authors can use tracks to
 maintain different major versions of their software.
 

--- a/docs/reference/snap-build-process.rst
+++ b/docs/reference/snap-build-process.rst
@@ -4,7 +4,7 @@ Snap build process
 ==================
 
 This page describes at a high level the workflow between a snap recipe and its
-resulting artefact.
+resulting artifact.
 
 
 The recipe file
@@ -100,7 +100,7 @@ The result
 The result of a successful Snapcraft build is a snap file, which is itself a
 compressed Squashfs archive with a ``.snap`` extension.
 
-After the build is complete, the resulting artefact is placed in the current
+After the build is complete, the resulting artifact is placed in the current
 working directory. Snapcraft then halts the VM or container and preserves it
 for reuse in any re-builds of the snap, to reduce processing time.
 

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -100,8 +100,8 @@ def _pack(
     """Pack a directory with `snap pack` as a snap or component.
 
     :param directory: Directory to pack.
-    :param output_dir: Directory to output the artefact to.
-    :param output_file: Name of the artefact.
+    :param output_dir: Directory to output the artifact to.
+    :param output_file: Name of the artifact.
     :param compression: Compression type to use, None for default.
 
     :returns: The filename of the packed snap or component.

--- a/snapcraft/parts/extract_metadata.py
+++ b/snapcraft/parts/extract_metadata.py
@@ -34,7 +34,7 @@ def extract_lifecycle_metadata(
     """Obtain metadata information.
 
     :param adopt_info: the Project's ``adopt-info``
-    :param parse_info: the ``parse-info`` information from the Project, organised
+    :param parse_info: the ``parse-info`` information from the Project, organized
       as a dict of "part-name" to "list of files providing metadata".
     :param work_dir: the lifecycle's working directory.
     """


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Renames 2 commonly used terms in snapcraft to US English, artefact and organise. 