### PR TITLE
chore: fix gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ eggs/
 .eggs/
 lib/
 lib64/
-parts/
 sdist/
 var/
 wheels/
@@ -97,7 +96,6 @@ dmypy.json
 
 # Lifecycle
 build/
-parts/
 prime/
 stage/
 

--- a/.gitignore
+++ b/.gitignore
@@ -95,9 +95,10 @@ env.bak/
 dmypy.json
 
 # Lifecycle
-build/
-prime/
-stage/
+/build/
+/prime/
+/stage/
+/parts/
 
 # Python virtual environment
 venv/

--- a/snapcraft/parts/extract_metadata.py
+++ b/snapcraft/parts/extract_metadata.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Utilities to extract project metadata from lifecycle directories."""
+
 from __future__ import annotations
 
 import pathlib

--- a/snapcraft/parts/grammar.py
+++ b/snapcraft/parts/grammar.py
@@ -72,8 +72,6 @@ def process_parts(
     processor = GrammarProcessor(arch=arch, target_arch=target_arch, checker=self_check)
 
     for part in parts_yaml_data.values():
-        part = process_part(
-            part_yaml_data=part, processor=processor
-        )
+        process_part(part_yaml_data=part, processor=processor)
 
     return parts_yaml_data

--- a/snapcraft/parts/plugins/__init__.py
+++ b/snapcraft/parts/plugins/__init__.py
@@ -16,7 +16,6 @@
 
 """Snapcraft specific plugins."""
 
-
 from .register import get_plugins, register
 
 from .colcon_plugin import ColconPlugin

--- a/snapcraft/parts/plugins/flutter_plugin.py
+++ b/snapcraft/parts/plugins/flutter_plugin.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """The flutter plugin."""
+
 from typing import Literal, cast
 
 from craft_parts import infos, plugins

--- a/snapcraft/parts/plugins/matter_sdk_plugin.py
+++ b/snapcraft/parts/plugins/matter_sdk_plugin.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """The matter SDK plugin."""
+
 import os
 from typing import Literal, cast
 

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -121,7 +121,6 @@ def _update_project_links(
 
         # only update the project if the project has not defined the field
         if not project_field:
-
             # values for a field from all metadata files
             metadata_values: list[str] = list()
 

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -84,7 +84,8 @@ class TestPluginColconPlugin:
 
         with pytest.raises(ValidationError):
             colcon.ColconPlugin.properties_class(  # noqa F841
-                source=".", foo="bar"  # type: ignore
+                source=".",
+                foo="bar",  # type: ignore
             )
 
     def test_property_all(self):
@@ -323,7 +324,6 @@ class TestPluginColconPlugin:
     def test_get_build_commands_with_all_properties_core22(
         self, setup_method_fixture, new_dir, monkeypatch
     ):
-
         plugin = setup_method_fixture(
             "core22",
             new_dir,
@@ -604,7 +604,6 @@ class TestPluginColconPlugin:
     def test_get_build_commands_with_cmake_debug(
         self, setup_method_fixture, new_dir, monkeypatch
     ):
-
         plugin = setup_method_fixture(
             "core22",
             new_dir,

--- a/tests/unit/parts/plugins/test_python_plugin.py
+++ b/tests/unit/parts/plugins/test_python_plugin.py
@@ -60,7 +60,6 @@ def test_get_build_environment(plugin, new_dir):
 
 
 def test_get_build_commands(plugin, new_dir):
-
     assert plugin.get_build_commands() == [
         f'"${{PARTS_PYTHON_INTERPRETER}}" -m venv ${{PARTS_PYTHON_VENV_ARGS}} "{new_dir}/parts/my-part/install"',
         f'PARTS_PYTHON_VENV_INTERP_PATH="{new_dir}/parts/my-part/install/bin/${{PARTS_PYTHON_INTERPRETER}}"',

--- a/tests/unit/parts/test_desktop_file.py
+++ b/tests/unit/parts/test_desktop_file.py
@@ -111,17 +111,14 @@ class TestDesktopIcon:
         expected_desktop_file = new_dir / f"{app_name}.desktop"
         assert expected_desktop_file.exists()
         with expected_desktop_file.open() as desktop_file:
-            assert (
-                desktop_file.read()
-                == dedent(
-                    """\
+            assert desktop_file.read() == dedent(
+                """\
             [Desktop Entry]
             Exec=foo
             Icon={}
 
         """
-                ).format(expected_icon)
-            )
+            ).format(expected_icon)
 
     @pytest.mark.parametrize(
         "icon,icon_path,expected_icon",

--- a/tests/unit/parts/test_yaml_utils.py
+++ b/tests/unit/parts/test_yaml_utils.py
@@ -26,11 +26,10 @@ from snapcraft.parts import yaml_utils
 
 
 def test_yaml_load():
-    assert (
-        yaml_utils.load(
-            io.StringIO(
-                dedent(
-                    """\
+    assert yaml_utils.load(
+        io.StringIO(
+            dedent(
+                """\
         base: core22
         entry:
             sub-entry:
@@ -38,17 +37,15 @@ def test_yaml_load():
               - list2
         scalar: scalar-value
     """
-                )
             )
         )
-        == {
-            "base": "core22",
-            "entry": {
-                "sub-entry": ["list1", "list2"],
-            },
-            "scalar": "scalar-value",
-        }
-    )
+    ) == {
+        "base": "core22",
+        "entry": {
+            "sub-entry": ["list1", "list2"],
+        },
+        "scalar": "scalar-value",
+    }
 
 
 def test_yaml_load_duplicates_errors():
@@ -96,22 +93,19 @@ def test_yaml_load_unhashable_errors():
 
 
 def test_yaml_load_build_base():
-    assert (
-        yaml_utils.load(
-            io.StringIO(
-                dedent(
-                    """\
+    assert yaml_utils.load(
+        io.StringIO(
+            dedent(
+                """\
         base: foo
         build-base: core22
     """
-                )
             )
         )
-        == {
-            "base": "foo",
-            "build-base": "core22",
-        }
-    )
+    ) == {
+        "base": "foo",
+        "build-base": "core22",
+    }
 
 
 def test_yaml_load_not_core22_base():


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

The .gitignore was ignoring the lifecycle `parts/` directory, but it had its own `parts/` directories (e.g. `snapcraft/parts/`) that were getting ignored as a side-effect. This also meant that Ruff wasn't checking those directories for formatting/linting errors.