### PR TITLE
ci: publish snaps to arm64

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,12 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner: 
+          - ubuntu-latest
+          - [self-hosted, arm64]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Decision to Publish
         id: decisions


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

Builds and publishes test snaps to arm64.  This would be useful for testing in scenarios like https://github.com/canonical/snapcraft/issues/5132 and https://github.com/canonical/craft-providers/issues/719.