### PR TITLE
fix(remotebuild): don't fail when cross-compiling

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -145,10 +145,6 @@ Snapcraft will request a build for each unique ``build-for`` architecture.
 
 .. note::
 
-   Launchpad does not support cross-compiling (`[13]`_).
-
-.. note::
-
     Launchpad does not support building multiple snaps on the same
     ``build-on`` architecture (`[14]`_).
 
@@ -217,5 +213,4 @@ Launchpad is not able to parse this notation (`[9]`_).
 .. _`[8]`: https://bugs.launchpad.net/snapcraft/+bug/2007789
 .. _`[9]`: https://bugs.launchpad.net/snapcraft/+bug/2042167
 .. _`[10]`: https://github.com/canonical/snapcraft/issues/4885
-.. _`[13]`: https://github.com/canonical/snapcraft/issues/4996
 .. _`[14]`: https://github.com/canonical/snapcraft/issues/4995

--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -130,7 +130,7 @@ this release.
 :literalref:`@mr-cal<https://github.com/mr-cal>`,
 and :literalref:`@sergio-costas<https://github.com/sergio-costas>`
 
-.. _#4996: https://github.com/canonical/snapcraft/pull/4996
+.. _#4996: https://github.com/canonical/snapcraft/issues/4996
 .. _#5250: https://github.com/canonical/snapcraft/pull/5250
 .. _#5258: https://github.com/canonical/snapcraft/pull/5258
 .. _craft-application#600: https://github.com/canonical/craft-application/issues/600

--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -29,14 +29,18 @@ it had to be manually updated.
 
 We've updated the completion file to be generated dynamically, which means it will
 always autocomplete the latest commands and options in Bash-compatible shells.
-Try it out in by typing ``snapcraft`` and pressing :kbd:`Tab` in your terminal.
+Try it out by typing ``snapcraft`` and pressing :kbd:`Tab` in your terminal.
 
 
 Improved remote builder
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Remote builds can now use the ``--build-for`` option to filter entries in an
-``architectures`` or ``platforms`` key in a project file.
+Previously, the remote builder only supported natively built snaps and failed to
+build cross-compiled snaps with an unhelpful error. Now, the remote builder supports
+both natively and cross-compiled snaps.
+
+Additionally, remote builds can now use the ``--build-for`` option to filter entries in
+an ``architectures`` or ``platforms`` key in a project file.
 
 
 Support for confdbs
@@ -92,22 +96,13 @@ builds, due to Launchpad's handling of the ``platforms`` key in project files.
 ``--build-for`` is the recommended alternative until Launchpad has comprehensive
 support for platforms.
 
-Known issues
-------------
-
-The following issues were reported and are scheduled to be fixed in upcoming
-patch releases.
-
-See individual issue links for any mitigations.
-
-- `#4996`_ Remote build gives an unfriendly error when attempting to cross-compile.
-
 
 Fixed bugs and issues
 ---------------------
 
 The following issues have been resolved in Snapcraft 8.7:
 
+- `#4996`_ Remote build gives an unfriendly error when attempting to cross-compile.
 - `#5258`_ The Flutter plugin failed to install Flutter for ``core22`` and ``core24``
   snaps.
 - `#5250`_ Resources path for ``QtWebEngineProcess`` wasn't exported for snaps
@@ -135,7 +130,7 @@ this release.
 :literalref:`@mr-cal<https://github.com/mr-cal>`,
 and :literalref:`@sergio-costas<https://github.com/sergio-costas>`
 
-.. _#4996: https://github.com/canonical/snapcraft/issues/4996
+.. _#4996: https://github.com/canonical/snapcraft/pull/4996
 .. _#5250: https://github.com/canonical/snapcraft/pull/5250
 .. _#5258: https://github.com/canonical/snapcraft/pull/5258
 .. _craft-application#600: https://github.com/canonical/craft-application/issues/600

--- a/snapcraft/commands/remote.py
+++ b/snapcraft/commands/remote.py
@@ -147,6 +147,7 @@ class RemoteBuildCommand(RemoteBuild):
             # if the project has platforms, then `--build-for` acts as a filter
             if build_fors:
                 emit.debug("Filtering the build plan using the '--build-for' argument.")
+                # loop through each `build-for` to create a list of architectures where the snaps can build on
                 for build_for in build_fors:
                     filtered_build_plan = filter_plan(
                         build_plan,
@@ -166,11 +167,11 @@ class RemoteBuildCommand(RemoteBuild):
                 emit.debug("Using the project's build plan")
                 archs = [build_info.build_on for build_info in build_plan]
         # No architectures in the project means '--build-for' no longer acts as a filter.
-        # Instead, it defines the architectures to build for.
+        # Instead, it defines the architectures to build on, and for.
         elif build_fors:
             emit.debug("Using '--build-for' as the list of architectures to build for")
             archs = build_fors
-        # default is to build for the host architecture
+        # default is to build on, and for, the host architecture
         else:
             archs = [str(DebianArchitecture.from_host())]
             emit.debug(

--- a/tests/spread/core22/remote-build/snaps/build-for-with-archs/arguments.txt
+++ b/tests/spread/core22/remote-build/snaps/build-for-with-archs/arguments.txt
@@ -1,1 +1,1 @@
---build-for amd64,s390x
+--build-for amd64,armhf

--- a/tests/spread/core22/remote-build/snaps/build-for-with-archs/expected-snaps.txt
+++ b/tests/spread/core22/remote-build/snaps/build-for-with-archs/expected-snaps.txt
@@ -1,2 +1,2 @@
 build-for-with-archs-core22_1.0_amd64.snap
-build-for-with-archs-core22_1.0_s390x.snap
+build-for-with-archs-core22_1.0_armhf.snap

--- a/tests/spread/core22/remote-build/snaps/build-for-with-archs/snapcraft.yaml
+++ b/tests/spread/core22/remote-build/snaps/build-for-with-archs/snapcraft.yaml
@@ -2,7 +2,8 @@ name: build-for-with-archs-core22
 base: core22
 version: "1.0"
 summary: Test snap for remote build
-description: Test snap for remote build
+description: |
+  Builds 2 natively compiled snaps and 1 cross-compiled snap.
 
 grade: stable
 confinement: strict
@@ -11,7 +12,7 @@ architectures:
   - build-on: [amd64]
     build-for: [amd64]
   - build-on: [s390x]
-    build-for: [s390x]
+    build-for: [armhf]
   - build-on: [riscv64]
     build-for: [riscv64]
 

--- a/tests/spread/core24/remote-build/snaps/build-for-with-platforms/arguments.txt
+++ b/tests/spread/core24/remote-build/snaps/build-for-with-platforms/arguments.txt
@@ -1,1 +1,1 @@
---build-for amd64,s390x
+--build-for amd64,armhf

--- a/tests/spread/core24/remote-build/snaps/build-for-with-platforms/expected-snaps.txt
+++ b/tests/spread/core24/remote-build/snaps/build-for-with-platforms/expected-snaps.txt
@@ -1,2 +1,2 @@
 build-for-with-platforms-core24_1.0_amd64.snap
-build-for-with-platforms-core24_1.0_s390x.snap
+build-for-with-platforms-core24_1.0_armhf.snap

--- a/tests/spread/core24/remote-build/snaps/build-for-with-platforms/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/build-for-with-platforms/snapcraft.yaml
@@ -2,7 +2,8 @@ name: build-for-with-platforms-core24
 base: core24
 version: "1.0"
 summary: Test snap for remote build
-description: Test snap for remote build
+description: |
+  Builds 2 natively compiled snaps and 1 cross-compiled snap.
 
 grade: stable
 confinement: strict
@@ -11,9 +12,9 @@ platforms:
   amd64:
     build-on: [amd64]
     build-for: [amd64]
-  s390x:
+  armhf:
     build-on: [s390x]
-    build-for: [s390x]
+    build-for: [armhf]
   riscv64:
     build-on: [riscv64]
     build-for: [riscv64]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

This PR updates Snapcraft to pass `build-on` architectures to Launchpad rather than the `build-for` architectures.  It updates the spread tests to exercise this.

Benefits:
* Previously, a snap with `build-for: [all]` would build on `amd64`.  Now it builds on one of the `build-on` architectures in the `snapcraft.yaml`.
* Cross-compiling works with remote builds.

This is possible due to the following constraints:
* Snapcraft only allows one artifact to be remotely built on each `build-on` architecture.
* Launchpad accepts a list of architectures where to build an artifact and choose one architecture from that list.

Spread tests: https://github.com/canonical/snapcraft/actions/runs/13401419675

Fixes #4996 
(CRAFT-3280)