### PR TITLE
feat(docs): add redirects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ extensions.extend(
         "sphinx.ext.ifconfig",
         "sphinxcontrib.details.directive",
         "sphinx_toolbox.collapse",
+        "sphinxext.rediraffe",
     )
 )
 
@@ -100,3 +101,6 @@ craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-
 (common_docs_path / "craft-parts").symlink_to(
     craft_parts_docs_path, target_is_directory=True
 )
+
+# Client-side page redirects.
+rediraffe_redirects = "redirects.txt"

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,8 @@
+# Client-side page redirects. Each mapping takes the format:
+#     `"<old path>" "<current path>"
+# Paths must be represented as source files relative to the root of the `docs` dir.
+# The old path must be a file that _doesn't exist_ in the source. The current path
+# must be a file that _does exist_ in the source.
+
+"howto/install-snapcraft.rst" "howto/set-up-snapcraft.rst"
+"howto/install.rst" "howto/set-up-snapcraft.rst"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -160,6 +160,7 @@ jeepney==0.8.0
 jinja2==3.1.5
     # via
     #   craft-application
+    #   craft-cli
     #   myst-parser
     #   sphinx
     #   sphinx-jinja2-compat
@@ -225,6 +226,7 @@ oauthlib==3.2.2
 overrides==7.7.0
     # via
     #   craft-archives
+    #   craft-cli
     #   craft-grammar
     #   craft-parts
     #   craft-store
@@ -292,6 +294,7 @@ pyspelling==2.10
     # via
     #   canonical-sphinx
     #   snapcraft (setup.py)
+python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz ; sys_platform == "linux"
     # via snapcraft (setup.py)
 python-dateutil==2.9.0.post0
     # via
@@ -396,6 +399,7 @@ sphinx==7.3.7
     #   sphinxcontrib-details-directive
     #   sphinxcontrib-jquery
     #   sphinxext-opengraph
+    #   sphinxext-rediraffe
 sphinx-autobuild==2024.10.3
     # via snapcraft (setup.py)
 sphinx-autodoc-typehints==2.3.0
@@ -442,6 +446,8 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxext-opengraph==0.9.1
     # via canonical-sphinx
+sphinxext-rediraffe==0.2.7
+    # via snapcraft (setup.py)
 starlette==0.41.2
     # via sphinx-autobuild
 tabulate==0.9.0
@@ -455,6 +461,7 @@ toml==0.10.2
 typing-extensions==4.12.2
     # via
     #   craft-application
+    #   craft-cli
     #   craft-platforms
     #   domdf-python-tools
     #   pydantic
@@ -486,4 +493,3 @@ ws4py==0.5.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
-python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz ; sys.platform == "linux"

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ docs_requires = {
     "sphinx-lint",
     "sphinx-toolbox",
     "pyspelling",
+    "sphinxext-rediraffe==0.2.7",
 }
 
 extras_requires = {"dev": dev_requires, "docs": docs_requires}


### PR DESCRIPTION
Redirects are maintained manually in `conf.py`.

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
