### PR TITLE
fix: update plugin build error message

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -59,7 +59,7 @@ craft-grammar==2.0.1
     # via
     #   craft-application
     #   snapcraft (setup.py)
-craft-parts==2.4.1
+craft-parts @ git+https://github.com/canonical/craft-parts@CRAFT-4070-Error-presentation-sometimes-omits-the-last-lines
     # via
     #   craft-application
     #   snapcraft (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ craft-grammar==2.0.1
     # via
     #   craft-application
     #   snapcraft (setup.py)
-craft-parts==2.4.1
+craft-parts @ git+https://github.com/canonical/craft-parts@CRAFT-4070-Error-presentation-sometimes-omits-the-last-lines
     # via
     #   craft-application
     #   snapcraft (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ install_requires = [
     "craft-archives~=2.0",
     "craft-cli>=2.15.0",
     "craft-grammar>=2.0.1,<3.0.0",
-    "craft-parts==2.4.1",
+    "craft-parts @ git+https://github.com/canonical/craft-parts@CRAFT-4070-Error-presentation-sometimes-omits-the-last-lines",
     "craft-platforms~=0.4",
     "craft-providers>=2.0.4,<3.0.0",
     "craft-store>=3.0.2,<4.0.0",


### PR DESCRIPTION
Update craft-parts to obtain the combined output in case of plugin
build error. This results in better information on the causes of
the failure.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox run -m lint`?
- [ ] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----
