### PR TITLE
ci: don't publish a wheel

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -10,63 +10,14 @@ permissions:
   contents: write
 
 jobs:
-  source-wheel:
-    runs-on: [self-hosted, jammy]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Fetch tag annotations
-        run: |
-          # Note: we fetch the tags here instead of using actions/checkout's "fetch-tags"
-          # because of https://github.com/actions/checkout/issues/1467
-          git fetch --force --tags --depth 1
-          git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          check-latest: true
-      - name: Build packages
-        run: |
-          pip install build twine
-          python3 -m build
-          twine check dist/*
-      - name: Upload pypi packages artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pypi-packages
-          path: dist/
-  pypi:
-    needs: ["source-wheel"]
-    runs-on: [self-hosted, jammy, amd64]
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    steps:
-      - name: Get packages
-        uses: actions/download-artifact@v4
-        with:
-          name: pypi-packages
-          path: dist/
-      - name: Publish to pypi
-        # Note: this action uses PyPI's support for Trusted Publishers
-        # It needs a configuration on the PyPI project - see:
-        # https://docs.pypi.org/trusted-publishers/adding-a-publisher/#github-actions
-        uses: pypa/gh-action-pypi-publish@release/v1
   github-release:
-    needs: ["source-wheel"]
-    runs-on: [self-hosted, jammy]
+    runs-on: [self-hosted]
     steps:
-      - name: Get pypi artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: pypi-packages
-      - name: Release
+      - name: Create a Prerelease
         uses: softprops/action-gh-release@v2
         with:
           # Generate release notes on the new GH release
           generate_release_notes: true
-          # Add wheel and source tarball
-          files: |
-            *.whl
-            *.tar.gz
+          # Mark this new release as a pre-release, to be marked manually
+          # as the latest stable release later.
+          prerelease: true


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

We don't need to publish wheels for snapcraft, but we can create a pre-release, just like [rockcraft](https://github.com/canonical/rockcraft/commit/6619134b2c4177aa46600329a324a963c04b5179).