### PR TITLE
fix: correct git errors in flutter plugin

### DIFF
--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -101,8 +101,6 @@ patch releases.
 See individual issue links for any mitigations.
 
 - `#4996`_ Remote build gives an unfriendly error when attempting to cross-compile.
-- `#5258`_ The Flutter plugin fails to install Flutter for ``core22`` and ``core24``
-  snaps.
 
 
 Fixed bugs and issues
@@ -110,6 +108,8 @@ Fixed bugs and issues
 
 The following issues have been resolved in Snapcraft 8.7:
 
+- `#5258`_ The Flutter plugin failed to install Flutter for ``core22`` and ``core24``
+  snaps.
 - `#5250`_ Resources path for ``QtWebEngineProcess`` wasn't exported for snaps
   using the KDE Neon 6 extension.
 - `craft-parts#978`_ The ``source-subdir`` field was ignored for the

--- a/snapcraft/parts/plugins/flutter_plugin.py
+++ b/snapcraft/parts/plugins/flutter_plugin.py
@@ -87,6 +87,8 @@ class FlutterPlugin(plugins.Plugin):
             # TODO detect changes to plugin properties
             f"git clone --depth 1 -b {options.flutter_channel} {FLUTTER_REPO} {self.flutter_dir}",
             # Workaround for flutter#163308
+            # Deletion of this file avoids an if statement that causes the following commands to
+            # fail
             f"rm {self.flutter_dir}/engine/src/.gn",
             "flutter precache --linux",
             "flutter pub get",

--- a/snapcraft/parts/plugins/flutter_plugin.py
+++ b/snapcraft/parts/plugins/flutter_plugin.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """The flutter plugin."""
+
 from typing import Literal, cast
 
 from craft_parts import infos, plugins
@@ -85,6 +86,8 @@ class FlutterPlugin(plugins.Plugin):
         return [
             # TODO detect changes to plugin properties
             f"git clone --depth 1 -b {options.flutter_channel} {FLUTTER_REPO} {self.flutter_dir}",
+            # Workaround for flutter#163308
+            f"rm {self.flutter_dir}/engine/src/.gn",
             "flutter precache --linux",
             "flutter pub get",
         ]

--- a/tests/unit/parts/plugins/test_flutter_plugin.py
+++ b/tests/unit/parts/plugins/test_flutter_plugin.py
@@ -65,6 +65,7 @@ def test_get_build_commands(part_info):
     assert plugin.get_build_commands() == [
         "git clone --depth 1 -b stable https://github.com/flutter/flutter.git "
         f"{plugin.flutter_dir}",
+        f"rm {plugin.flutter_dir}/engine/src/.gn",
         "flutter precache --linux",
         "flutter pub get",
         "flutter build linux --release --verbose --target lib/main.dart",
@@ -81,6 +82,7 @@ def test_get_build_commands_alternative_target(part_info):
     assert plugin.get_build_commands() == [
         f"git clone --depth 1 -b stable https://github.com/flutter/flutter.git "
         f"{plugin.flutter_dir}",
+        f"rm {plugin.flutter_dir}/engine/src/.gn",
         "flutter precache --linux",
         "flutter pub get",
         "flutter build linux --release --verbose --target lib/not-main.dart",
@@ -98,6 +100,7 @@ def test_get_build_commands_different_channels(part_info, value):
     assert plugin.get_build_commands() == [
         f"git clone --depth 1 -b {value} https://github.com/flutter/flutter.git "
         f"{plugin.flutter_dir}",
+        f"rm {plugin.flutter_dir}/engine/src/.gn",
         "flutter precache --linux",
         "flutter pub get",
         "flutter build linux --release --verbose --target lib/main.dart",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

This PR uses the [workaround suggested here](https://github.com/flutter/flutter/issues/163308#issuecomment-2661479464). It's a dirty workaround, but it seems like the Flutter development team is going to fix this issue as a bug so this should only be around until upstream is fixed.

Closes #5258 
CRAFT-4149.