### PR TITLE
test: mark all legacy tests as slow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,13 @@ import xdg.BaseDirectory
 from craft_store.auth import MemoryKeyring
 
 
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Use collection hook to mark all legacy tests as slow"""
+    for item in items:
+        if "tests/legacy" in str(item.path):
+            item.add_marker(pytest.mark.slow)
+
+
 @pytest.fixture(autouse=True)
 def temp_xdg(tmpdir, mocker):
     """Use a temporary locaction for XDG directories."""


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

The legacy tests are rarely wanted and are, on average, much slower than any of the modern tests. This PR marks them all as slow tests for the purposes of `make test-fast`.