### PR TITLE
fix(remotebuild): use the project's privacy for repos and recipes

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -19,8 +19,9 @@ publicly available when starting a remote build. This prompt can be
 automatically agreed to by passing ``--launchpad-accept-public-upload``.
 
 Closed-source projects can be built using the remote builder. This requires
-the user to create a private Launchpad project and pass the project with the
-``--project <project-name>`` command line argument.
+the user to create a private `Launchpad project`_ and pass the project with the
+``--project <project-name>`` command line argument. An ``ssh`` key must be
+registered in Launchpad because source code is uploaded using SSH.
 
 Git repository
 --------------
@@ -170,6 +171,7 @@ Similarly, ``core22`` supports a shorthand notation for ``architectures`` but
 Launchpad is not able to parse this notation (`[9]`_).
 
 .. _`Launchpad account`: https://launchpad.net/+login
+.. _`Launchpad project`: https://launchpad.net/projects/+new
 .. _`Launchpad`: https://launchpad.net/
 .. _`build farm`: https://launchpad.net/builders
 .. _`[2]`: https://github.com/canonical/snapcraft/issues/4842

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -70,6 +70,19 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+8.6.1 (2025-Feb-DD)
+-------------------
+
+Remote build
+============
+
+* Fix a bug where the source code, build recipes, and build logs for remote
+  builds of private Launchpad projects would be publicly available on
+  Launchpad while the build was in progress.
+
+..
+  For a complete list of commits, check out the `8.6.1`_ release on GitHub.
+
 8.6.0 (2025-Feb-05)
 -------------------
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -45,7 +45,7 @@ coverage[toml]==7.6.4
     # via
     #   pytest-cov
     #   snapcraft (setup.py)
-craft-application==4.4.0
+craft-application==4.4.1
     # via snapcraft (setup.py)
 craft-archives==2.0.1
     # via

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -59,7 +59,7 @@ click==8.1.7
     #   uvicorn
 colorama==0.4.6
     # via sphinx-autobuild
-craft-application==4.4.0
+craft-application==4.4.1
     # via snapcraft (setup.py)
 craft-archives==2.0.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via snapcraft (setup.py)
-craft-application==4.4.0
+craft-application==4.4.1
     # via snapcraft (setup.py)
 craft-archives==2.0.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires = [
     "attrs",
     "catkin-pkg; sys_platform == 'linux'",
     "click",
-    "craft-application~=4.4",
+    "craft-application>=4.4.1,<5.0.0",
     "craft-archives~=2.0",
     "craft-cli~=2.9",
     "craft-grammar>=2.0.1,<3.0.0",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Pulls in fixes from https://github.com/canonical/craft-application/pull/615, which fixes a bug where the remote-builder would create a public repository and recipe, even when the project is private.

Fixes #5221 
(CRAFT-4035)