### PR TITLE
fix(project): Use an annotated type for duration strings

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -711,19 +711,19 @@
                         },
                         "start-timeout": {
                             "type": "string",
-                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "pattern": "^([0-9]+(ns|us|ms|s|m)){1,5}$",
                             "validation-failure": "{.instance!r} is not a valid timeout value.",
                             "description": "Optional time to wait for daemon to start - <n>ns | <n>us | <n>ms | <n>s | <n>m"
                         },
                         "stop-timeout": {
                             "type": "string",
-                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "pattern": "^([0-9]+(ns|us|ms|s|m)){1,5}$",
                             "validation-failure": "{.instance!r} is not a valid timeout value.",
                             "description": "Optional time to wait for daemon to stop - <n>ns | <n>us | <n>ms | <n>s | <n>m"
                         },
                         "watchdog-timeout": {
                             "type": "string",
-                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "pattern": "^([0-9]+(ns|us|ms|s|m)){1,5}$",
                             "validation-failure": "{.instance!r} is not a valid timeout value.",
                             "description": "Service watchdog timeout - <n>ns | <n>us | <n>ms | <n>s | <n>m"
                         },
@@ -733,7 +733,7 @@
                         },
                         "restart-delay": {
                             "type": "string",
-                            "pattern": "^[0-9]+(ns|us|ms|s|m)*$",
+                            "pattern": "^([0-9]+(ns|us|ms|s|m)){1,5}$",
                             "validation-failure": "{.instance!r} is not a valid delay value.",
                             "description": "Delay between service restarts - <n>ns | <n>us | <n>ms | <n>s | <n>m. Defaults to unset. See the systemd.service manual on RestartSec for details."
                         },

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -294,7 +294,8 @@ DurationString = Annotated[
     str,
     pydantic.Field(
         examples=["1", "2s", "3m", "4ms", "5us", "6m7s8ms"],
-        pattern=TIME_DURATION_REGEX
+        pattern=TIME_DURATION_REGEX,
+        description="A duration string to be parsed by snapd.",
     ),
     pydantic.BeforeValidator(_validate_duration_string),
 ]

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -40,6 +40,8 @@ from snapcraft.models.project import apply_root_packages
 
 # required project data for core24 snaps
 CORE24_DATA = {"base": "core24", "grade": "devel"}
+VALID_DURATIONS = ["10ns", "10us", "10ms", "10s", "10m", "10m4s3us"]
+INVALID_DURATIONS = ["10", "10 s", "10 seconds", "1:00", "invalid"]
 
 
 @pytest.fixture
@@ -982,19 +984,14 @@ class TestAppValidation:
         assert project.apps is not None
         assert project.apps["app1"].post_stop_command == "test-post-stop-command"
 
-    @pytest.mark.parametrize(
-        "start_timeout", ["10", "10ns", "10us", "10ms", "10s", "10m"]
-    )
+    @pytest.mark.parametrize("start_timeout", VALID_DURATIONS)
     def test_app_start_timeout_valid(self, start_timeout, app_yaml_data):
         data = app_yaml_data(start_timeout=start_timeout)
         project = Project.unmarshal(data)
         assert project.apps is not None
         assert project.apps["app1"].start_timeout == start_timeout
 
-    @pytest.mark.parametrize(
-        "start_timeout",
-        ["10 s", "10 seconds", "1:00", "invalid"],
-    )
+    @pytest.mark.parametrize("start_timeout", INVALID_DURATIONS)
     def test_app_start_timeout_invalid(self, start_timeout, app_yaml_data):
         data = app_yaml_data(start_timeout=start_timeout)
 
@@ -1002,19 +999,14 @@ class TestAppValidation:
         with pytest.raises(pydantic.ValidationError, match=error):
             Project.unmarshal(data)
 
-    @pytest.mark.parametrize(
-        "stop_timeout", ["10", "10ns", "10us", "10ms", "10s", "10m"]
-    )
+    @pytest.mark.parametrize("stop_timeout", VALID_DURATIONS)
     def test_app_stop_timeout_valid(self, stop_timeout, app_yaml_data):
         data = app_yaml_data(stop_timeout=stop_timeout)
         project = Project.unmarshal(data)
         assert project.apps is not None
         assert project.apps["app1"].stop_timeout == stop_timeout
 
-    @pytest.mark.parametrize(
-        "stop_timeout",
-        ["10 s", "10 seconds", "1:00", "invalid"],
-    )
+    @pytest.mark.parametrize("stop_timeout", INVALID_DURATIONS)
     def test_app_stop_timeout_invalid(self, stop_timeout, app_yaml_data):
         data = app_yaml_data(stop_timeout=stop_timeout)
 
@@ -1022,19 +1014,14 @@ class TestAppValidation:
         with pytest.raises(pydantic.ValidationError, match=error):
             Project.unmarshal(data)
 
-    @pytest.mark.parametrize(
-        "watchdog_timeout", ["10", "10ns", "10us", "10ms", "10s", "10m"]
-    )
+    @pytest.mark.parametrize("watchdog_timeout", VALID_DURATIONS)
     def test_app_watchdog_timeout_valid(self, watchdog_timeout, app_yaml_data):
         data = app_yaml_data(watchdog_timeout=watchdog_timeout)
         project = Project.unmarshal(data)
         assert project.apps is not None
         assert project.apps["app1"].watchdog_timeout == watchdog_timeout
 
-    @pytest.mark.parametrize(
-        "watchdog_timeout",
-        ["10 s", "10 seconds", "1:00", "invalid"],
-    )
+    @pytest.mark.parametrize("watchdog_timeout", INVALID_DURATIONS)
     def test_app_watchdog_timeout_invalid(self, watchdog_timeout, app_yaml_data):
         data = app_yaml_data(watchdog_timeout=watchdog_timeout)
 
@@ -1048,19 +1035,14 @@ class TestAppValidation:
         assert project.apps is not None
         assert project.apps["app1"].reload_command == "test-reload-command"
 
-    @pytest.mark.parametrize(
-        "restart_delay", ["10", "10ns", "10us", "10ms", "10s", "10m"]
-    )
+    @pytest.mark.parametrize("restart_delay", VALID_DURATIONS)
     def test_app_restart_delay_valid(self, restart_delay, app_yaml_data):
         data = app_yaml_data(restart_delay=restart_delay)
         project = Project.unmarshal(data)
         assert project.apps is not None
         assert project.apps["app1"].restart_delay == restart_delay
 
-    @pytest.mark.parametrize(
-        "restart_delay",
-        ["10 s", "10 seconds", "1:00", "invalid"],
-    )
+    @pytest.mark.parametrize("restart_delay", INVALID_DURATIONS)
     def test_app_restart_delay_invalid(self, restart_delay, app_yaml_data):
         data = app_yaml_data(restart_delay=restart_delay)
 


### PR DESCRIPTION
Inspired by: https://github.com/canonical/snapcraft/pull/5210

This makes an annotated type for duration strings and uses a stricter regex.

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
