### PR TITLE
fix(extensions): resources path for QtWebEngineProcess on kde-neon-6

### DIFF
--- a/extensions/desktop/kde-neon-6/launcher-specific
+++ b/extensions/desktop/kde-neon-6/launcher-specific
@@ -35,7 +35,7 @@ append_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/lib/$ARCH"
 # Fix locating the QtWebEngineProcess executable
 export QTWEBENGINEPROCESS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/qt6/libexec/QtWebEngineProcess"
 # And QtWebEngine's path to resources
-QTWEBENGINE_RESOURCES_PATH="$SNAP_DESKTOP_RUNTIME/usr/share/qt6/resources"
+export QTWEBENGINE_RESOURCES_PATH="$SNAP_DESKTOP_RUNTIME/usr/share/qt6/resources"
 
 # Removes Qt warning: Could not find a location
 # of the system Compose files


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox run -m lint`?
- [x] Have you successfully run `tox run -e test-py310`? (supported versions: `py39`, `py310`, `py311`, `py312`)

-----

This line was added in #4823 in https://github.com/canonical/snapcraft/pull/4823/commits/d8013464002b93d613f7e2955ca707023777919c

However, the `export` was missing in the original commit.  This error was picked up by shellcheck in #5225.  I'm moving it into a separate PR for trackability.