### PR TITLE
test: fix spread.yaml multipass backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -67,16 +67,10 @@ backends:
     type: adhoc
     allocate: |
       multipass_count=$(flock -x .spread_multipass -c 'COUNT=$(cat .spread_multipass); echo $(($COUNT + 1)) | tee .spread_multipass')
-      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
-          image="daily:devel"
-          instance_name="spread-devel-${multipass_count}"
-      else
-          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
-          # translated to an image XX.YY.
-          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          spread_name=$(echo ${image} | sed -e 's/\.//g')
-          instance_name="spread-${spread_name}-${multipass_count}"
-      fi
+
+      image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
+      spread_name=$(echo ${image} | sed -e 's/\.//g')
+      instance_name="spread-${spread_name}-${multipass_count}"
 
       if [ -z "${image}" ]; then
         FATAL "$SPREAD_SYSTEM is not supported!"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

The multipass backend had a switch that would cause it to pull a newer image than desired. This PR forces it to only use the image explicitly requested by task.yaml files. Tested locally, works for selecting both 22.04 and 24.04 images with spread.