### PR TITLE
docs(release-notes): update remote-build notes

### DIFF
--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -35,12 +35,8 @@ Try it out by typing ``snapcraft`` and pressing :kbd:`Tab` in your terminal.
 Improved remote builder
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, the remote builder only supported natively built snaps and failed to
-build cross-compiled snaps with an unhelpful error. Now, the remote builder supports
-both natively and cross-compiled snaps.
-
-Additionally, remote builds can now use the ``--build-for`` option to filter entries in
-an ``architectures`` or ``platforms`` key in a project file.
+Remote builds can now use the ``--build-for`` option to filter entries in an
+``architectures`` or ``platforms`` key in a project file.
 
 
 Support for confdbs
@@ -102,7 +98,6 @@ Fixed bugs and issues
 
 The following issues have been resolved in Snapcraft 8.7:
 
-- `#4996`_ Remote build gives an unfriendly error when attempting to cross-compile.
 - `#5258`_ The Flutter plugin failed to install Flutter for ``core22`` and ``core24``
   snaps.
 - `#5250`_ Resources path for ``QtWebEngineProcess`` wasn't exported for snaps
@@ -130,7 +125,6 @@ this release.
 :literalref:`@mr-cal<https://github.com/mr-cal>`,
 and :literalref:`@sergio-costas<https://github.com/sergio-costas>`
 
-.. _#4996: https://github.com/canonical/snapcraft/issues/4996
 .. _#5250: https://github.com/canonical/snapcraft/pull/5250
 .. _#5258: https://github.com/canonical/snapcraft/pull/5258
 .. _craft-application#600: https://github.com/canonical/craft-application/issues/600


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

I got mixed up with the new release notes and which version of Snapcraft was going to get #5265.  It's now going into Snapcraft 8.8, not 8.7, so I need to drop this from the release notes.

Fortunately, this isn't in the tagged [8.7.0](https://canonical-snapcraft.readthedocs-hosted.com/en/8.7.0/release-notes/snapcraft-8-7.html) or [8.7.1](https://canonical-snapcraft.readthedocs-hosted.com/en/8.7.1/release-notes/snapcraft-8-7.html) release notes.