### PR TITLE
style: use PEP 604 unions, PEP 585 annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ lint.select = [
     "ICN",  # Unconventional import aliases.
     "Q",  # Consistent quotations
     "RET",  # Return values
+    "UP006", # PEP 585 - type hinting generics
 ]
 lint.ignore = [
     # These following copy the flake8 configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ lint.select = [
     "Q",  # Consistent quotations
     "RET",  # Return values
     "UP006", # PEP 585 - type hinting generics
+    "UP007", # PEP 604 - union typing
 ]
 lint.ignore = [
     # These following copy the flake8 configuration

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -20,7 +20,7 @@ import argparse
 import contextlib
 import os
 import sys
-from typing import Any, Dict
+from typing import Any
 
 import craft_application.commands
 import craft_cli
@@ -213,7 +213,7 @@ def get_dispatcher() -> craft_cli.Dispatcher:
 
 
 def _run_dispatcher(
-    dispatcher: craft_cli.Dispatcher, global_args: Dict[str, Any]
+    dispatcher: craft_cli.Dispatcher, global_args: dict[str, Any]
 ) -> None:
     if global_args.get("trace"):
         emit.message(

--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -23,7 +23,7 @@ import pathlib
 import stat
 import textwrap
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -193,7 +193,7 @@ class StoreExportLoginCommand(AppCommand):
                 f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead",
             )
 
-        kwargs: Dict[str, Any] = {}
+        kwargs: dict[str, Any] = {}
         if parsed_args.snaps:
             kwargs["packages"] = parsed_args.snaps.split(",")
         if parsed_args.channels:

--- a/snapcraft/commands/extensions.py
+++ b/snapcraft/commands/extensions.py
@@ -17,7 +17,6 @@
 """Snapcraft extension commands."""
 
 import textwrap
-from typing import Dict, List
 
 import tabulate
 from craft_application.commands import AppCommand
@@ -43,9 +42,9 @@ class ExtensionModel(BaseModel):
     """Extension model for presentation."""
 
     name: str
-    bases: List[str]
+    bases: list[str]
 
-    def marshal(self) -> Dict[str, str]:
+    def marshal(self) -> dict[str, str]:
         """Marshal model into a dictionary for presentation."""
         return {
             "Extension name": self.name,
@@ -66,7 +65,7 @@ class ListExtensionsCommand(AppCommand):
 
     @overrides
     def run(self, parsed_args) -> None:
-        extension_presentation: Dict[str, ExtensionModel] = {}
+        extension_presentation: dict[str, ExtensionModel] = {}
 
         # New extensions.
         for extension_name in extensions.registry.get_extension_names():

--- a/snapcraft/commands/lint.py
+++ b/snapcraft/commands/lint.py
@@ -24,7 +24,7 @@ import tempfile
 import textwrap
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -108,7 +108,7 @@ class LintCommand(AppCommand):
                 snap_file, assert_file, parsed_args.http_proxy, parsed_args.https_proxy
             )
 
-    def _get_assert_file(self, snap_file: Path) -> Optional[Path]:
+    def _get_assert_file(self, snap_file: Path) -> Path | None:
         """Get an assertion file for a snap file.
 
         The assertion file name should be formatted as `<snap-name>.assert`.
@@ -134,9 +134,9 @@ class LintCommand(AppCommand):
     def _prepare_instance(
         self,
         snap_file: Path,
-        assert_file: Optional[Path],
-        http_proxy: Optional[str],
-        https_proxy: Optional[str],
+        assert_file: Path | None,
+        http_proxy: str | None,
+        https_proxy: str | None,
     ) -> None:
         """Prepare an instance to lint a snap file.
 
@@ -203,7 +203,7 @@ class LintCommand(AppCommand):
             finally:
                 providers.capture_logs_from_instance(instance)
 
-    def _run_linter(self, snap_file: Path, assert_file: Optional[Path]) -> None:
+    def _run_linter(self, snap_file: Path, assert_file: Path | None) -> None:
         """Run snapcraft linters on a snap file.
 
         :param snap_file: Path to snap file to lint.
@@ -257,7 +257,7 @@ class LintCommand(AppCommand):
 
             yield Path(temp_dir)
 
-    def _load_project(self, snapcraft_yaml_file: Path) -> Optional[models.Project]:
+    def _load_project(self, snapcraft_yaml_file: Path) -> models.Project | None:
         """Load a snapcraft Project from a snapcraft.yaml, if present.
 
         The snapcraft.yaml exist for snaps built with the `--enable-manifest` parameter.
@@ -290,7 +290,7 @@ class LintCommand(AppCommand):
     def _install_snap(
         self,
         snap_file: Path,
-        assert_file: Optional[Path],
+        assert_file: Path | None,
         snap_metadata: snap_yaml.SnapMetadata,
     ) -> Path:
         """Install a snap file and optional assertion file.
@@ -343,7 +343,7 @@ class LintCommand(AppCommand):
 
         return Path("/snap") / snap_metadata.name / "current"
 
-    def _load_lint_filters(self, project: Optional[models.Project]) -> models.Lint:
+    def _load_lint_filters(self, project: models.Project | None) -> models.Lint:
         """Load lint filters from a Project and disable the classic linter.
 
         :param project: Project from the snap file, if present.

--- a/snapcraft/commands/plugins.py
+++ b/snapcraft/commands/plugins.py
@@ -17,7 +17,7 @@
 """Snapcraft discovery commands."""
 
 import textwrap
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -64,7 +64,7 @@ class ListPluginsCommand(AppCommand):
             raise errors.LegacyFallback()
 
         base = parsed_args.base
-        message: Optional[str] = None
+        message: str | None = None
 
         if base is None:
             try:

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -20,7 +20,7 @@ import itertools
 import operator
 import textwrap
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set, Tuple, cast
+from typing import TYPE_CHECKING, Optional, Sequence, cast
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -95,7 +95,7 @@ class StoreStatusCommand(AppCommand):
             if not architectures:
                 return
 
-        tracks: List[str] = []
+        tracks: list[str] = []
         if parsed_args.track:
             tracks = cast(list, parsed_args.track)
             existing_tracks = {
@@ -157,7 +157,7 @@ def _get_channel_line(
     channel_info: SnapChannel,
     hint: str,
     progress_string: str,
-) -> List[str]:
+) -> list[str]:
     version_string = hint
     revision_string = hint
     expiration_date_string = ""
@@ -189,8 +189,8 @@ def _get_channel_lines_for_channel(  # noqa: C901 (complex-structure)
     channel_name: str,
     architecture: str,
     current_tick: str,
-) -> Tuple[str, List[List[str]]]:
-    channel_lines: List[List[str]] = []
+) -> tuple[str, list[list[str]]]:
+    channel_lines: list[list[str]] = []
 
     channel_info = snap_channel_map.get_channel_info(channel_name)
 
@@ -285,7 +285,7 @@ def _get_channel_lines_for_channel(  # noqa: C901 (complex-structure)
 
 
 def _has_channels_for_architecture(
-    snap_channel_map, architecture: str, channels: List[str]
+    snap_channel_map, architecture: str, channels: list[str]
 ) -> bool:
     progressive = (False, True)
     # channel_query = (channel_name, progressive)
@@ -398,7 +398,7 @@ class StoreListTracksCommand(AppCommand):
         )
 
         # Iterate over the entries, replace None with - for consistent presentation
-        track_table: List[List[str]] = [
+        track_table: list[list[str]] = [
             [
                 track.name,
                 track.status,
@@ -503,13 +503,13 @@ class StoreListRevisionsCommand(AppCommand):
 
         emit.message(tabulated_revisions)
 
-    def _get_channels_for_revision(self, releases, revision: int) -> List[str]:
+    def _get_channels_for_revision(self, releases, revision: int) -> list[str]:
         # channels: the set of channels revision was released to, active or not.
-        channels: Set[str] = set()
+        channels: set[str] = set()
         # seen_channel: applies to channels regardless of revision.
         # The first channel that shows up for each architecture is to
         # be marked as the active channel, all others are historic.
-        seen_channel: Dict[str, Set[str]] = {}
+        seen_channel: dict[str, set[str]] = {}
 
         for release in releases.releases:
             if release.architecture not in seen_channel:

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -20,7 +20,7 @@ import itertools
 import operator
 import textwrap
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Sequence, cast
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -152,8 +152,8 @@ def _get_channel_order(snap_channels, tracks: Sequence[str]) -> OrderedDict:
 
 def _get_channel_line(
     *,
-    mapped_channel: Optional[MappedChannel],
-    revision: Optional[Revision],
+    mapped_channel: MappedChannel | None,
+    revision: Revision | None,
     channel_info: SnapChannel,
     hint: str,
     progress_string: str,
@@ -195,7 +195,7 @@ def _get_channel_lines_for_channel(  # noqa: C901 (complex-structure)
     channel_info = snap_channel_map.get_channel_info(channel_name)
 
     try:
-        progressive_mapped_channel: Optional[MappedChannel] = (
+        progressive_mapped_channel: MappedChannel | None = (
             snap_channel_map.get_mapped_channel(
                 channel_name=channel_name, architecture=architecture, progressive=True
             )
@@ -239,7 +239,7 @@ def _get_channel_lines_for_channel(  # noqa: C901 (complex-structure)
         progress_string = _HINTS.NO_PROGRESS
 
     try:
-        mapped_channel: Optional[MappedChannel] = snap_channel_map.get_mapped_channel(
+        mapped_channel: MappedChannel | None = snap_channel_map.get_mapped_channel(
             channel_name=channel_name, architecture=architecture, progressive=False
         )
     except ValueError:

--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -19,7 +19,7 @@
 import pathlib
 import textwrap
 from collections import abc
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -107,7 +107,7 @@ class StoreUploadCommand(AppCommand):
         if not snap_file.exists() or not snap_file.is_file():
             raise ArgumentParsingError(f"{str(snap_file)!r} is not a valid file")
 
-        channels: Optional[List[str]] = None
+        channels: Optional[list[str]] = None
         if parsed_args.channels:
             channels = parsed_args.channels.split(",")
 

--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -19,7 +19,7 @@
 import pathlib
 import textwrap
 from collections import abc
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from craft_application.commands import AppCommand
 from craft_cli import emit
@@ -107,7 +107,7 @@ class StoreUploadCommand(AppCommand):
         if not snap_file.exists() or not snap_file.is_file():
             raise ArgumentParsingError(f"{str(snap_file)!r} is not a valid file")
 
-        channels: Optional[list[str]] = None
+        channels: list[str] | None = None
         if parsed_args.channels:
             channels = parsed_args.channels.split(",")
 

--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -22,7 +22,7 @@ import subprocess
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import craft_application.util
 import yaml
@@ -225,7 +225,7 @@ def edit_validation_sets(
                 raise errors.SnapcraftError("operation aborted") from err
 
 
-def _sign_assertion(assertion: Dict[str, Any], *, key_name: Optional[str]) -> bytes:
+def _sign_assertion(assertion: dict[str, Any], *, key_name: Optional[str]) -> bytes:
     emit.debug("Signing assertion.")
     cmdline = ["snap", "sign"]
     if key_name:

--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -22,7 +22,7 @@ import subprocess
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import craft_application.util
 import yaml
@@ -139,7 +139,7 @@ class StoreEditValidationSetsCommand(AppCommand):
 
 def _submit_validation_set(
     edited_validation_sets: validation_sets.EditableBuildAssertion,
-    key_name: Optional[str],
+    key_name: str | None,
     store_client: StoreClientCLI,
 ) -> None:
     emit.debug(
@@ -225,7 +225,7 @@ def edit_validation_sets(
                 raise errors.SnapcraftError("operation aborted") from err
 
 
-def _sign_assertion(assertion: dict[str, Any], *, key_name: Optional[str]) -> bytes:
+def _sign_assertion(assertion: dict[str, Any], *, key_name: str | None) -> bytes:
     emit.debug("Signing assertion.")
     cmdline = ["snap", "sign"]
     if key_name:

--- a/snapcraft/elf/_elf_file.py
+++ b/snapcraft/elf/_elf_file.py
@@ -21,7 +21,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, cast
+from typing import Optional, cast
 
 from craft_cli import emit
 from elftools.construct import ConstructError
@@ -32,8 +32,8 @@ from snapcraft import utils
 
 from . import errors
 
-_ElfArchitectureTuple = Tuple[str, str, str]
-_SonameCacheDict = Dict[Tuple[_ElfArchitectureTuple, str], Path]
+_ElfArchitectureTuple = tuple[str, str, str]
+_SonameCacheDict = dict[tuple[_ElfArchitectureTuple, str], Path]
 
 _DEBUG_INFO = ".debug_info"
 _DYNAMIC = ".dynamic"
@@ -47,7 +47,7 @@ class _NeededLibrary:
 
     def __init__(self, *, name: str) -> None:
         self.name = name
-        self.versions: Set[str] = set()
+        self.versions: set[str] = set()
 
     def add_version(self, version: str) -> None:
         """Add a new library version."""
@@ -64,7 +64,7 @@ class SonameCache:
         """Obtain cached item."""
         return self._soname_paths[key]
 
-    def __setitem__(self, key: Tuple[_ElfArchitectureTuple, str], item: Path):
+    def __setitem__(self, key: tuple[_ElfArchitectureTuple, str], item: Path):
         """Add item to cache."""
         # Initial API error checks
         if not isinstance(key, tuple):
@@ -114,7 +114,7 @@ class _Library:
         *,
         soname: str,
         soname_path: Path,
-        search_paths: List[Path],
+        search_paths: list[Path],
         base_path: Optional[Path],
         arch_tuple: _ElfArchitectureTuple,
         soname_cache: SonameCache,
@@ -195,13 +195,13 @@ class ElfFile:
         :param str path: path to an elf_file within a snapcraft project.
         """
         self.path = path
-        self.dependencies: Set[_Library] = set()
+        self.dependencies: set[_Library] = set()
 
         self.arch_tuple: Optional[_ElfArchitectureTuple] = None
         self.interp = ""
         self.soname = ""
-        self.versions: Set[str] = set()
-        self.needed: Dict[str, _NeededLibrary] = {}
+        self.versions: set[str] = set()
+        self.needed: dict[str, _NeededLibrary] = {}
         self.execstack_set = False
         self.is_dynamic = True
         self.build_id = ""
@@ -353,10 +353,10 @@ class ElfFile:
         self,
         root_path: Path,
         base_path: Optional[Path],
-        content_dirs: List[Path],
+        content_dirs: list[Path],
         arch_triplet: str,
         soname_cache: Optional[SonameCache] = None,
-    ) -> Set[Path]:
+    ) -> set[Path]:
         """Load the set of libraries that are needed to satisfy elf's runtime.
 
         This may include libraries contained within the project.
@@ -379,7 +379,7 @@ class ElfFile:
         if base_path is not None:
             search_paths.append(base_path)
 
-        ld_library_paths: List[str] = []
+        ld_library_paths: list[str] = []
         for path in search_paths:
             ld_library_paths.extend(
                 utils.get_common_ld_library_paths(path, arch_triplet)
@@ -404,7 +404,7 @@ class ElfFile:
             )
 
         # Return the set of dependency paths, minus those found in the base.
-        dependencies: Set[Path] = set()
+        dependencies: set[Path] = set()
         for library in self.dependencies:
             if not library.in_base_snap:
                 dependencies.add(library.path)
@@ -416,8 +416,8 @@ def _get_host_libc_path(arch_triplet) -> Path:
 
 
 def _determine_libraries(
-    *, path: Path, ld_library_paths: List[str], arch_triplet: str
-) -> Dict[str, str]:
+    *, path: Path, ld_library_paths: list[str], arch_triplet: str
+) -> dict[str, str]:
     # Try the usual method with ldd.
     with contextlib.suppress(subprocess.CalledProcessError):
         return _ldd(path, ld_library_paths)
@@ -442,8 +442,8 @@ def _determine_libraries(
 
 
 def _ldd(
-    path: Path, ld_library_paths: List[str], *, ld_preload: Optional[str] = None
-) -> Dict[str, str]:
+    path: Path, ld_library_paths: list[str], *, ld_preload: Optional[str] = None
+) -> dict[str, str]:
     """Use host ldd to determine library dependencies."""
     ldd = utils.get_host_tool("ldd")  # TODO: use `ld` from the base snap (#4751)
     env = {
@@ -456,7 +456,7 @@ def _ldd(
     return _parse_ldd_output(_check_output([ldd, str(path)], extra_env=env))
 
 
-def _ld_trace(path: Path, ld_library_paths: List[str]) -> Dict[str, str]:
+def _ld_trace(path: Path, ld_library_paths: list[str]) -> dict[str, str]:
     """Use LD_TRACE_LOADED_OBJECTS to determine library dependencies."""
     env = {
         "LD_TRACE_LOADED_OBJECTS": "1",
@@ -466,7 +466,7 @@ def _ld_trace(path: Path, ld_library_paths: List[str]) -> Dict[str, str]:
     return _parse_ldd_output(_check_output([str(path)], extra_env=env))
 
 
-def _parse_ldd_output(output: str) -> Dict[str, str]:
+def _parse_ldd_output(output: str) -> dict[str, str]:
     """Parse ldd output.
 
     Example ldd outputs:
@@ -479,7 +479,7 @@ def _parse_ldd_output(output: str) -> Dict[str, str]:
 
     :returns: Dictionary of dependencies, mapping library name to path.
     """
-    libraries: Dict[str, str] = {}
+    libraries: dict[str, str] = {}
     ldd_lines = output.splitlines()
 
     for line in ldd_lines:
@@ -503,7 +503,7 @@ def _parse_ldd_output(output: str) -> Dict[str, str]:
     return libraries
 
 
-def _ldd_resolve(soname: str, soname_path: str) -> Tuple[str, str]:
+def _ldd_resolve(soname: str, soname_path: str) -> tuple[str, str]:
     emit.debug(f"_ldd_resolve: {soname!r} {soname_path!r}")
 
     # If found, resolve the path components.  We can safely determine that
@@ -520,7 +520,7 @@ def _ldd_resolve(soname: str, soname_path: str) -> Tuple[str, str]:
     return soname, soname
 
 
-def _check_output(cmd: List[str], *, extra_env: Dict[str, str]) -> str:
+def _check_output(cmd: list[str], *, extra_env: dict[str, str]) -> str:
     env = os.environ.copy()
     env.update(extra_env)
 

--- a/snapcraft/elf/_elf_file.py
+++ b/snapcraft/elf/_elf_file.py
@@ -21,7 +21,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 from craft_cli import emit
 from elftools.construct import ConstructError
@@ -115,7 +115,7 @@ class _Library:
         soname: str,
         soname_path: Path,
         search_paths: list[Path],
-        base_path: Optional[Path],
+        base_path: Path | None,
         arch_tuple: _ElfArchitectureTuple,
         soname_cache: SonameCache,
     ) -> None:
@@ -197,7 +197,7 @@ class ElfFile:
         self.path = path
         self.dependencies: set[_Library] = set()
 
-        self.arch_tuple: Optional[_ElfArchitectureTuple] = None
+        self.arch_tuple: _ElfArchitectureTuple | None = None
         self.interp = ""
         self.soname = ""
         self.versions: set[str] = set()
@@ -352,10 +352,10 @@ class ElfFile:
     def load_dependencies(
         self,
         root_path: Path,
-        base_path: Optional[Path],
+        base_path: Path | None,
         content_dirs: list[Path],
         arch_triplet: str,
-        soname_cache: Optional[SonameCache] = None,
+        soname_cache: SonameCache | None = None,
     ) -> set[Path]:
         """Load the set of libraries that are needed to satisfy elf's runtime.
 
@@ -442,7 +442,7 @@ def _determine_libraries(
 
 
 def _ldd(
-    path: Path, ld_library_paths: list[str], *, ld_preload: Optional[str] = None
+    path: Path, ld_library_paths: list[str], *, ld_preload: str | None = None
 ) -> dict[str, str]:
     """Use host ldd to determine library dependencies."""
     ldd = utils.get_host_tool("ldd")  # TODO: use `ld` from the base snap (#4751)

--- a/snapcraft/elf/_patcher.py
+++ b/snapcraft/elf/_patcher.py
@@ -22,7 +22,6 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import List, Set
 
 from craft_cli import emit
 
@@ -101,7 +100,7 @@ class Patcher:
                 elf_file_path=elf_file.path,
             )
 
-    def _run_patchelf(self, *, patchelf_args: List[str], elf_file_path: Path) -> None:
+    def _run_patchelf(self, *, patchelf_args: list[str], elf_file_path: Path) -> None:
         # Run patchelf on a copy of the primed file and replace it
         # after it is successful. This allows us to break the potential
         # hard link created when migrating the file across the steps of
@@ -126,7 +125,7 @@ class Patcher:
             shutil.copy2(temp_file.name, elf_file_path)
 
     @functools.lru_cache(maxsize=1024)  # noqa: B019 Possible memory leaks in lru_cache
-    def get_current_rpath(self, elf_file: ElfFile) -> List[str]:
+    def get_current_rpath(self, elf_file: ElfFile) -> list[str]:
         """Obtain the current rpath from the ELF file dynamic section."""
         output = subprocess.check_output(
             [self._patchelf_cmd, "--print-rpath", str(elf_file.path)]
@@ -134,10 +133,10 @@ class Patcher:
         return [x for x in output.decode().strip().split(":") if x]
 
     @functools.lru_cache(maxsize=1024)  # noqa: B019 Possible memory leaks in lru_cache
-    def get_proposed_rpath(self, elf_file: ElfFile) -> List[str]:
+    def get_proposed_rpath(self, elf_file: ElfFile) -> list[str]:
         """Obtain the proposed rpath pointing to the base or application snaps."""
-        origin_rpaths: List[str] = []
-        base_rpaths: Set[str] = set()
+        origin_rpaths: list[str] = []
+        base_rpaths: set[str] = set()
         existing_rpaths = self.get_current_rpath(elf_file)
 
         for dependency in elf_file.dependencies:

--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -21,7 +21,7 @@ import os
 import platform
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable
 
 from craft_cli import emit
 from elftools.common.exceptions import ELFError
@@ -131,7 +131,7 @@ def get_dynamic_linker(*, root_path: Path, snap_path: Path) -> str:
     raise errors.DynamicLinkerNotFound(root_path / arch_config.dynamic_linker)
 
 
-def get_arch_triplet(arch: Optional[str] = None) -> str:
+def get_arch_triplet(arch: str | None = None) -> str:
     """Get the arch triplet string for an architecture.
 
     :param arch: Architecture to get the triplet of. If None, then get the arch triplet

--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -21,7 +21,7 @@ import os
 import platform
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Set
+from typing import Iterable, Optional
 
 from craft_cli import emit
 from elftools.common.exceptions import ELFError
@@ -30,13 +30,13 @@ from . import ElfFile, errors
 
 
 @functools.lru_cache(maxsize=1)
-def get_elf_files(root_path: Path) -> List[ElfFile]:
+def get_elf_files(root_path: Path) -> list[ElfFile]:
     """Obtain a set of all ELF files in a subtree.
 
     :param root_path: The root of the subtree to list ELF files from.
     :return: A set of ELF files found in the given subtree.
     """
-    file_list: List[str] = []
+    file_list: list[str] = []
     for root, _, files in os.walk(str(root_path)):
         for file_name in files:
             # Filter out object files
@@ -50,14 +50,14 @@ def get_elf_files(root_path: Path) -> List[ElfFile]:
     return get_elf_files_from_list(root_path, file_list)
 
 
-def get_elf_files_from_list(root: Path, file_list: Iterable[str]) -> List[ElfFile]:
+def get_elf_files_from_list(root: Path, file_list: Iterable[str]) -> list[ElfFile]:
     """Return a list of ELF files from file_list prepended with root.
 
     :param str root: the root directory from where the file_list is generated.
     :param file_list: a list of file in root.
     :returns: a list of ElfFile objects.
     """
-    elf_files: Set[ElfFile] = set()
+    elf_files: set[ElfFile] = set()
 
     for part_file in file_list:
         # Filter out object (*.o) files-- we only care about binaries.
@@ -149,6 +149,6 @@ def get_arch_triplet(arch: Optional[str] = None) -> str:
     return arch_config.arch_triplet
 
 
-def get_all_arch_triplets() -> List[str]:
+def get_all_arch_triplets() -> list[str]:
     """Get a list of all architecture triplets."""
     return [architecture.arch_triplet for architecture in _ARCH_CONFIG.values()]

--- a/snapcraft/elf/errors.py
+++ b/snapcraft/elf/errors.py
@@ -17,7 +17,6 @@
 """Helpers to parse and handle ELF binary files."""
 
 from pathlib import Path
-from typing import List
 
 from snapcraft import errors
 
@@ -25,7 +24,7 @@ from snapcraft import errors
 class PatcherError(errors.SnapcraftError):
     """Failed to patch an ELF file."""
 
-    def __init__(self, path: Path, *, cmd: List[str], code: int) -> None:
+    def __init__(self, path: Path, *, cmd: list[str], code: int) -> None:
         self.path = path
         self.cmd = cmd
         self.code = code

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -17,7 +17,6 @@
 """Snapcraft error definitions."""
 
 import subprocess
-from typing import Optional
 
 from craft_cli import CraftError
 
@@ -147,13 +146,13 @@ class MaintenanceBase(SnapcraftError):
     """Error for bases under ESM and no longer supported in this release."""
 
     def __init__(self, base: str) -> None:
-        channel: Optional[str] = None
+        channel: str | None = None
         if base == "core":
             channel = "4.x"
         elif base == "core18":
             channel = "7.x"
 
-        resolution: Optional[str] = None
+        resolution: str | None = None
         if channel:
             resolution = f"Install from or refresh to the {channel!r} channel."
 

--- a/snapcraft/extensions/_ros2_humble_meta.py
+++ b/snapcraft/extensions/_ros2_humble_meta.py
@@ -20,7 +20,7 @@
 
 import dataclasses
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 
@@ -47,7 +47,7 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return True
 
     @overrides

--- a/snapcraft/extensions/_ros2_humble_meta.py
+++ b/snapcraft/extensions/_ros2_humble_meta.py
@@ -20,7 +20,7 @@
 
 import dataclasses
 from abc import abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from overrides import overrides
 
@@ -51,7 +51,7 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
         return True
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         root_snippet = super().get_root_snippet()
         root_snippet["plugs"] = {
             self.ros2_humble_snaps.content: {
@@ -64,7 +64,7 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
         return root_snippet
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         app_snippet = super().get_app_snippet(app_name=app_name)
         python_paths = app_snippet["environment"]["PYTHONPATH"]
         new_python_paths = [
@@ -79,7 +79,7 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
         return app_snippet
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         part_snippet = super().get_part_snippet(plugin_name=plugin_name)
 
         # These are colcon-plugin specific entries
@@ -92,7 +92,7 @@ class ROS2HumbleMetaBase(ROS2HumbleExtension):
         return part_snippet
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         parts_snippet = super().get_parts_snippet()
         # Very unlikely but it may happen that the snapped application doesn't
         # even pull those deps. In that case, there is no valid ROS 2 ws to source.

--- a/snapcraft/extensions/_ros2_jazzy_meta.py
+++ b/snapcraft/extensions/_ros2_jazzy_meta.py
@@ -20,7 +20,7 @@
 
 import dataclasses
 from abc import abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from overrides import overrides
 
@@ -51,7 +51,7 @@ class ROS2JazzyMetaBase(ROS2JazzyExtension):
         return True
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         root_snippet = super().get_root_snippet()
         root_snippet["plugs"] = {
             self.ros2_jazzy_snaps.content: {
@@ -64,7 +64,7 @@ class ROS2JazzyMetaBase(ROS2JazzyExtension):
         return root_snippet
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         app_snippet = super().get_app_snippet(app_name=app_name)
         python_paths = app_snippet["environment"]["PYTHONPATH"]
         new_python_paths = [
@@ -79,7 +79,7 @@ class ROS2JazzyMetaBase(ROS2JazzyExtension):
         return app_snippet
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         part_snippet = super().get_part_snippet(plugin_name=plugin_name)
 
         # These are colcon-plugin specific entries
@@ -92,7 +92,7 @@ class ROS2JazzyMetaBase(ROS2JazzyExtension):
         return part_snippet
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         parts_snippet = super().get_parts_snippet()
         # Very unlikely but it may happen that the snapped application doesn't
         # even pull those deps. In that case, there is no valid ROS 2 ws to source.

--- a/snapcraft/extensions/_ros2_jazzy_meta.py
+++ b/snapcraft/extensions/_ros2_jazzy_meta.py
@@ -20,7 +20,7 @@
 
 import dataclasses
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 
@@ -47,7 +47,7 @@ class ROS2JazzyMetaBase(ROS2JazzyExtension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return True
 
     @overrides

--- a/snapcraft/extensions/_utils.py
+++ b/snapcraft/extensions/_utils.py
@@ -19,7 +19,7 @@
 import collections
 import contextlib
 import copy
-from typing import TYPE_CHECKING, Any, Dict, List, Set
+from typing import TYPE_CHECKING, Any
 
 from .registry import get_extension_class
 
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
 
 
 def apply_extensions(
-    yaml_data: Dict[str, Any], *, arch: str, target_arch: str
-) -> Dict[str, Any]:
+    yaml_data: dict[str, Any], *, arch: str, target_arch: str
+) -> dict[str, Any]:
     """Apply all extensions.
 
     :param dict yaml_data: Loaded, unprocessed snapcraft.yaml
@@ -42,7 +42,7 @@ def apply_extensions(
 
     # Mapping of extension names to set of app names to which the extension needs to be
     # applied.
-    declared_extensions: Dict[str, Set[str]] = collections.defaultdict(set)
+    declared_extensions: dict[str, set[str]] = collections.defaultdict(set)
 
     for app_name, app_definition in yaml_data.get("apps", {}).items():
         extension_names = app_definition.get("extensions", [])
@@ -67,8 +67,8 @@ def apply_extensions(
 
 
 def _apply_extension(
-    yaml_data: Dict[str, Any],
-    app_names: Set[str],
+    yaml_data: dict[str, Any],
+    app_names: set[str],
     extension: "Extension",
 ) -> None:
     # Apply the root components of the extension (if any)
@@ -127,10 +127,10 @@ def _apply_extension_property(existing_property: Any, extension_property: Any) -
     return extension_property
 
 
-def _remove_list_duplicates(seq: List[str]) -> List[str]:
+def _remove_list_duplicates(seq: list[str]) -> list[str]:
     """De-dupe string list maintaining ordering."""
-    seen: Set[str] = set()
-    deduped: List[str] = []
+    seen: set[str] = set()
+    deduped: list[str] = []
 
     for item in seq:
         if item not in seen:

--- a/snapcraft/extensions/env_injector.py
+++ b/snapcraft/extensions/env_injector.py
@@ -16,7 +16,7 @@
 
 """Extension to automatically set environment variables on snaps."""
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from overrides import overrides
 
@@ -55,12 +55,12 @@ class EnvInjector(Extension):
 
     @staticmethod
     @overrides
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         return ("core24",)
 
     @staticmethod
     @overrides
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         return ("strict", "devmode", "classic")
 
     @staticmethod
@@ -69,11 +69,11 @@ class EnvInjector(Extension):
         return True
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         return {}
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         """Return the app snippet to apply."""
         return {
             "command-chain": ["bin/command-chain/env-exporter"],
@@ -83,11 +83,11 @@ class EnvInjector(Extension):
         }
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         return {}
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         toolchain = self.get_toolchain(self.arch)
         if toolchain is None:
             raise ValueError(

--- a/snapcraft/extensions/env_injector.py
+++ b/snapcraft/extensions/env_injector.py
@@ -16,7 +16,7 @@
 
 """Extension to automatically set environment variables on snaps."""
 
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 
@@ -65,7 +65,7 @@ class EnvInjector(Extension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return True
 
     @overrides

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -20,7 +20,7 @@ import abc
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, Tuple, final
+from typing import Any, Optional, Sequence, final
 
 from craft_cli import emit
 
@@ -39,7 +39,7 @@ class Extension(abc.ABC):
     """
 
     def __init__(
-        self, *, yaml_data: Dict[str, Any], arch: str, target_arch: str
+        self, *, yaml_data: dict[str, Any], arch: str, target_arch: str
     ) -> None:
         """Create a new Extension."""
         self.yaml_data = yaml_data
@@ -48,12 +48,12 @@ class Extension(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         """Return a tuple of supported bases."""
 
     @staticmethod
     @abc.abstractmethod
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         """Return a tuple of supported confinement settings."""
 
     @staticmethod
@@ -62,22 +62,22 @@ class Extension(abc.ABC):
         """Return whether or not this extension is unstable for given base."""
 
     @abc.abstractmethod
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         """Return the root snippet to apply."""
 
     @abc.abstractmethod
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         """Return the app snippet to apply.
 
         :param app_name: the name of the app where the snippet will be applied
         """
 
     @abc.abstractmethod
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         """Return the part snippet to apply to existing parts."""
 
     @abc.abstractmethod
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         """Return the parts to add to parts."""
 
     @final

--- a/snapcraft/extensions/extension.py
+++ b/snapcraft/extensions/extension.py
@@ -20,7 +20,7 @@ import abc
 import os
 import sys
 from pathlib import Path
-from typing import Any, Optional, Sequence, final
+from typing import Any, Sequence, final
 
 from craft_cli import emit
 
@@ -58,7 +58,7 @@ class Extension(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         """Return whether or not this extension is unstable for given base."""
 
     @abc.abstractmethod
@@ -88,7 +88,7 @@ class Extension(abc.ABC):
         :raises errors.ExtensionError: if the extension is incompatible with the project.
         """
         base: str = self.yaml_data["base"]
-        confinement: Optional[str] = self.yaml_data.get("confinement")
+        confinement: str | None = self.yaml_data.get("confinement")
 
         if self.is_experimental(base) and not os.getenv(
             "SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -19,7 +19,7 @@
 import dataclasses
 import functools
 import re
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 
@@ -82,7 +82,7 @@ class GNOME(Extension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return False
 
     @overrides

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -19,7 +19,7 @@
 import dataclasses
 import functools
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from overrides import overrides
 
@@ -72,12 +72,12 @@ class GNOME(Extension):
 
     @staticmethod
     @overrides
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         return ("core22", "core24")
 
     @staticmethod
     @overrides
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         return "strict", "devmode"
 
     @staticmethod
@@ -86,7 +86,7 @@ class GNOME(Extension):
         return False
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         command_chain = ["snap/command-chain/desktop-launch"]
         if self.yaml_data["base"] == "core24":
             command_chain.insert(0, "snap/command-chain/gpu-2404-wrapper")
@@ -108,7 +108,7 @@ class GNOME(Extension):
         base = self.yaml_data["base"]
         sdk_snap = _SDK_SNAP[base]
 
-        build_snaps: List[str] = []
+        build_snaps: list[str] = []
         for part in self.yaml_data["parts"].values():
             build_snaps.extend(part.get("build-snaps", []))
 
@@ -127,7 +127,7 @@ class GNOME(Extension):
         return GNOMESnaps(sdk=sdk_snap, content=content, builtin=builtin)
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         platform_snap = self.gnome_snaps.content
         base = self.yaml_data["base"]
 
@@ -215,7 +215,7 @@ class GNOME(Extension):
         }
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         sdk_snap = self.gnome_snaps.sdk
 
         return {
@@ -311,7 +311,7 @@ class GNOME(Extension):
         }
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         """Get the parts snippet for the GNOME extension.
 
         If the GNOME SDK is not built into the content snap, the add the

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -20,7 +20,7 @@
 import dataclasses
 import functools
 import re
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 
@@ -90,7 +90,7 @@ class KDENeon(Extension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return False
 
     @overrides

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -20,7 +20,7 @@
 import dataclasses
 import functools
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from overrides import overrides
 
@@ -48,8 +48,8 @@ class KDESnaps:
     kf5_sdk_snap: str
     content_qt5: str
     content_kf5: str
-    gpu_plugs: Dict[str, Any]
-    gpu_layouts: Dict[str, Any]
+    gpu_plugs: dict[str, Any]
+    gpu_layouts: dict[str, Any]
     qt5_builtin: bool = True
     kf5_builtin: bool = True
 
@@ -80,12 +80,12 @@ class KDENeon(Extension):
 
     @staticmethod
     @overrides
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         return ("core22", "core24")
 
     @staticmethod
     @overrides
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         return "strict", "devmode"
 
     @staticmethod
@@ -94,7 +94,7 @@ class KDENeon(Extension):
         return False
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         command_chain = ["snap/command-chain/desktop-launch"]
         if self.yaml_data["base"] == "core24":
             command_chain.insert(0, "snap/command-chain/gpu-2404-wrapper")
@@ -141,7 +141,7 @@ class KDENeon(Extension):
             case _:
                 raise AssertionError(f"Unsupported base: {base}")
 
-        build_snaps: List[str] = []
+        build_snaps: list[str] = []
         for part in self.yaml_data["parts"].values():
             build_snaps.extend(part.get("build-snaps", []))
 
@@ -176,7 +176,7 @@ class KDENeon(Extension):
         )
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         platform_kf5_snap = self.kde_snaps.content_kf5
         content_kf5_snap = self.kde_snaps.content_kf5 + "-all"
         gpu_plugs = self.kde_snaps.gpu_plugs
@@ -234,7 +234,7 @@ class KDENeon(Extension):
         }
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         qt5_sdk_snap = self.kde_snaps.qt5_sdk_snap
         kf5_sdk_snap = self.kde_snaps.kf5_sdk_snap
 
@@ -412,7 +412,7 @@ class KDENeon(Extension):
         }
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         """Get the parts snippet for the KDE extension.
 
         If the KDE Neon SDK is not built into the content snap, the add the

--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -20,7 +20,7 @@
 import dataclasses
 import functools
 import re
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 
@@ -98,7 +98,7 @@ class KDENeon6(Extension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return False
 
     @overrides

--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -20,7 +20,7 @@
 import dataclasses
 import functools
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from overrides import overrides
 
@@ -48,8 +48,8 @@ class KDESnaps6:
     kf6_sdk_snap: str
     content_qt6: str
     content_kf6: str
-    gpu_plugs: Dict[str, Any]
-    gpu_layouts: Dict[str, Any]
+    gpu_plugs: dict[str, Any]
+    gpu_layouts: dict[str, Any]
     qt6_builtin: bool = True
     kf6_builtin: bool = True
 
@@ -88,12 +88,12 @@ class KDENeon6(Extension):
 
     @staticmethod
     @overrides
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         return ("core22", "core24")
 
     @staticmethod
     @overrides
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         return "strict", "devmode"
 
     @staticmethod
@@ -102,7 +102,7 @@ class KDENeon6(Extension):
         return False
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         command_chain = ["snap/command-chain/desktop-launch"]
         if self.yaml_data["base"] == "core24":
             command_chain.insert(0, "snap/command-chain/gpu-2404-wrapper")
@@ -149,7 +149,7 @@ class KDENeon6(Extension):
             case _:
                 raise AssertionError(f"Unsupported base: {base}")
 
-        build_snaps: List[str] = []
+        build_snaps: list[str] = []
         for part in self.yaml_data["parts"].values():
             build_snaps.extend(part.get("build-snaps", []))
 
@@ -184,7 +184,7 @@ class KDENeon6(Extension):
         )
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         platform_kf6_snap = self.kde_snaps.content_kf6
         content_kf6_snap = self.kde_snaps.content_kf6 + "-all"
         gpu_plugs = self.kde_snaps.gpu_plugs
@@ -242,7 +242,7 @@ class KDENeon6(Extension):
         }
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         qt6_sdk_snap = self.kde_snaps.qt6_sdk_snap
         kf6_sdk_snap = self.kde_snaps.kf6_sdk_snap
 
@@ -428,7 +428,7 @@ class KDENeon6(Extension):
         }
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         # We can change this to the lightweight command-chain when
         # the content snap includes the desktop-launch from
         # https://github.com/canonical/snapcraft-desktop-integration

--- a/snapcraft/extensions/registry.py
+++ b/snapcraft/extensions/registry.py
@@ -16,7 +16,7 @@
 
 """Extension registry."""
 
-from typing import TYPE_CHECKING, Dict, List, Type
+from typing import TYPE_CHECKING
 
 from snapcraft import errors
 
@@ -37,9 +37,9 @@ from .ros2_jazzy_ros_core import ROS2JazzyRosCoreExtension
 if TYPE_CHECKING:
     from .extension import Extension
 
-    ExtensionType = Type[Extension]
+    ExtensionType = type[Extension]
 
-_EXTENSIONS: Dict[str, "ExtensionType"] = {
+_EXTENSIONS: dict[str, "ExtensionType"] = {
     "env-injector": EnvInjector,
     "gnome": GNOME,
     "ros2-humble": ROS2HumbleExtension,
@@ -56,7 +56,7 @@ _EXTENSIONS: Dict[str, "ExtensionType"] = {
 }
 
 
-def get_extension_names() -> List[str]:
+def get_extension_names() -> list[str]:
     """Obtain a extension class given the name.
 
     :param name: The extension name.

--- a/snapcraft/extensions/ros2_humble.py
+++ b/snapcraft/extensions/ros2_humble.py
@@ -18,7 +18,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Humble."""
 
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 from typing_extensions import Final
@@ -44,7 +44,7 @@ class ROS2HumbleExtension(Extension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return False
 
     @overrides

--- a/snapcraft/extensions/ros2_humble.py
+++ b/snapcraft/extensions/ros2_humble.py
@@ -18,7 +18,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Humble."""
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from overrides import overrides
 from typing_extensions import Final
@@ -34,12 +34,12 @@ class ROS2HumbleExtension(Extension):
 
     @staticmethod
     @overrides
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         return ("core22",)
 
     @staticmethod
     @overrides
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         return ("strict", "devmode")
 
     @staticmethod
@@ -48,7 +48,7 @@ class ROS2HumbleExtension(Extension):
         return False
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         return {
             "package-repositories": [
                 {
@@ -87,7 +87,7 @@ class ROS2HumbleExtension(Extension):
         }
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         python_paths = [
             f"$SNAP/opt/ros/{self.ROS_DISTRO}/lib/python3.10/site-packages",
             "$SNAP/usr/lib/python3/dist-packages",
@@ -106,7 +106,7 @@ class ROS2HumbleExtension(Extension):
         }
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         return {
             "build-environment": [
                 {"ROS_VERSION": self.ROS_VERSION},
@@ -115,7 +115,7 @@ class ROS2HumbleExtension(Extension):
         }
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         return {
             f"ros2-{self.ROS_DISTRO}/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",

--- a/snapcraft/extensions/ros2_jazzy.py
+++ b/snapcraft/extensions/ros2_jazzy.py
@@ -16,7 +16,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Jazzy."""
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from overrides import overrides
 from typing_extensions import Final
@@ -32,12 +32,12 @@ class ROS2JazzyExtension(Extension):
 
     @staticmethod
     @overrides
-    def get_supported_bases() -> Tuple[str, ...]:
+    def get_supported_bases() -> tuple[str, ...]:
         return ("core24",)
 
     @staticmethod
     @overrides
-    def get_supported_confinement() -> Tuple[str, ...]:
+    def get_supported_confinement() -> tuple[str, ...]:
         return ("strict", "devmode")
 
     @staticmethod
@@ -46,7 +46,7 @@ class ROS2JazzyExtension(Extension):
         return False
 
     @overrides
-    def get_root_snippet(self) -> Dict[str, Any]:
+    def get_root_snippet(self) -> dict[str, Any]:
         return {
             "package-repositories": [
                 {
@@ -85,7 +85,7 @@ class ROS2JazzyExtension(Extension):
         }
 
     @overrides
-    def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         python_paths = [
             f"$SNAP/opt/ros/{self.ROS_DISTRO}/lib/python3.12/site-packages",
             "$SNAP/usr/lib/python3/dist-packages",
@@ -104,7 +104,7 @@ class ROS2JazzyExtension(Extension):
         }
 
     @overrides
-    def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         return {
             "build-environment": [
                 {"ROS_VERSION": self.ROS_VERSION},
@@ -113,7 +113,7 @@ class ROS2JazzyExtension(Extension):
         }
 
     @overrides
-    def get_parts_snippet(self) -> Dict[str, Any]:
+    def get_parts_snippet(self) -> dict[str, Any]:
         return {
             f"ros2-{self.ROS_DISTRO}/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",

--- a/snapcraft/extensions/ros2_jazzy.py
+++ b/snapcraft/extensions/ros2_jazzy.py
@@ -16,7 +16,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Jazzy."""
 
-from typing import Any, Optional
+from typing import Any
 
 from overrides import overrides
 from typing_extensions import Final
@@ -42,7 +42,7 @@ class ROS2JazzyExtension(Extension):
 
     @staticmethod
     @overrides
-    def is_experimental(base: Optional[str]) -> bool:
+    def is_experimental(base: str | None) -> bool:
         return False
 
     @overrides

--- a/snapcraft/legacy_cli.py
+++ b/snapcraft/legacy_cli.py
@@ -17,7 +17,7 @@
 """Handle re-execution into legacy code."""
 
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
 from craft_cli import emit
 
@@ -26,7 +26,7 @@ import snapcraft_legacy
 from snapcraft_legacy.cli import legacy
 
 _LIB_NAMES = ("craft_parts", "craft_providers", "craft_store", "snapcraft.remote")
-_ORIGINAL_LIB_NAME_LOG_LEVEL: Dict[str, int] = {}
+_ORIGINAL_LIB_NAME_LOG_LEVEL: dict[str, int] = {}
 
 
 def run_legacy(err: Optional[Exception] = None):

--- a/snapcraft/legacy_cli.py
+++ b/snapcraft/legacy_cli.py
@@ -17,7 +17,6 @@
 """Handle re-execution into legacy code."""
 
 import logging
-from typing import Optional
 
 from craft_cli import emit
 
@@ -29,7 +28,7 @@ _LIB_NAMES = ("craft_parts", "craft_providers", "craft_store", "snapcraft.remote
 _ORIGINAL_LIB_NAME_LOG_LEVEL: dict[str, int] = {}
 
 
-def run_legacy(err: Optional[Exception] = None):
+def run_legacy(err: Exception | None = None):
     """Run legacy implementation."""
     # Reset the libraries to their original log level
     for lib_name in _LIB_NAMES:

--- a/snapcraft/linters/classic_linter.py
+++ b/snapcraft/linters/classic_linter.py
@@ -17,7 +17,6 @@
 """Classic linter implementation."""
 
 from pathlib import Path
-from typing import List
 
 from overrides import overrides
 
@@ -32,7 +31,7 @@ class ClassicLinter(Linter):
     """Linter for classic snaps."""
 
     @overrides
-    def run(self) -> List[LinterIssue]:
+    def run(self) -> list[LinterIssue]:
         if not self._snap_metadata.base or self._snap_metadata.base == "bare":
             return []
 
@@ -97,7 +96,7 @@ class ClassicLinter(Linter):
         return issues
 
     def _check_elf_interpreter(
-        self, elf_file: ElfFile, *, linker: str, issues: List[LinterIssue]
+        self, elf_file: ElfFile, *, linker: str, issues: list[LinterIssue]
     ) -> None:
         """Check ELF executable interpreter is set to base or snap linker."""
         if elf_file.interp and elf_file.interp != linker:
@@ -115,7 +114,7 @@ class ClassicLinter(Linter):
         elf_file: ElfFile,
         *,
         patcher: Patcher,
-        issues: List[LinterIssue],
+        issues: list[LinterIssue],
     ) -> None:
         """Check if the ELF executable rpath points to base or current snap."""
         current_rpath = patcher.get_current_rpath(elf_file)

--- a/snapcraft/linters/library_linter.py
+++ b/snapcraft/linters/library_linter.py
@@ -19,7 +19,6 @@
 import re
 import subprocess
 from pathlib import Path
-from typing import List, Set
 
 from craft_cli import emit
 from overrides import overrides
@@ -38,12 +37,12 @@ class LibraryLinter(Linter):
         self._ld_config_cache: dict[str, Path] = {}
 
     @staticmethod
-    def get_categories() -> List[str]:
+    def get_categories() -> list[str]:
         """Get the specific sub-categories that can be filtered against."""
         return ["unused-library", "missing-library"]
 
     @overrides
-    def run(self) -> List[LinterIssue]:
+    def run(self) -> list[LinterIssue]:
         if self._snap_metadata.type not in ("app", None):
             return []
 
@@ -53,11 +52,11 @@ class LibraryLinter(Linter):
         else:
             installed_base_path = None
 
-        issues: List[LinterIssue] = []
+        issues: list[LinterIssue] = []
         elf_files = elf_utils.get_elf_files(current_path)
         soname_cache = SonameCache()
-        all_libraries: Set[Path] = set()
-        used_libraries: Set[Path] = set()
+        all_libraries: set[Path] = set()
+        used_libraries: set[Path] = set()
 
         self._generate_ld_config_cache()
 
@@ -162,9 +161,9 @@ class LibraryLinter(Linter):
         self,
         elf_file: ElfFile,
         *,
-        search_paths: List[Path],
-        dependencies: List[Path],
-        issues: List[LinterIssue],
+        search_paths: list[Path],
+        dependencies: list[Path],
+        issues: list[LinterIssue],
     ) -> None:
         """Check if ELF executable dependencies are satisfied by snap files.
 
@@ -203,8 +202,8 @@ class LibraryLinter(Linter):
                 issues.append(issue)
 
     def _get_unused_library_issues(
-        self, all_libraries: Set[Path], used_libraries: Set[Path]
-    ) -> List[LinterIssue]:
+        self, all_libraries: set[Path], used_libraries: set[Path]
+    ) -> list[LinterIssue]:
         """Get a list of unused library issues.
 
         :param all_libraries: a set of paths to all libraries
@@ -212,7 +211,7 @@ class LibraryLinter(Linter):
 
         :returns: list of LinterIssues for unused libraries
         """
-        issues: List[LinterIssue] = []
+        issues: list[LinterIssue] = []
         unused_libraries = all_libraries - used_libraries
 
         # sort libraries so the results are ordered in a deterministic way

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -22,7 +22,6 @@ import json
 import os
 from functools import partial
 from pathlib import Path
-from typing import Optional
 
 from craft_cli import emit
 
@@ -111,7 +110,7 @@ def _update_status(status: LinterStatus, result: LinterResult) -> LinterStatus:
     return status
 
 
-def run_linters(location: Path, *, lint: Optional[models.Lint]) -> list[LinterIssue]:
+def run_linters(location: Path, *, lint: models.Lint | None) -> list[LinterIssue]:
     """Run all the defined linters.
 
     :param location: The root of the snap payload subtree to run linters on.
@@ -149,7 +148,7 @@ def run_linters(location: Path, *, lint: Optional[models.Lint]) -> list[LinterIs
 
 
 def _ignore_matching_filenames(
-    issues: list[LinterIssue], *, lint: Optional[models.Lint]
+    issues: list[LinterIssue], *, lint: models.Lint | None
 ) -> None:
     """Mark any remaining filename match as ignored."""
     if lint is None:

--- a/snapcraft/linters/linters.py
+++ b/snapcraft/linters/linters.py
@@ -22,7 +22,7 @@ import json
 import os
 from functools import partial
 from pathlib import Path
-from typing import Dict, List, Optional, Type
+from typing import Optional
 
 from craft_cli import emit
 
@@ -33,10 +33,10 @@ from .base import Linter, LinterIssue, LinterResult
 from .classic_linter import ClassicLinter
 from .library_linter import LibraryLinter
 
-LinterType = Type[Linter]
+LinterType = type[Linter]
 
 
-LINTERS: Dict[str, LinterType] = {
+LINTERS: dict[str, LinterType] = {
     "classic": ClassicLinter,
     "library": LibraryLinter,
 }
@@ -52,7 +52,7 @@ class LinterStatus(enum.IntEnum):
     WARNINGS = 3
 
 
-_lint_reports: Dict[LinterResult, str] = {
+_lint_reports: dict[LinterResult, str] = {
     LinterResult.OK: "Lint OK",
     LinterResult.WARNING: "Lint warnings",
     LinterResult.ERROR: "Lint errors",
@@ -60,7 +60,7 @@ _lint_reports: Dict[LinterResult, str] = {
 
 
 def report(
-    issues: List[LinterIssue], *, json_output: bool = False, intermediate: bool = False
+    issues: list[LinterIssue], *, json_output: bool = False, intermediate: bool = False
 ) -> LinterStatus:
     """Display the linter report in textual or json formats.
 
@@ -77,7 +77,7 @@ def report(
     status = LinterStatus.OK
 
     # split dictionary based on result
-    issues_by_result: Dict[LinterResult, List[LinterIssue]] = {}
+    issues_by_result: dict[LinterResult, list[LinterIssue]] = {}
     for issue in issues:
         status = _update_status(status, issue.result)
         if status == LinterStatus.FATAL:
@@ -111,14 +111,14 @@ def _update_status(status: LinterStatus, result: LinterResult) -> LinterStatus:
     return status
 
 
-def run_linters(location: Path, *, lint: Optional[models.Lint]) -> List[LinterIssue]:
+def run_linters(location: Path, *, lint: Optional[models.Lint]) -> list[LinterIssue]:
     """Run all the defined linters.
 
     :param location: The root of the snap payload subtree to run linters on.
     :param lint: The linter configuration defined for this project.
     :return: A list of linter issues.
     """
-    all_issues: List[LinterIssue] = []
+    all_issues: list[LinterIssue] = []
     previous_dir = os.getcwd()
     try:
         os.chdir(location)
@@ -149,7 +149,7 @@ def run_linters(location: Path, *, lint: Optional[models.Lint]) -> List[LinterIs
 
 
 def _ignore_matching_filenames(
-    issues: List[LinterIssue], *, lint: Optional[models.Lint]
+    issues: list[LinterIssue], *, lint: Optional[models.Lint]
 ) -> None:
     """Mark any remaining filename match as ignored."""
     if lint is None:

--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -20,7 +20,7 @@ import contextlib
 import operator
 import os
 from io import StringIO
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import lxml.etree
 import validators
@@ -186,7 +186,7 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
     return None
 
 
-def _get_urls_from_xml_element(nodes, url_type) -> Optional[List[str]]:
+def _get_urls_from_xml_element(nodes, url_type) -> Optional[list[str]]:
     urls = []  # type: List[str]
     for node in nodes:
         if (
@@ -214,7 +214,7 @@ def _get_latest_release_from_nodes(nodes) -> Optional[str]:
     return None
 
 
-def _get_desktop_file_ids_from_nodes(nodes) -> List[str]:
+def _get_desktop_file_ids_from_nodes(nodes) -> list[str]:
     desktop_file_ids = []  # type: List[str]
     for node in nodes:
         if "type" in node.attrib and node.attrib["type"] == "desktop-id":
@@ -237,7 +237,7 @@ def _desktop_file_id_to_path(desktop_file_id: str, *, workdir: str) -> Optional[
     return None
 
 
-def _extract_icon(dom, workdir: str, desktop_file_paths: List[str]) -> Optional[str]:
+def _extract_icon(dom, workdir: str, desktop_file_paths: list[str]) -> Optional[str]:
     icon_node = dom.find("icon")
     if icon_node is not None and "type" in icon_node.attrib:
         icon_node_type = icon_node.attrib["type"]
@@ -264,7 +264,7 @@ def _extract_icon(dom, workdir: str, desktop_file_paths: List[str]) -> Optional[
 
 
 def _get_icon_from_desktop_file(
-    workdir: str, desktop_file_paths: List[str]
+    workdir: str, desktop_file_paths: list[str]
 ) -> Optional[str]:
     # Icons in the desktop file can be either a full path to the icon file, or a name
     # to be searched in the standard locations. If the path is specified, use that,

--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -20,7 +20,7 @@ import contextlib
 import operator
 import os
 from io import StringIO
-from typing import Optional, cast
+from typing import cast
 
 import lxml.etree
 import validators
@@ -84,7 +84,7 @@ _XSLT = """\
 """
 
 
-def extract(relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
+def extract(relpath: str, *, workdir: str) -> ExtractedMetadata | None:
     """Extract appstream metadata.
 
     :param file_relpath: Relative path to the file containing metadata.
@@ -174,7 +174,7 @@ def _get_xslt():
     return lxml.etree.XSLT(xslt)
 
 
-def _get_value_from_xml_element(tree, key) -> Optional[str]:
+def _get_value_from_xml_element(tree, key) -> str | None:
     node = tree.find(key)
     if node is not None and node.text:
         # Lines that should be empty end up with empty space after the
@@ -186,7 +186,7 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
     return None
 
 
-def _get_urls_from_xml_element(nodes, url_type) -> Optional[list[str]]:
+def _get_urls_from_xml_element(nodes, url_type) -> list[str] | None:
     urls: list[str] = []
     for node in nodes:
         if (
@@ -207,7 +207,7 @@ def _get_urls_from_xml_element(nodes, url_type) -> Optional[list[str]]:
     return None
 
 
-def _get_latest_release_from_nodes(nodes) -> Optional[str]:
+def _get_latest_release_from_nodes(nodes) -> str | None:
     for node in nodes:
         if "version" in node.attrib:
             return node.attrib["version"]
@@ -222,7 +222,7 @@ def _get_desktop_file_ids_from_nodes(nodes) -> list[str]:
     return desktop_file_ids
 
 
-def _desktop_file_id_to_path(desktop_file_id: str, *, workdir: str) -> Optional[str]:
+def _desktop_file_id_to_path(desktop_file_id: str, *, workdir: str) -> str | None:
     # For details about desktop file ids and their corresponding paths, see
     # https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
     for xdg_data_dir in ("usr/local/share", "usr/share"):
@@ -237,7 +237,7 @@ def _desktop_file_id_to_path(desktop_file_id: str, *, workdir: str) -> Optional[
     return None
 
 
-def _extract_icon(dom, workdir: str, desktop_file_paths: list[str]) -> Optional[str]:
+def _extract_icon(dom, workdir: str, desktop_file_paths: list[str]) -> str | None:
     icon_node = dom.find("icon")
     if icon_node is not None and "type" in icon_node.attrib:
         icon_node_type = icon_node.attrib["type"]
@@ -265,7 +265,7 @@ def _extract_icon(dom, workdir: str, desktop_file_paths: list[str]) -> Optional[
 
 def _get_icon_from_desktop_file(
     workdir: str, desktop_file_paths: list[str]
-) -> Optional[str]:
+) -> str | None:
     # Icons in the desktop file can be either a full path to the icon file, or a name
     # to be searched in the standard locations. If the path is specified, use that,
     # otherwise look for the icon in the hicolor theme (also covers icon type="stock").
@@ -285,7 +285,7 @@ def _get_icon_from_desktop_file(
     return None
 
 
-def _get_icon_from_theme(workdir: str, theme: str, icon: str) -> Optional[str]:
+def _get_icon_from_theme(workdir: str, theme: str, icon: str) -> str | None:
     # Icon themes can carry icons in different pre-rendered sizes or scalable. Scalable
     # implementation is optional, so we'll try the largest pixmap and then scalable if
     # no other sizes are available.

--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -187,7 +187,7 @@ def _get_value_from_xml_element(tree, key) -> Optional[str]:
 
 
 def _get_urls_from_xml_element(nodes, url_type) -> Optional[list[str]]:
-    urls = []  # type: List[str]
+    urls: list[str] = []
     for node in nodes:
         if (
             node is not None
@@ -215,7 +215,7 @@ def _get_latest_release_from_nodes(nodes) -> Optional[str]:
 
 
 def _get_desktop_file_ids_from_nodes(nodes) -> list[str]:
-    desktop_file_ids = []  # type: List[str]
+    desktop_file_ids: list[str] = []
     for node in nodes:
         if "type" in node.attrib and node.attrib["type"] == "desktop-id":
             desktop_file_ids.append(node.text.strip())

--- a/snapcraft/meta/extracted_metadata.py
+++ b/snapcraft/meta/extracted_metadata.py
@@ -17,7 +17,7 @@
 """External metadata definition."""
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Optional
 
 
 @dataclass
@@ -45,23 +45,23 @@ class ExtractedMetadata:
     icon: Optional[str] = None
     """The extracted application icon."""
 
-    desktop_file_paths: List[str] = field(default_factory=list)
+    desktop_file_paths: list[str] = field(default_factory=list)
     """The extracted application desktop file paths."""
 
     license: Optional[str] = None
     """The extracted package license"""
 
-    contact: Optional[List[str]] = None
+    contact: Optional[list[str]] = None
     """The extracted package contact"""
 
-    donation: Optional[List[str]] = None
+    donation: Optional[list[str]] = None
     """The extracted package donation"""
 
-    issues: Optional[List[str]] = None
+    issues: Optional[list[str]] = None
     """The extracted package issues"""
 
-    source_code: Optional[List[str]] = None
+    source_code: Optional[list[str]] = None
     """The extracted package source code"""
 
-    website: Optional[List[str]] = None
+    website: Optional[list[str]] = None
     """The extracted package website"""

--- a/snapcraft/meta/extracted_metadata.py
+++ b/snapcraft/meta/extracted_metadata.py
@@ -17,51 +17,50 @@
 """External metadata definition."""
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass
 class ExtractedMetadata:
     """Collection of metadata extracted from a part."""
 
-    common_id: Optional[str] = None
+    common_id: str | None = None
     """The common identifier across multiple packaging formats."""
 
-    title: Optional[str] = None
+    title: str | None = None
     """The extracted package title."""
 
-    summary: Optional[str] = None
+    summary: str | None = None
     """The extracted package summary."""
 
-    description: Optional[str] = None
+    description: str | None = None
     """The extracted package description."""
 
-    version: Optional[str] = None
+    version: str | None = None
     """The extracted package version."""
 
-    grade: Optional[str] = None
+    grade: str | None = None
     """The extracted package version."""
 
-    icon: Optional[str] = None
+    icon: str | None = None
     """The extracted application icon."""
 
     desktop_file_paths: list[str] = field(default_factory=list)
     """The extracted application desktop file paths."""
 
-    license: Optional[str] = None
+    license: str | None = None
     """The extracted package license"""
 
-    contact: Optional[list[str]] = None
+    contact: list[str] | None = None
     """The extracted package contact"""
 
-    donation: Optional[list[str]] = None
+    donation: list[str] | None = None
     """The extracted package donation"""
 
-    issues: Optional[list[str]] = None
+    issues: list[str] | None = None
     """The extracted package issues"""
 
-    source_code: Optional[list[str]] = None
+    source_code: list[str] | None = None
     """The extracted package source code"""
 
-    website: Optional[list[str]] = None
+    website: list[str] | None = None
     """The extracted package website"""

--- a/snapcraft/meta/metadata.py
+++ b/snapcraft/meta/metadata.py
@@ -16,13 +16,11 @@
 
 """External metadata helpers."""
 
-from typing import Optional
-
 from . import appstream
 from .extracted_metadata import ExtractedMetadata
 
 
-def extract_metadata(file_relpath: str, *, workdir: str) -> Optional[ExtractedMetadata]:
+def extract_metadata(file_relpath: str, *, workdir: str) -> ExtractedMetadata | None:
     """Retrieve external metadata from part files.
 
     :param file_relpath: Relative path to the file containing metadata.

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import copy
 import re
 import textwrap
-from typing import Any, Literal, Mapping, Tuple, cast
+from typing import Any, Literal, Mapping, cast
 
 import pydantic
 from craft_application import models
@@ -1449,7 +1449,7 @@ def _format_pydantic_error_message(msg):
     return msg
 
 
-def _printable_field_location_split(location: str) -> Tuple[str, str]:
+def _printable_field_location_split(location: str) -> tuple[str, str]:
     """Return split field location.
 
     If top-level, location is returned as unquoted "top-level".

--- a/snapcraft/os_release.py
+++ b/snapcraft/os_release.py
@@ -18,7 +18,6 @@
 
 import contextlib
 from pathlib import Path
-from typing import Dict
 
 from snapcraft import errors
 
@@ -45,7 +44,7 @@ class OsRelease:
         :param str os_release_file: Path to os-release file to be parsed.
         """
         with contextlib.suppress(FileNotFoundError):
-            self._os_release: Dict[str, str] = {}
+            self._os_release: dict[str, str] = {}
             with os_release_file.open(encoding="utf-8") as release_file:
                 for line in release_file:
                     entry = line.rstrip().split("=")

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -19,7 +19,6 @@
 import subprocess
 from functools import wraps
 from pathlib import Path
-from typing import Optional, Union
 
 from craft_cli import emit
 
@@ -45,7 +44,7 @@ def _verify_snap(directory: Path) -> None:
         raise errors.SnapcraftError(msg, details=f"{err!s}") from err
 
 
-def _get_directory(output: Optional[str]) -> Path:
+def _get_directory(output: str | None) -> Path:
     """Get directory to output the snap file to.
 
     If no directory is provided, return current working directory.
@@ -64,11 +63,11 @@ def _get_directory(output: Optional[str]) -> Path:
 
 
 def _get_filename(
-    output: Optional[str],
-    name: Optional[str] = None,
-    version: Optional[str] = None,
-    target_arch: Optional[str] = None,
-) -> Optional[str]:
+    output: str | None,
+    name: str | None = None,
+    version: str | None = None,
+    target_arch: str | None = None,
+) -> str | None:
     """Get output filename of the snap file.
 
     If `output` is not a file, then the filename will be <name>_<version>_<target_arch>.snap
@@ -94,8 +93,8 @@ def _get_filename(
 def _pack(
     directory: Path,
     output_dir: Path,
-    output_file: Optional[str],
-    compression: Optional[str],
+    output_file: str | None,
+    compression: str | None,
 ) -> str:
     """Pack a directory with `snap pack` as a snap or component.
 
@@ -108,7 +107,7 @@ def _pack(
 
     :raises SnapcraftError: If the directory cannot be packed.
     """
-    command: list[Union[str, Path]] = ["snap", "pack"]
+    command: list[str | Path] = ["snap", "pack"]
 
     if output_file:
         command.extend(["--filename", output_file])
@@ -130,7 +129,7 @@ def _pack(
 def _retry_with_newer_snapd(func):
     @wraps(func)
     def retry_with_edge_snapd(
-        directory: Path, output_dir: Path, compression: Optional[str] = None
+        directory: Path, output_dir: Path, compression: str | None = None
     ) -> str:
         try:
             return func(directory, output_dir, compression)
@@ -159,7 +158,7 @@ def _retry_with_newer_snapd(func):
 
 @_retry_with_newer_snapd
 def pack_component(
-    directory: Path, output_dir: Path, compression: Optional[str] = None
+    directory: Path, output_dir: Path, compression: str | None = None
 ) -> str:
     """Pack a directory containing component data.
 
@@ -193,11 +192,11 @@ def pack_component(
 def pack_snap(
     directory: Path,
     *,
-    output: Optional[str],
-    compression: Optional[str] = None,
-    name: Optional[str] = None,
-    version: Optional[str] = None,
-    target_arch: Optional[str] = None,
+    output: str | None,
+    compression: str | None = None,
+    name: str | None = None,
+    version: str | None = None,
+    target_arch: str | None = None,
 ) -> str:
     """Pack snap contents with `snap pack`.
 

--- a/snapcraft/pack.py
+++ b/snapcraft/pack.py
@@ -19,7 +19,7 @@
 import subprocess
 from functools import wraps
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from craft_cli import emit
 
@@ -108,7 +108,7 @@ def _pack(
 
     :raises SnapcraftError: If the directory cannot be packed.
     """
-    command: List[Union[str, Path]] = ["snap", "pack"]
+    command: list[Union[str, Path]] = ["snap", "pack"]
 
     if output_file:
         command.extend(["--filename", output_file])

--- a/snapcraft/parts/desktop_file.py
+++ b/snapcraft/parts/desktop_file.py
@@ -20,7 +20,6 @@ import configparser
 import os
 import shlex
 from pathlib import Path
-from typing import Optional
 
 from craft_cli import emit
 
@@ -69,7 +68,7 @@ class DesktopFile:
 
         self._parser[section]["Exec"] = " ".join(exec_split)
 
-    def _parse_and_reformat_section(self, *, section, icon_path: Optional[str] = None):
+    def _parse_and_reformat_section(self, *, section, icon_path: str | None = None):
         if "Exec" not in self._parser[section]:
             raise errors.DesktopFileError(self._filename, "missing 'Exec' key")
 
@@ -97,7 +96,7 @@ class DesktopFile:
                     f"not found in prime directory."
                 )
 
-    def _parse_and_reformat(self, *, icon_path: Optional[str] = None) -> None:
+    def _parse_and_reformat(self, *, icon_path: str | None = None) -> None:
         if "Desktop Entry" not in self._parser.sections():
             raise errors.DesktopFileError(
                 self._filename, "missing 'Desktop Entry' section"
@@ -106,7 +105,7 @@ class DesktopFile:
         for section in self._parser.sections():
             self._parse_and_reformat_section(section=section, icon_path=icon_path)
 
-    def write(self, *, gui_dir: Path, icon_path: Optional[str] = None) -> None:
+    def write(self, *, gui_dir: Path, icon_path: str | None = None) -> None:
         """Write the desktop file.
 
         :param gui_dir: The desktop file destination directory.

--- a/snapcraft/parts/grammar.py
+++ b/snapcraft/parts/grammar.py
@@ -16,7 +16,7 @@
 
 """Grammar processor."""
 
-from typing import Any, Dict
+from typing import Any
 
 from craft_grammar import GrammarProcessor
 
@@ -33,8 +33,8 @@ _SCALAR_VALUES = ["source"]
 
 
 def process_part(
-    *, part_yaml_data: Dict[str, Any], processor: GrammarProcessor
-) -> Dict[str, Any]:
+    *, part_yaml_data: dict[str, Any], processor: GrammarProcessor
+) -> dict[str, Any]:
     """Process grammar for a given part."""
     existing_keys = (key for key in _KEYS if key in part_yaml_data)
 
@@ -57,8 +57,8 @@ def process_part(
 
 
 def process_parts(
-    *, parts_yaml_data: Dict[str, Any], arch: str, target_arch: str
-) -> Dict[str, Any]:
+    *, parts_yaml_data: dict[str, Any], arch: str, target_arch: str
+) -> dict[str, Any]:
     """Process grammar for parts.
 
     :param yaml_data: unprocessed snapcraft.yaml.

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -22,7 +22,7 @@ import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import craft_parts
 from craft_cli import emit
@@ -117,7 +117,7 @@ def _run_command(  # noqa PLR0913 (too-many-arguments)
     command_name: str,
     *,
     project: models.Project,
-    parse_info: Dict[str, List[str]],
+    parse_info: dict[str, list[str]],
     assets_dir: Path,
     start_time: datetime,
     parallel_build_count: int,
@@ -553,7 +553,7 @@ def _run_in_provider(  # noqa PLR0915
 
 
 def _expose_prime(
-    project_path: Path, instance: Executor, partitions: Optional[List[str]]
+    project_path: Path, instance: Executor, partitions: Optional[list[str]]
 ):
     """Expose the instance's prime directory in ``project_path`` on the host.
 
@@ -597,7 +597,7 @@ def set_global_environment(info: ProjectInfo) -> None:
         info.global_environment.update(_get_environment_for_partitions(info))
 
 
-def _get_environment_for_partitions(info: ProjectInfo) -> Dict[str, str]:
+def _get_environment_for_partitions(info: ProjectInfo) -> dict[str, str]:
     """Get environment variables related to partitions.
 
     Assumes the partition feature is enabled and partitions are defined.
@@ -606,7 +606,7 @@ def _get_environment_for_partitions(info: ProjectInfo) -> Dict[str, str]:
 
     :returns: A dictionary contain environment variables for partitions.
     """
-    environment: Dict[str, str] = {}
+    environment: dict[str, str] = {}
 
     if not info.partitions:
         raise ValueError("Project does not contain any partitions.")
@@ -631,7 +631,7 @@ def _check_experimental_plugins(
 ) -> None:
     """Ensure the experimental plugin flag is enabled to use unstable plugins."""
     for name, part in project.parts.items():
-        if not isinstance(part, Dict):
+        if not isinstance(part, dict):
             continue
 
         plugin = part.get("plugin", "")
@@ -720,11 +720,11 @@ def patch_elf(step_info: StepInfo, use_system_libs: bool = True) -> bool:
 
 
 def _expand_environment(
-    snapcraft_yaml: Dict[str, Any],
+    snapcraft_yaml: dict[str, Any],
     *,
     parallel_build_count: int,
     target_arch: str,
-    partitions: Optional[List[str]],
+    partitions: Optional[list[str]],
 ) -> None:
     """Expand global variables in the provided dictionary values.
 
@@ -765,8 +765,8 @@ def _expand_environment(
 
 
 def get_build_plan(
-    yaml_data: Dict[str, Any], parsed_args: "argparse.Namespace"
-) -> List[Tuple[str, str]]:
+    yaml_data: dict[str, Any], parsed_args: "argparse.Namespace"
+) -> list[tuple[str, str]]:
     """Get a list of all build_on->build_for architectures from the project file.
 
     Additionally, check for the command line argument `--build-for <architecture>`
@@ -782,7 +782,7 @@ def get_build_plan(
     archs = models.ArchitectureProject.unmarshal(yaml_data).architectures
 
     host_arch = str(DebianArchitecture.from_host())
-    build_plan: List[Tuple[str, str]] = []
+    build_plan: list[tuple[str, str]] = []
 
     # `isinstance()` calls are for mypy type checking and should not change logic
     for arch in [arch for arch in archs if isinstance(arch, models.Architecture)]:
@@ -815,7 +815,7 @@ def get_build_plan(
     return build_plan
 
 
-def _validate_and_get_partitions(yaml_data: Dict[str, Any]) -> Optional[List[str]]:
+def _validate_and_get_partitions(yaml_data: dict[str, Any]) -> Optional[list[str]]:
     """Validate partitions support, enable the feature, and get a list of partitions.
 
     :param yaml_data: The project's YAML data.
@@ -855,7 +855,7 @@ def _is_manager(parsed_args: "argparse.Namespace") -> bool:
 
 
 def _warn_on_multiple_builds(
-    parsed_args: "argparse.Namespace", build_plan: List[Tuple[str, str]]
+    parsed_args: "argparse.Namespace", build_plan: list[tuple[str, str]]
 ) -> None:
     """Warn if snapcraft will build multiple snaps in the same environment.
 

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -22,7 +22,7 @@ import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import craft_parts
 from craft_cli import emit
@@ -293,7 +293,7 @@ def _run_lifecycle_and_pack(  # noqa PLR0913
 
 
 def _pack_components(
-    lifecycle: PartsLifecycle, project: models.Project, output: Optional[str]
+    lifecycle: PartsLifecycle, project: models.Project, output: str | None
 ) -> None:
     """Pack components.
 
@@ -552,9 +552,7 @@ def _run_in_provider(  # noqa PLR0915
             providers.capture_logs_from_instance(instance)
 
 
-def _expose_prime(
-    project_path: Path, instance: Executor, partitions: Optional[list[str]]
-):
+def _expose_prime(project_path: Path, instance: Executor, partitions: list[str] | None):
     """Expose the instance's prime directory in ``project_path`` on the host.
 
     :param project_path: path of the project
@@ -724,7 +722,7 @@ def _expand_environment(
     *,
     parallel_build_count: int,
     target_arch: str,
-    partitions: Optional[list[str]],
+    partitions: list[str] | None,
 ) -> None:
     """Expand global variables in the provided dictionary values.
 
@@ -815,7 +813,7 @@ def get_build_plan(
     return build_plan
 
 
-def _validate_and_get_partitions(yaml_data: dict[str, Any]) -> Optional[list[str]]:
+def _validate_and_get_partitions(yaml_data: dict[str, Any]) -> list[str] | None:
     """Validate partitions support, enable the feature, and get a list of partitions.
 
     :param yaml_data: The project's YAML data.

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -19,7 +19,7 @@
 import pathlib
 import subprocess
 import types
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import craft_parts
 from craft_archives import repo
@@ -67,15 +67,15 @@ class PartsLifecycle:
         confinement: str,
         package_repositories: list[dict[str, Any]],
         parallel_build_count: int,
-        part_names: Optional[list[str]],
-        adopt_info: Optional[str],
+        part_names: list[str] | None,
+        adopt_info: str | None,
         parse_info: dict[str, list[str]],
         project_name: str,
         project_vars: dict[str, str],
-        extra_build_snaps: Optional[list[str]] = None,
+        extra_build_snaps: list[str] | None = None,
         target_arch: str,
         track_stage_packages: bool,
-        partitions: Optional[list[str]],
+        partitions: list[str] | None,
     ):
         self._work_dir = work_dir
         self._assets_dir = assets_dir
@@ -255,7 +255,7 @@ class PartsLifecycle:
             self._lcm.refresh_packages_list()
         emit.progress("Installed package repositories", permanent=True)
 
-    def clean(self, *, part_names: Optional[list[str]] = None) -> None:
+    def clean(self, *, part_names: list[str] | None = None) -> None:
         """Remove lifecycle artifacts.
 
         :param part_names: The names of the parts to clean. If not
@@ -286,12 +286,12 @@ class PartsLifecycle:
         package_list.sort()
         return package_list
 
-    def get_part_pull_assets(self, *, part_name: str) -> Optional[dict[str, Any]]:
+    def get_part_pull_assets(self, *, part_name: str) -> dict[str, Any] | None:
         """Obtain the pull state assets."""
         return self._lcm.get_pull_assets(part_name=part_name)
 
 
-def launch_shell(*, cwd: Optional[pathlib.Path] = None) -> None:
+def launch_shell(*, cwd: pathlib.Path | None = None) -> None:
     """Launch a user shell for debugging environment.
 
     :param cwd: Working directory to start user in.

--- a/snapcraft/parts/parts.py
+++ b/snapcraft/parts/parts.py
@@ -19,7 +19,7 @@
 import pathlib
 import subprocess
 import types
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, Optional, cast
 
 import craft_parts
 from craft_archives import repo
@@ -58,24 +58,24 @@ class PartsLifecycle:
 
     def __init__(  # noqa PLR0913
         self,
-        all_parts: Dict[str, Any],
+        all_parts: dict[str, Any],
         *,
         work_dir: pathlib.Path,
         assets_dir: pathlib.Path,
         base: str,  # effective base
         project_base: str,
         confinement: str,
-        package_repositories: List[Dict[str, Any]],
+        package_repositories: list[dict[str, Any]],
         parallel_build_count: int,
-        part_names: Optional[List[str]],
+        part_names: Optional[list[str]],
         adopt_info: Optional[str],
-        parse_info: Dict[str, List[str]],
+        parse_info: dict[str, list[str]],
         project_name: str,
-        project_vars: Dict[str, str],
-        extra_build_snaps: Optional[List[str]] = None,
+        project_vars: dict[str, str],
+        extra_build_snaps: Optional[list[str]] = None,
         target_arch: str,
         track_stage_packages: bool,
-        partitions: Optional[List[str]],
+        partitions: Optional[list[str]],
     ):
         self._work_dir = work_dir
         self._assets_dir = assets_dir
@@ -158,7 +158,7 @@ class PartsLifecycle:
         return self._lcm.project_info.arch_triplet
 
     @property
-    def project_vars(self) -> Dict[str, str]:
+    def project_vars(self) -> dict[str, str]:
         """Return the value of project variable ``version``."""
         return {
             "version": self._lcm.project_info.get_project_var("version"),
@@ -255,7 +255,7 @@ class PartsLifecycle:
             self._lcm.refresh_packages_list()
         emit.progress("Installed package repositories", permanent=True)
 
-    def clean(self, *, part_names: Optional[List[str]] = None) -> None:
+    def clean(self, *, part_names: Optional[list[str]] = None) -> None:
         """Remove lifecycle artifacts.
 
         :param part_names: The names of the parts to clean. If not
@@ -269,15 +269,15 @@ class PartsLifecycle:
         emit.progress(message)
         self._lcm.clean(part_names=part_names)
 
-    def extract_metadata(self) -> List[ExtractedMetadata]:
+    def extract_metadata(self) -> list[ExtractedMetadata]:
         """Obtain metadata information."""
         return extract_lifecycle_metadata(
             self._adopt_info, self._parse_info, self._work_dir, self._partitions
         )
 
-    def get_primed_stage_packages(self) -> List[str]:
+    def get_primed_stage_packages(self) -> list[str]:
         """Obtain the list of primed stage packages from all parts."""
-        primed_stage_packages: Set[str] = set()
+        primed_stage_packages: set[str] = set()
         for name in self._all_part_names:
             stage_packages = self._lcm.get_primed_stage_packages(part_name=name)
             if stage_packages:
@@ -286,7 +286,7 @@ class PartsLifecycle:
         package_list.sort()
         return package_list
 
-    def get_part_pull_assets(self, *, part_name: str) -> Optional[Dict[str, Any]]:
+    def get_part_pull_assets(self, *, part_name: str) -> Optional[dict[str, Any]]:
         """Obtain the pull state assets."""
         return self._lcm.get_pull_assets(part_name=part_name)
 

--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, List, Set, cast
+from typing import Iterable, cast
 
 import catkin_pkg.package
 import click
@@ -52,7 +52,7 @@ class RosdepUnexpectedResultError(RosdepError):
 
 def _parse_rosdep_resolve_dependencies(
     dependency_name: str, output: str
-) -> Dict[str, Set[str]]:
+) -> dict[str, set[str]]:
     # The output of rosdep follows the pattern:
     #
     #    #apt
@@ -65,7 +65,7 @@ def _parse_rosdep_resolve_dependencies(
     # Split these out into a dict of dependency type -> dependencies.
     delimiters = re.compile(r"\n|\s")
     lines = delimiters.split(output)
-    dependencies: Dict[str, Set[str]] = {}
+    dependencies: dict[str, set[str]] = {}
     dependency_set = None
     for line in lines:
         line = line.strip()  # noqa PLW2901
@@ -87,7 +87,7 @@ class RosPlugin(plugins.Plugin):
     _MAP_CORE_ROSDISTRO = {"core24": "jazzy"}
 
     @overrides
-    def get_build_snaps(self) -> Set[str]:
+    def get_build_snaps(self) -> set[str]:
         return (
             set(self._options.colcon_ros_build_snaps)  # type: ignore
             if self._options.colcon_ros_build_snaps  # type: ignore
@@ -95,14 +95,14 @@ class RosPlugin(plugins.Plugin):
         )
 
     @overrides
-    def get_build_packages(self) -> Set[str]:
+    def get_build_packages(self) -> set[str]:
         base = self._part_info.base
         if base == "core22":
             return {"python3-rosdep", "rospack-tools"}
         return {"python3-rosdep", f"ros-{self._MAP_CORE_ROSDISTRO[base]}-ros2pkg"}
 
     @overrides
-    def get_build_environment(self) -> Dict[str, str]:
+    def get_build_environment(self) -> dict[str, str]:
         return {"ROS_PYTHON_VERSION": "3"}
 
     @classmethod
@@ -111,7 +111,7 @@ class RosPlugin(plugins.Plugin):
         return True
 
     @abc.abstractmethod
-    def _get_workspace_activation_commands(self) -> List[str]:
+    def _get_workspace_activation_commands(self) -> list[str]:
         """Return a list of commands source a ROS workspace.
 
         The commands returned will be run before doing anything else.
@@ -124,7 +124,7 @@ class RosPlugin(plugins.Plugin):
         """
 
     @abc.abstractmethod
-    def _get_build_commands(self) -> List[str]:
+    def _get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step.
 
         The commands returned will be run after rosdep is used to install
@@ -137,7 +137,7 @@ class RosPlugin(plugins.Plugin):
         specific functionality.
         """
 
-    def _get_list_packages_commands(self) -> List[str]:
+    def _get_list_packages_commands(self) -> list[str]:
         """Generate a list of ROS 2 packages available in build snaps.
 
         The ROS 2 workspaces contained in build snaps are crawled with `rospack`
@@ -194,7 +194,7 @@ class RosPlugin(plugins.Plugin):
 
         return cmd
 
-    def _get_stage_runtime_dependencies_commands(self) -> List[str]:
+    def _get_stage_runtime_dependencies_commands(self) -> list[str]:
         env = {"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"}
 
         for key in [
@@ -240,7 +240,7 @@ class RosPlugin(plugins.Plugin):
         ]
 
     @overrides
-    def get_build_commands(self) -> List[str]:
+    def get_build_commands(self) -> list[str]:
         return (
             [  # noqa S608 (false positive on SQL injection)
                 "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
@@ -281,7 +281,7 @@ def plugin_cli():
     """Define the plugin_cli Click group."""
 
 
-def get_installed_dependencies(installed_packages_path: str) -> Set[str]:
+def get_installed_dependencies(installed_packages_path: str) -> set[str]:
     """Retrieve recursive apt dependencies of a given package list."""
     if os.path.isfile(installed_packages_path):
         try:
@@ -346,7 +346,7 @@ def stage_runtime_dependencies(  # noqa: PLR0913 (too many arguments)
     """Stage the runtime dependencies of the ROS stack using rosdep."""
     click.echo("Staging runtime dependencies...")
     # @todo: support python packages (only apt currently supported)
-    apt_packages: Set[str] = set()
+    apt_packages: set[str] = set()
 
     installed_pkgs = cast(
         Iterable[catkin_pkg.package.Package],

--- a/snapcraft/parts/plugins/python_plugin.py
+++ b/snapcraft/parts/plugins/python_plugin.py
@@ -16,8 +16,6 @@
 
 """The Snapcraft Python plugin."""
 
-from typing import Optional
-
 from craft_parts.plugins import python_plugin
 from overrides import override
 
@@ -28,5 +26,5 @@ class PythonPlugin(python_plugin.PythonPlugin):
     """A Python plugin for Snapcraft."""
 
     @override
-    def _get_system_python_interpreter(self) -> Optional[str]:
+    def _get_system_python_interpreter(self) -> str | None:
         return python_common.get_system_interpreter(self._part_info)

--- a/snapcraft/parts/plugins/uv_plugin.py
+++ b/snapcraft/parts/plugins/uv_plugin.py
@@ -16,8 +16,6 @@
 
 """The Snapcraft uv plugin."""
 
-from typing import Optional
-
 from craft_parts.plugins import uv_plugin
 from overrides import override
 
@@ -28,5 +26,5 @@ class UvPlugin(uv_plugin.UvPlugin):
     """A uv plugin for Snapcraft."""
 
     @override
-    def _get_system_python_interpreter(self) -> Optional[str]:
+    def _get_system_python_interpreter(self) -> str | None:
         return python_common.get_system_interpreter(self._part_info)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -22,7 +22,7 @@ import shutil
 import stat
 import urllib.parse
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 
 import requests
 from craft_cli import emit
@@ -212,7 +212,7 @@ def _find_icon_file(assets_dir: Path) -> Path | None:
 
 
 def _validate_command_chain(
-    command_chain: List[str], *, name: str, prime_dir: Path
+    command_chain: list[str], *, name: str, prime_dir: Path
 ) -> None:
     """Verify if each item in the command chain is executable."""
     for item in command_chain:

--- a/snapcraft/parts/update_metadata.py
+++ b/snapcraft/parts/update_metadata.py
@@ -17,7 +17,7 @@
 """External metadata helpers."""
 
 from pathlib import Path
-from typing import Dict, Final, List, OrderedDict, cast
+from typing import Final, OrderedDict, cast
 
 import pydantic
 from craft_application.models import ProjectTitle, SummaryStr, UniqueStrList, VersionStr
@@ -27,14 +27,14 @@ from snapcraft import errors
 from snapcraft.meta import ExtractedMetadata
 from snapcraft.models import MANDATORY_ADOPTABLE_FIELDS, Project
 
-_VALID_ICON_EXTENSIONS: Final[List[str]] = ["png", "svg"]
+_VALID_ICON_EXTENSIONS: Final[list[str]] = ["png", "svg"]
 
 
 def update_project_metadata(
     project: Project,
     *,
-    project_vars: Dict[str, str],
-    metadata_list: List[ExtractedMetadata],
+    project_vars: dict[str, str],
+    metadata_list: list[ExtractedMetadata],
     assets_dir: Path,
     prime_dir: Path,
 ) -> None:
@@ -65,7 +65,7 @@ def update_project_metadata(
 def update_from_extracted_metadata(
     project: Project,
     *,
-    metadata_list: List[ExtractedMetadata],
+    metadata_list: list[ExtractedMetadata],
     assets_dir: Path,
     prime_dir: Path,
 ) -> None:
@@ -108,7 +108,7 @@ def update_from_extracted_metadata(
 
 def _update_project_links(
     project: Project,
-    metadata_list: List[ExtractedMetadata],
+    metadata_list: list[ExtractedMetadata],
 ) -> None:
     """Update project links from metadata.
 
@@ -136,7 +136,7 @@ def _update_project_links(
                 setattr(project, field, cast(UniqueStrList, metadata_values))
 
 
-def _update_project_variables(project: Project, project_vars: Dict[str, str]):
+def _update_project_variables(project: Project, project_vars: dict[str, str]):
     """Update project fields with values set during lifecycle processing."""
     try:
         if project_vars["version"]:

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -18,7 +18,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, TextIO, cast
+from typing import Any, TextIO, cast
 
 import yaml
 import yaml.error
@@ -108,7 +108,7 @@ def safe_load(filestream: TextIO) -> dict[str, Any]:
         raise errors.SnapcraftError(f"snapcraft.yaml parsing error: {err!s}") from err
 
 
-def get_base(filestream: TextIO) -> Optional[str]:
+def get_base(filestream: TextIO) -> str | None:
     """Get the effective base from a snapcraft.yaml file.
 
     :param filename: The YAML file to load.

--- a/snapcraft/parts/yaml_utils.py
+++ b/snapcraft/parts/yaml_utils.py
@@ -18,7 +18,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TextIO, cast
+from typing import Any, Optional, TextIO, cast
 
 import yaml
 import yaml.error
@@ -95,7 +95,7 @@ class _SafeLoader(yaml.SafeLoader):
         )
 
 
-def safe_load(filestream: TextIO) -> Dict[str, Any]:
+def safe_load(filestream: TextIO) -> dict[str, Any]:
     """Safe load and parse YAML-formatted file to a dictionary.
 
     :returns: A dictionary containing the yaml data.
@@ -138,7 +138,7 @@ def get_base_from_yaml(data: dict[str, Any]) -> str | None:
     )
 
 
-def load(filestream: TextIO) -> Dict[str, Any]:
+def load(filestream: TextIO) -> dict[str, Any]:
     """Load and parse a YAML-formatted file.
 
     :param filename: The YAML file to load.
@@ -170,8 +170,8 @@ def load(filestream: TextIO) -> Dict[str, Any]:
 
 
 def apply_yaml(
-    yaml_data: Dict[str, Any], build_on: str, build_for: str
-) -> Dict[str, Any]:
+    yaml_data: dict[str, Any], build_on: str, build_for: str
+) -> dict[str, Any]:
     """Apply Snapcraft logic to yaml_data.
 
     Extensions are applied and advanced grammar is processed.
@@ -238,14 +238,14 @@ def get_snap_project(project_dir: Path | None = None) -> _SnapProject:
     raise errors.ProjectMissing()
 
 
-def extract_parse_info(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
+def extract_parse_info(yaml_data: dict[str, Any]) -> dict[str, list[str]]:
     """Remove parse-info data from parts.
 
     :param yaml_data: The project YAML data.
 
     :return: The extracted parse info for each part.
     """
-    parse_info: Dict[str, List[str]] = {}
+    parse_info: dict[str, list[str]] = {}
 
     if "parts" in yaml_data:
         for name, data in yaml_data["parts"].items():
@@ -255,7 +255,7 @@ def extract_parse_info(yaml_data: Dict[str, Any]) -> Dict[str, List[str]]:
     return parse_info
 
 
-def process_yaml(project_file: Path) -> Dict[str, Any]:
+def process_yaml(project_file: Path) -> dict[str, Any]:
     """Process yaml data from file into a dictionary.
 
     :param project_file: Path to project.

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -21,7 +21,6 @@ import os
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
 
 from craft_cli import emit
 from craft_providers import Provider, ProviderError, bases, executor
@@ -167,8 +166,8 @@ def get_base_configuration(
     *,
     alias: bases.BuilddBaseAlias,
     instance_name: str,
-    http_proxy: Optional[str] = None,
-    https_proxy: Optional[str] = None,
+    http_proxy: str | None = None,
+    https_proxy: str | None = None,
 ) -> bases.BuilddBase:
     """Create a BuilddBase configuration for rockcraft."""
     environment = get_command_environment(
@@ -213,8 +212,8 @@ def get_base_configuration(
 
 
 def get_command_environment(
-    http_proxy: Optional[str] = None, https_proxy: Optional[str] = None
-) -> dict[str, Optional[str]]:
+    http_proxy: str | None = None, https_proxy: str | None = None
+) -> dict[str, str | None]:
     """Construct an environment needed to execute a command.
 
     :param http_proxy: http proxy to add to environment
@@ -274,7 +273,7 @@ def get_instance_name(
     )
 
 
-def get_provider(provider: Optional[str] = None) -> Provider:
+def get_provider(provider: str | None = None) -> Provider:
     """Get the configured or appropriate provider for the host OS.
 
     To determine the appropriate provider,

--- a/snapcraft/providers.py
+++ b/snapcraft/providers.py
@@ -21,7 +21,7 @@ import os
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, Optional
+from typing import Optional
 
 from craft_cli import emit
 from craft_providers import Provider, ProviderError, bases, executor
@@ -214,7 +214,7 @@ def get_base_configuration(
 
 def get_command_environment(
     http_proxy: Optional[str] = None, https_proxy: Optional[str] = None
-) -> Dict[str, Optional[str]]:
+) -> dict[str, Optional[str]]:
     """Construct an environment needed to execute a command.
 
     :param http_proxy: http proxy to add to environment

--- a/snapcraft/snap_config.py
+++ b/snapcraft/snap_config.py
@@ -16,7 +16,7 @@
 
 """Snap config file definitions and helpers."""
 
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Literal
 
 import craft_application.models
 import pydantic
@@ -39,7 +39,7 @@ class SnapConfig(craft_application.models.CraftBaseModel):
     provider: ProviderName | None = None
 
 
-def get_snap_config() -> Optional[SnapConfig]:
+def get_snap_config() -> SnapConfig | None:
     """Get validated snap configuration.
 
     :return: SnapConfig. If not running as a snap, return None.

--- a/snapcraft/store/_legacy_account.py
+++ b/snapcraft/store/_legacy_account.py
@@ -21,7 +21,7 @@ import configparser
 import json
 import os
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Sequence
 
 import craft_store
 import pymacaroons
@@ -161,7 +161,7 @@ class LegacyUbuntuOne(craft_store.UbuntuOneStoreClient):
         endpoints: craft_store.endpoints.Endpoints,
         application_name: str,
         user_agent: str,
-        environment_auth: Optional[str] = None,
+        environment_auth: str | None = None,
         ephemeral: bool = False,
     ) -> None:
         # Adapt to the JSON format if the environment has configparser based credentials.
@@ -198,8 +198,8 @@ class LegacyUbuntuOne(craft_store.UbuntuOneStoreClient):
         permissions: Sequence[str],
         description: str,
         ttl: int,
-        packages: Optional[Sequence[craft_store.endpoints.Package]] = None,
-        channels: Optional[Sequence[str]] = None,
+        packages: Sequence[craft_store.endpoints.Package] | None = None,
+        channels: Sequence[str] | None = None,
         **kwargs,
     ) -> str:
         raise errors.SnapcraftError(

--- a/snapcraft/store/_legacy_account.py
+++ b/snapcraft/store/_legacy_account.py
@@ -21,7 +21,7 @@ import configparser
 import json
 import os
 from pathlib import Path
-from typing import Dict, Optional, Sequence
+from typing import Optional, Sequence
 
 import craft_store
 import pymacaroons
@@ -66,7 +66,7 @@ def _deserialize_macaroon(value) -> pymacaroons.Macaroon:
         raise errors.LegacyCredentialsParseError("Failed to deserialize macaroon")
 
 
-def _get_macaroons_from_conf(conf) -> Dict[str, str]:
+def _get_macaroons_from_conf(conf) -> dict[str, str]:
     """Format a macaroon and its associated discharge.
 
     :return: A string suitable to use in an Authorization header.

--- a/snapcraft/store/channel_map.py
+++ b/snapcraft/store/channel_map.py
@@ -23,7 +23,7 @@ The full API is documented on
 https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-channel-map
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import jsonschema
 from craft_store.models import SnapListReleasesModel
@@ -62,9 +62,9 @@ class Progressive:
     def __init__(
         self,
         *,
-        paused: Optional[bool],
-        percentage: Optional[float],
-        current_percentage: Optional[float],
+        paused: bool | None,
+        percentage: float | None,
+        current_percentage: float | None,
     ) -> None:
         self.paused = paused
         self.percentage = percentage
@@ -112,7 +112,7 @@ class MappedChannel:
         channel: str,
         revision: int,
         architecture: str,
-        expiration_date: Optional[str],
+        expiration_date: str | None,
         progressive: Progressive,
     ) -> None:
         self.channel = channel
@@ -200,8 +200,8 @@ class SnapChannel:
         name: str,
         track: str,
         risk: str,
-        branch: Optional[str],
-        fallback: Optional[str],
+        branch: str | None,
+        fallback: str | None,
     ) -> None:
         self.name = name
         self.track = track
@@ -247,8 +247,8 @@ class SnapTrack:
         *,
         name: str,
         status: str,
-        creation_date: Optional[str],
-        version_pattern: Optional[str],
+        creation_date: str | None,
+        version_pattern: str | None,
     ) -> None:
         self.name = name
         self.status = status
@@ -284,7 +284,7 @@ class Snap:
     def __init__(
         self,
         *,
-        name: Optional[str],
+        name: str | None,
         channels: list[SnapChannel],
         tracks: list[SnapTrack],
     ) -> None:

--- a/snapcraft/store/channel_map.py
+++ b/snapcraft/store/channel_map.py
@@ -23,7 +23,7 @@ The full API is documented on
 https://dashboard.snapcraft.io/docs/v2/en/snaps.html#snap-channel-map
 """
 
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Optional
 
 import jsonschema
 from craft_store.models import SnapListReleasesModel
@@ -33,7 +33,7 @@ class Progressive:
     """Represent Progressive information for a MappedChannel."""
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "Progressive":
+    def unmarshal(cls, payload: dict[str, Any]) -> "Progressive":
         """Unmarshal payload into a Progressive."""
         jsonschema.validate(
             payload,
@@ -47,7 +47,7 @@ class Progressive:
             current_percentage=payload.get("current-percentage"),
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this Progressive into a dict."""
         return {
             "paused": self.paused,
@@ -75,7 +75,7 @@ class MappedChannel:
     """Represent a mapped channel item for "channel-map" in ChannelMap."""
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "MappedChannel":
+    def unmarshal(cls, payload: dict[str, Any]) -> "MappedChannel":
         """Unmarshal payload into a MappedChannel."""
         jsonschema.validate(
             payload, CHANNEL_MAP_JSONSCHEMA["properties"]["channel-map"]["items"]
@@ -88,7 +88,7 @@ class MappedChannel:
             progressive=Progressive.unmarshal(payload["progressive"]),
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this MappedChannel into a dict."""
         return {
             "channel": self.channel,
@@ -126,7 +126,7 @@ class Revision:
     """Represent a revision item for "revisions" in ChannelMap."""
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "Revision":
+    def unmarshal(cls, payload: dict[str, Any]) -> "Revision":
         """Unmarshal payload into a Revision."""
         jsonschema.validate(
             payload, CHANNEL_MAP_JSONSCHEMA["properties"]["revisions"]["items"]
@@ -137,7 +137,7 @@ class Revision:
             architectures=payload["architectures"],
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this Revision into a dict."""
         return {
             "revision": self.revision,
@@ -153,7 +153,7 @@ class Revision:
         )
 
     def __init__(
-        self, *, revision: int, version: str, architectures: List[str]
+        self, *, revision: int, version: str, architectures: list[str]
     ) -> None:
         self.revision = revision
         self.version = version
@@ -164,7 +164,7 @@ class SnapChannel:
     """Represent a channel item in "channels" in Snap."""
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "SnapChannel":
+    def unmarshal(cls, payload: dict[str, Any]) -> "SnapChannel":
         """Unmarshal payload into a SnapChannel."""
         jsonschema.validate(
             payload,
@@ -180,7 +180,7 @@ class SnapChannel:
             fallback=payload["fallback"],
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this SnapChannel into a dict."""
         return {
             "name": self.name,
@@ -214,7 +214,7 @@ class SnapTrack:
     """Represent a track item in "tracks" in Snap."""
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "SnapTrack":
+    def unmarshal(cls, payload: dict[str, Any]) -> "SnapTrack":
         """Unmarshal payload into a SnapTrack."""
         jsonschema.validate(
             payload,
@@ -229,7 +229,7 @@ class SnapTrack:
             version_pattern=payload["version-pattern"],
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this SnapTrack into a dict."""
         return {
             "name": self.name,
@@ -260,7 +260,7 @@ class Snap:
     """Represent "snap" in ChannelMap."""
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "Snap":
+    def unmarshal(cls, payload: dict[str, Any]) -> "Snap":
         """Unmarshal payload into a Snap."""
         jsonschema.validate(payload, CHANNEL_MAP_JSONSCHEMA["properties"]["snap"])
         return cls(
@@ -269,7 +269,7 @@ class Snap:
             tracks=[SnapTrack.unmarshal(st) for st in payload.get("tracks", [])],
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this Snap into a dict."""
         return {
             "name": self.name,
@@ -285,8 +285,8 @@ class Snap:
         self,
         *,
         name: Optional[str],
-        channels: List[SnapChannel],
-        tracks: List[SnapTrack],
+        channels: list[SnapChannel],
+        tracks: list[SnapTrack],
     ) -> None:
         self.name = name
         self.channels = channels
@@ -310,7 +310,7 @@ class ChannelMap:
         )
 
     @classmethod
-    def unmarshal(cls, payload: Dict[str, Any]) -> "ChannelMap":
+    def unmarshal(cls, payload: dict[str, Any]) -> "ChannelMap":
         """Unmarshal payload into a ChannelMap."""
         jsonschema.validate(payload, CHANNEL_MAP_JSONSCHEMA)
         return cls(
@@ -319,7 +319,7 @@ class ChannelMap:
             snap=Snap.unmarshal(payload["snap"]),
         )
 
-    def marshal(self) -> Dict[str, Any]:
+    def marshal(self) -> dict[str, Any]:
         """Marshal this ChannelMap into a dict."""
         return {
             "channel-map": [c.marshal() for c in self.channel_map],
@@ -332,7 +332,7 @@ class ChannelMap:
         return f"<{self.__class__.__name__}: {self.snap.name!r}>"
 
     def __init__(
-        self, *, channel_map: List[MappedChannel], revisions: List[Revision], snap: Snap
+        self, *, channel_map: list[MappedChannel], revisions: list[Revision], snap: Snap
     ) -> None:
         self.channel_map = channel_map
         self.revisions = revisions
@@ -380,16 +380,16 @@ class ChannelMap:
                 return revision_item
         raise ValueError(f"No revision information for {revision_number!r}")
 
-    def get_existing_architectures(self) -> Set[str]:
+    def get_existing_architectures(self) -> set[str]:
         """Return a list of the existing architectures for this map."""
-        architectures: List[str] = []
+        architectures: list[str] = []
         for revision_item in self.revisions:
             architectures.extend(revision_item.architectures)
 
         return set(architectures)
 
 
-CHANNEL_MAP_JSONSCHEMA: Dict[str, Any] = {
+CHANNEL_MAP_JSONSCHEMA: dict[str, Any] = {
     "properties": {
         "channel-map": {
             "items": {

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -20,7 +20,7 @@ import os
 import platform
 import time
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Optional, Sequence, cast
 
 import craft_store
 import distro
@@ -86,7 +86,7 @@ def get_store_login_url() -> str:
     return os.getenv("UBUNTU_ONE_SSO_URL", constants.UBUNTU_ONE_SSO_URL)
 
 
-def _prompt_login() -> Tuple[str, str]:
+def _prompt_login() -> tuple[str, str]:
     emit.message("Enter your Ubuntu One e-mail address and password.")
     emit.message(
         "If you do not have an Ubuntu One account, you can create one "
@@ -316,7 +316,7 @@ class LegacyStoreClientCLI:
 
     def get_account_info(
         self,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return account information."""
         return self.request(
             "GET",
@@ -324,11 +324,11 @@ class LegacyStoreClientCLI:
             headers={"Accept": "application/json"},
         ).json()
 
-    def get_names(self) -> List[Tuple[str, str, str, str]]:
+    def get_names(self) -> list[tuple[str, str, str, str]]:
         """Return a table with the registered names and status."""
         account_info = self.get_account_info()
 
-        snaps: List[Tuple[str, str, str, str]] = [
+        snaps: list[tuple[str, str, str, str]] = [
             (
                 name,
                 info["since"],
@@ -359,7 +359,7 @@ class LegacyStoreClientCLI:
         :param channels: the channels to release to
         :param progressive_percentage: enable progressive releases up to a given percentage
         """
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "name": snap_name,
             "revision": str(revision),
             "channels": channels,
@@ -426,7 +426,7 @@ class LegacyStoreClientCLI:
         snap_file_size: int,
         built_at: Optional[str],
         channels: Optional[Sequence[str]],
-        components: Optional[Dict[str, str]],
+        components: Optional[dict[str, str]],
     ) -> int:
         """Notify an upload to the Snap Store.
 
@@ -630,7 +630,7 @@ class OnPremStoreClientCLI(LegacyStoreClientCLI):
         snap_file_size: int,
         built_at: Optional[str],
         channels: Optional[Sequence[str]],
-        components: Optional[Dict[str, str]],
+        components: Optional[dict[str, str]],
     ) -> int:
         if channels:
             raise errors.SnapcraftError("Releasing during currently unsupported")

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -20,7 +20,7 @@ import os
 import platform
 import time
 from datetime import timedelta
-from typing import Any, Optional, Sequence, cast
+from typing import Any, Sequence, cast
 
 import craft_store
 import distro
@@ -99,7 +99,7 @@ def _prompt_login() -> tuple[str, str]:
 
 
 def _get_hostname(
-    hostname: Optional[str] = platform.node(),  # noqa: B008 Function call in arg defaults
+    hostname: str | None = platform.node(),  # noqa: B008 Function call in arg defaults
 ) -> str:
     """Return the computer's network name or UNNKOWN if it cannot be determined."""
     if not hostname:
@@ -179,9 +179,9 @@ class LegacyStoreClientCLI:
         self,
         *,
         ttl: int = int(timedelta(days=365).total_seconds()),  # noqa: B008
-        acls: Optional[Sequence[str]] = None,
-        packages: Optional[Sequence[str]] = None,
-        channels: Optional[Sequence[str]] = None,
+        acls: Sequence[str] | None = None,
+        packages: Sequence[str] | None = None,
+        channels: Sequence[str] | None = None,
         **kwargs,
     ) -> str:
         """Log in to the Snap Store and prompt if required."""
@@ -280,7 +280,7 @@ class LegacyStoreClientCLI:
         snap_name: str,
         *,
         is_private: bool = False,
-        store_id: Optional[str] = None,
+        store_id: str | None = None,
     ) -> None:
         """Register snap_name with the Snap Store.
 
@@ -350,7 +350,7 @@ class LegacyStoreClientCLI:
         *,
         revision: int,
         channels: Sequence[str],
-        progressive_percentage: Optional[int] = None,
+        progressive_percentage: int | None = None,
     ) -> None:
         """Register snap_name with the Snap Store.
 
@@ -424,9 +424,9 @@ class LegacyStoreClientCLI:
         snap_name: str,
         upload_id: str,
         snap_file_size: int,
-        built_at: Optional[str],
-        channels: Optional[Sequence[str]],
-        components: Optional[dict[str, str]],
+        built_at: str | None,
+        channels: Sequence[str] | None,
+        components: dict[str, str] | None,
     ) -> int:
         """Notify an upload to the Snap Store.
 
@@ -628,9 +628,9 @@ class OnPremStoreClientCLI(LegacyStoreClientCLI):
         snap_name: str,
         upload_id: str,
         snap_file_size: int,
-        built_at: Optional[str],
-        channels: Optional[Sequence[str]],
-        components: Optional[dict[str, str]],
+        built_at: str | None,
+        channels: Sequence[str] | None,
+        components: dict[str, str] | None,
     ) -> int:
         if channels:
             raise errors.SnapcraftError("Releasing during currently unsupported")
@@ -676,9 +676,9 @@ class OnPremStoreClientCLI(LegacyStoreClientCLI):
         self,
         snap_name: str,
         *,
-        revision: Optional[int],
+        revision: int | None,
         channels: Sequence[str],
-        progressive_percentage: Optional[int] = None,
+        progressive_percentage: int | None = None,
     ) -> None:
         if progressive_percentage is not None:
             raise errors.SnapcraftError("Progressive percentage currently unsupported")

--- a/snapcraft/store/onprem_client.py
+++ b/snapcraft/store/onprem_client.py
@@ -17,7 +17,7 @@
 """On premises Store Client implementation."""
 
 import os
-from typing import Any, Dict, Final
+from typing import Any, Final
 
 import craft_store.creds
 from craft_store import BaseClient, endpoints, models
@@ -41,7 +41,7 @@ class OnPremClient(BaseClient):
     """On Premises Snapcraft Store Client."""
 
     @overrides
-    def _get_macaroon(self, token_request: Dict[str, Any]) -> str:
+    def _get_macaroon(self, token_request: dict[str, Any]) -> str:
         macaroon_env = os.getenv(constants.ENVIRONMENT_ADMIN_MACAROON)
         if macaroon_env is None:
             raise errors.SnapcraftError(

--- a/snapcraft/ua_manager.py
+++ b/snapcraft/ua_manager.py
@@ -19,7 +19,7 @@
 import contextlib
 import json
 import subprocess
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Iterator, Optional
 
 from craft_cli import emit
 from craft_parts.packages import Repository
@@ -134,7 +134,7 @@ def _is_attached() -> bool:
     return _status()["attached"]
 
 
-def _is_service_enabled(service_name: str, service_data: List[Dict[str, str]]) -> bool:
+def _is_service_enabled(service_name: str, service_data: list[dict[str, str]]) -> bool:
     """Check if a service is enabled.
 
     :param service_name: name of service to check
@@ -152,7 +152,7 @@ def _is_service_enabled(service_name: str, service_data: List[Dict[str, str]]) -
     return False
 
 
-def _status() -> Dict[str, Any]:
+def _status() -> dict[str, Any]:
     stdout = subprocess.check_output(["ua", "status", "--all", "--format", "json"])
     return json.loads(stdout)
 

--- a/snapcraft/ua_manager.py
+++ b/snapcraft/ua_manager.py
@@ -19,7 +19,7 @@
 import contextlib
 import json
 import subprocess
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator
 
 from craft_cli import emit
 from craft_parts.packages import Repository
@@ -158,9 +158,7 @@ def _status() -> dict[str, Any]:
 
 
 @contextlib.contextmanager
-def ua_manager(
-    ua_token: Optional[str], *, services: Optional[set[str]]
-) -> Iterator[None]:
+def ua_manager(ua_token: str | None, *, services: set[str] | None) -> Iterator[None]:
     """Attach and detach UA token as required.
 
     Uses try/finally to ensure that token is detached on error.

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -26,7 +26,7 @@ import shutil
 import sys
 from getpass import getpass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable
 
 from craft_application.util import strtobool
 from craft_cli import emit
@@ -64,7 +64,7 @@ def get_managed_environment_log_path():
     )
 
 
-def get_managed_environment_snap_channel() -> Optional[str]:
+def get_managed_environment_snap_channel() -> str | None:
     """User-specified channel to use when installing Snapcraft snap from Snap Store.
 
     :returns: Channel string if specified, else None.
@@ -74,12 +74,12 @@ def get_managed_environment_snap_channel() -> Optional[str]:
 
 def get_effective_base(
     *,
-    base: Optional[str],
-    build_base: Optional[str],
-    project_type: Optional[str],
-    name: Optional[str],
+    base: str | None,
+    build_base: str | None,
+    project_type: str | None,
+    name: str | None,
     translate_devel: bool = True,
-) -> Optional[str]:
+) -> str | None:
     """Return the base to use to create the snap.
 
     Return the build-base if set.
@@ -222,9 +222,7 @@ def humanize_list(
     return f"{humanized} {conjunction} {quoted_items[-1]}"
 
 
-def get_common_ld_library_paths(
-    prime_dir: Path, arch_triplet: Optional[str]
-) -> list[str]:
+def get_common_ld_library_paths(prime_dir: Path, arch_triplet: str | None) -> list[str]:
     """Return common existing PATH entries for a snap.
 
     :param prime_dir: Path to the prime directory.
@@ -249,7 +247,7 @@ def get_common_ld_library_paths(
     return [str(p) for p in paths if p.exists()]
 
 
-def get_ld_library_paths(prime_dir: Path, arch_triplet: Optional[str]) -> str:
+def get_ld_library_paths(prime_dir: Path, arch_triplet: str | None) -> str:
     """Return a usable in-snap LD_LIBRARY_PATH variable.
 
     :param prime_dir: Path to the prime directory.
@@ -315,7 +313,7 @@ def get_snap_tool(command_name: str) -> str:
     return command_path
 
 
-def _find_command_path_in_root(root: str, command_name: str) -> Optional[str]:
+def _find_command_path_in_root(root: str, command_name: str) -> str | None:
     for bin_directory in (
         "usr/local/sbin",
         "usr/local/bin",
@@ -331,7 +329,7 @@ def _find_command_path_in_root(root: str, command_name: str) -> Optional[str]:
     return None
 
 
-def process_version(version: Optional[str]) -> str:
+def process_version(version: str | None) -> str:
     """Handle special version strings."""
     if version is None:
         raise ValueError("version cannot be None")

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -26,7 +26,7 @@ import shutil
 import sys
 from getpass import getpass
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 from craft_application.util import strtobool
 from craft_cli import emit
@@ -224,7 +224,7 @@ def humanize_list(
 
 def get_common_ld_library_paths(
     prime_dir: Path, arch_triplet: Optional[str]
-) -> List[str]:
+) -> list[str]:
     """Return common existing PATH entries for a snap.
 
     :param prime_dir: Path to the prime directory.

--- a/tests/legacy/fake_servers/api.py
+++ b/tests/legacy/fake_servers/api.py
@@ -1633,7 +1633,7 @@ class FakeStoreAPIServer(base.BaseFakeServer):
             [("Content-Type", "application/json")],
         )
 
-    def _save_validation_sets_assertion(self, assertion: Dict[str, Any]) -> None:
+    def _save_validation_sets_assertion(self, assertion: dict[str, Any]) -> None:
         self.validation_set_assertions[assertion["name"]] = assertion
 
     def post_validation_sets(self, request):

--- a/tests/legacy/fixture_setup/os_release.py
+++ b/tests/legacy/fixture_setup/os_release.py
@@ -27,9 +27,9 @@ class FakeOsRelease(fixtures.Fixture):
     def __init__(
         self,
         id: str = "ubuntu",
-        version_id: Optional[str] = "18.04",
-        version_codename: Optional[str] = None,
-        name: Optional[str] = "Ubuntu",
+        version_id: str | None = "18.04",
+        version_codename: str | None = None,
+        name: str | None = "Ubuntu",
     ) -> None:
         self._id = id
         self._version_id = version_id

--- a/tests/legacy/unit/build_providers/__init__.py
+++ b/tests/legacy/unit/build_providers/__init__.py
@@ -47,9 +47,9 @@ class ProviderImpl(Provider):
         self.clean_project_mock = mock.Mock()
         self.shell_mock = mock.Mock()
         self.save_info_mock = mock.Mock()
-        self.loaded_info: Optional[Dict[str, str]] = None
+        self.loaded_info: Optional[dict[str, str]] = None
 
-    def _load_info(self) -> Dict[str, str]:
+    def _load_info(self) -> dict[str, str]:
         if self.loaded_info is None:
             return super()._load_info()
         return self.loaded_info

--- a/tests/legacy/unit/build_providers/__init__.py
+++ b/tests/legacy/unit/build_providers/__init__.py
@@ -47,14 +47,14 @@ class ProviderImpl(Provider):
         self.clean_project_mock = mock.Mock()
         self.shell_mock = mock.Mock()
         self.save_info_mock = mock.Mock()
-        self.loaded_info: Optional[dict[str, str]] = None
+        self.loaded_info: dict[str, str] | None = None
 
     def _load_info(self) -> dict[str, str]:
         if self.loaded_info is None:
             return super()._load_info()
         return self.loaded_info
 
-    def _run(self, command, hide_output=False) -> Optional[bytes]:
+    def _run(self, command, hide_output=False) -> bytes | None:
         return self.run_mock(command)
 
     def _launch(self) -> None:

--- a/tests/legacy/unit/build_providers/lxd/test_lxd.py
+++ b/tests/legacy/unit/build_providers/lxd/test_lxd.py
@@ -63,7 +63,7 @@ class FakeContainer:
     def status(self) -> str:
         return self._status
 
-    def __init__(self, config: Dict[str, Any], wait: bool) -> None:
+    def __init__(self, config: dict[str, Any], wait: bool) -> None:
         self._status = "STOPPED"
         self.config = config
         self.devices = dict()  # type: Dict[str, Any]
@@ -149,7 +149,7 @@ class FakeContainers:
         self.get_mock(container_name)
         return self._containers[container_name]
 
-    def create(self, config: Dict[str, Any], wait: bool) -> FakeContainer:
+    def create(self, config: dict[str, Any], wait: bool) -> FakeContainer:
         self.create_mock(config=config, wait=wait)
         self._containers[config["name"]] = FakeContainer(config, wait)
         return self._containers[config["name"]]

--- a/tests/legacy/unit/commands/conftest.py
+++ b/tests/legacy/unit/commands/conftest.py
@@ -27,7 +27,7 @@ def click_run():
     """Run commands using Click's testing backend."""
     cli = CliRunner()
 
-    def runner(args: List[str]):
+    def runner(args: list[str]):
         return cli.invoke(run, args)
 
     return runner

--- a/tests/legacy/unit/commands/test_build_providers.py
+++ b/tests/legacy/unit/commands/test_build_providers.py
@@ -286,7 +286,7 @@ class BuildProviderDebugCommandTestCase(LifecycleCommandsBaseTestCase):
 
         class Provider(ProviderImpl):
             def execute_step(
-                self, step: steps.Step, part_names: Optional[Sequence[str]] = None
+                self, step: steps.Step, part_names: Sequence[str] | None = None
             ) -> None:
                 if part_names is None:
                     part_names = []
@@ -344,11 +344,11 @@ class BuildProviderShellCommandTestCase(LifecycleCommandsBaseTestCase):
         execute_step_mock = mock.Mock()
 
         class Provider(ProviderImpl):
-            def pack_project(self, *, output: Optional[str] = None) -> None:
+            def pack_project(self, *, output: str | None = None) -> None:
                 pack_project_mock(output)
 
             def execute_step(
-                self, step: steps.Step, part_names: Optional[Sequence[str]] = None
+                self, step: steps.Step, part_names: Sequence[str] | None = None
             ) -> None:
                 execute_step_mock(step, part_names=part_names)
 
@@ -491,7 +491,7 @@ class BuildProviderCleanCommandTestCase(LifecycleCommandsBaseTestCase):
 
         class Provider(ProviderImpl):
             def execute_step(
-                self, step: steps.Step, part_names: Optional[Sequence[str]] = None
+                self, step: steps.Step, part_names: Sequence[str] | None = None
             ) -> None:
                 if part_names is None:
                     part_names = []

--- a/tests/legacy/unit/commands/test_extensions.py
+++ b/tests/legacy/unit/commands/test_extensions.py
@@ -190,11 +190,11 @@ def _test1_extension_fixture():
         """
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -214,11 +214,11 @@ def _test2_extension_fixture():
         """
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -232,11 +232,11 @@ def _test2_extension_fixture():
 def _test3_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core18", "core20")
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -249,11 +249,11 @@ def _test3_extension_fixture():
 def _test4_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20", "core18")
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):

--- a/tests/legacy/unit/commands/test_snap.py
+++ b/tests/legacy/unit/commands/test_snap.py
@@ -27,7 +27,7 @@ from . import LifecycleCommandsBaseTestCase
 
 class TestSnap(LifecycleCommandsBaseTestCase):
     def assert_build_provider_calls(
-        self, shell: bool = False, output: Optional[str] = None
+        self, shell: bool = False, output: str | None = None
     ):
         self.fake_lifecycle_execute.mock.assert_not_called()
 

--- a/tests/legacy/unit/conftest.py
+++ b/tests/legacy/unit/conftest.py
@@ -95,7 +95,7 @@ def fake_exists(monkeypatch):
     class FileCheck:
         def __init__(self) -> None:
             self._original_exists = os.path.exists
-            self.paths: List[str] = list()
+            self.paths: list[str] = list()
 
         def exists(self, path: str) -> bool:
             if pathlib.Path(path) in self.paths:

--- a/tests/legacy/unit/lifecycle/test_order_core20.py
+++ b/tests/legacy/unit/lifecycle/test_order_core20.py
@@ -28,7 +28,7 @@ from snapcraft_legacy.project import Project
 
 class FakePart:
     def __init__(
-        self, name: str = "part1", build_attributes: Optional[Sequence] = None
+        self, name: str = "part1", build_attributes: Sequence | None = None
     ) -> None:
         self.name = name
 

--- a/tests/legacy/unit/plugins/v2/test_kernel.py
+++ b/tests/legacy/unit/plugins/v2/test_kernel.py
@@ -85,7 +85,7 @@ class TestPluginKernel(TestCase):
         kernelcompilerparameters=None,
         kernelenablezfssupport=False,
         kernelenableperf=False,
-        kernelusellvm: Union[bool, str] = False,
+        kernelusellvm: bool | str = False,
         arch=platform.machine(),
     ):
         @dataclass

--- a/tests/legacy/unit/project_loader/extensions/test_utils.py
+++ b/tests/legacy/unit/project_loader/extensions/test_utils.py
@@ -819,11 +819,11 @@ class InvalidExtensionTest(ExtensionTestBase):
 def _environment_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -839,11 +839,11 @@ def _environment_extension_fixture():
 def _build_environment_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -865,11 +865,11 @@ def _build_environment_extension_fixture():
 def _build_environment2_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -891,11 +891,11 @@ def _build_environment2_extension_fixture():
 def _plugin_aware_part_snippet_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -910,7 +910,7 @@ def _plugin_aware_part_snippet_extension_fixture():
             self.parts = {}
 
         @overrides
-        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
             if plugin_name == "catkin":
                 return {}
             return self.part_snippet
@@ -921,11 +921,11 @@ def _plugin_aware_part_snippet_extension_fixture():
 def _plug_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -938,11 +938,11 @@ def _plug_extension_fixture():
 def _plug2_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -955,11 +955,11 @@ def _plug2_extension_fixture():
 def _daemon_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -972,11 +972,11 @@ def _daemon_extension_fixture():
 def _adopt_info_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):
@@ -989,11 +989,11 @@ def _adopt_info_extension_fixture():
 def _invalid_extension_fixture():
     class ExtensionImpl(Extension):
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core20",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         def __init__(self, extension_name, yaml_data):

--- a/tests/legacy/unit/test_errors.py
+++ b/tests/legacy/unit/test_errors.py
@@ -616,7 +616,7 @@ class StrangeExceptionSimple(errors.SnapcraftException):
 
 
 class StrangeExceptionWithFormatting(errors.SnapcraftException):
-    def __init__(self, neighborhood: str, contact: str, ghosts: List[str]) -> None:
+    def __init__(self, neighborhood: str, contact: str, ghosts: list[str]) -> None:
         self._neighborhood = neighborhood
         self._contact = contact
         self._ghosts = ghosts

--- a/tests/os_release.py
+++ b/tests/os_release.py
@@ -25,7 +25,7 @@ _ID_TO_UBUNTU_CODENAME = {
 }
 
 
-def get_version_codename() -> Optional[str]:
+def get_version_codename() -> str | None:
     """Return the OS version codename
 
     This first tries to use the VERSION_CODENAME. If that's missing, it

--- a/tests/spread/plugins/v2/snaps/local-plugin-from-base-hello/snap/plugins/x_local_plugin.py
+++ b/tests/spread/plugins/v2/snaps/local-plugin-from-base-hello/snap/plugins/x_local_plugin.py
@@ -14,14 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Dict, List, Set
+from typing import Any
 
 from snapcraft.plugins.v2 import PluginV2
 
 
 class PluginImpl(PluginV2):
     @classmethod
-    def get_schema(cls) -> Dict[str, Any]:
+    def get_schema(cls) -> dict[str, Any]:
         return {
             "$schema": "http://json-schema.org/draft-04/schema#",
             "type": "object",
@@ -29,16 +29,16 @@ class PluginImpl(PluginV2):
             "properties": {"foo": {"type": "string"}},
         }
 
-    def get_build_snaps(self) -> Set[str]:
+    def get_build_snaps(self) -> set[str]:
         return set()
 
-    def get_build_packages(self) -> Set[str]:
+    def get_build_packages(self) -> set[str]:
         return {"gcc"}
 
-    def get_build_environment(self) -> Dict[str, str]:
+    def get_build_environment(self) -> dict[str, str]:
         return dict()
 
-    def get_build_commands(self) -> List[str]:
+    def get_build_commands(self) -> list[str]:
         return [
             "mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin",
             "gcc hello.c -o ${SNAPCRAFT_PART_INSTALL}/bin/hello",

--- a/tests/spread/plugins/v2/snaps/local-plugin-from-nil-hello/snap/plugins/x_local_plugin.py
+++ b/tests/spread/plugins/v2/snaps/local-plugin-from-nil-hello/snap/plugins/x_local_plugin.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Set
 
 from snapcraft.plugins.v2 import nil
 
@@ -26,12 +25,12 @@ class PluginImpl(nil.NilPlugin):
         schema["properties"]["foo"] = {"type": "string"}
         return schema
 
-    def get_build_packages(self) -> Set[str]:
+    def get_build_packages(self) -> set[str]:
         build_packages = super().get_build_packages()
         build_packages.add("gcc")
         return build_packages
 
-    def get_build_commands(self) -> List[str]:
+    def get_build_commands(self) -> list[str]:
         commands = super().get_build_commands()
         commands.append("mkdir -p ${SNAPCRAFT_PART_INSTALL}/bin")
         commands.append("gcc hello.c -o ${SNAPCRAFT_PART_INSTALL}/bin/hello")

--- a/tests/unit/commands/test_validation_sets.py
+++ b/tests/unit/commands/test_validation_sets.py
@@ -16,7 +16,7 @@
 
 import argparse
 import json
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import call
 
 import pytest
@@ -124,7 +124,7 @@ def fake_dashboard_get_validation_sets(fake_validation_sets, mocker):
 
 @pytest.fixture
 def fake_snap_sign(mocker):
-    def sign(assertion: Dict[str, Any], *, key_name: str) -> bytes:
+    def sign(assertion: dict[str, Any], *, key_name: str) -> bytes:
         return (json.dumps(assertion) + f"\n\nSIGNED{key_name}").encode()
 
     return mocker.patch(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,7 +18,7 @@ import base64
 import contextlib
 import textwrap
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 from unittest.mock import Mock
 
 import pytest
@@ -51,7 +51,7 @@ def snapcraft_yaml(new_dir):
 
     def write_file(
         *, filename: str = "snap/snapcraft.yaml", **kwargs
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         content = {
             "name": "mytest",
             "version": "0.1",
@@ -84,30 +84,30 @@ def fake_extension():
         """The test extension implementation."""
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core22", "core24")
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         @staticmethod
         def is_experimental(base: Optional[str] = None) -> bool:
             return False
 
-        def get_root_snippet(self) -> Dict[str, Any]:
+        def get_root_snippet(self) -> dict[str, Any]:
             return {"grade": "fake-grade"}
 
-        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
             return {"plugs": ["fake-plug"]}
 
-        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
             if plugin_name == "catkin":
                 return {}
 
             return {"after": ["fake-extension/fake-part"]}
 
-        def get_parts_snippet(self) -> Dict[str, Any]:
+        def get_parts_snippet(self) -> dict[str, Any]:
             return {"fake-extension/fake-part": {"plugin": "nil"}}
 
     register("fake-extension", ExtensionImpl)
@@ -123,27 +123,27 @@ def fake_extension_extra():
         """The test extension implementation."""
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core22",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         @staticmethod
         def is_experimental(base: Optional[str] = None) -> bool:
             return False
 
-        def get_root_snippet(self) -> Dict[str, Any]:
+        def get_root_snippet(self) -> dict[str, Any]:
             return {}
 
-        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
             return {"plugs": ["fake-plug", "fake-plug-extra"]}
 
-        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
             return {"after": ["fake-extension-extra/fake-part"]}
 
-        def get_parts_snippet(self) -> Dict[str, Any]:
+        def get_parts_snippet(self) -> dict[str, Any]:
             return {"fake-extension-extra/fake-part": {"plugin": "nil"}}
 
     register("fake-extension-extra", ExtensionImpl)
@@ -157,27 +157,27 @@ def fake_extension_invalid_parts():
         """The test extension implementation."""
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core22",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         @staticmethod
         def is_experimental(base: Optional[str] = None) -> bool:
             return False
 
-        def get_root_snippet(self) -> Dict[str, Any]:
+        def get_root_snippet(self) -> dict[str, Any]:
             return {"grade": "fake-grade"}
 
-        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
             return {"plugs": ["fake-plug"]}
 
-        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
             return {"after": ["fake-extension/fake-part"]}
 
-        def get_parts_snippet(self) -> Dict[str, Any]:
+        def get_parts_snippet(self) -> dict[str, Any]:
             return {"fake-part": {"plugin": "nil"}, "fake-part-2": {"plugin": "nil"}}
 
     register("fake-extension-invalid-parts", ExtensionImpl)
@@ -193,27 +193,27 @@ def fake_extension_experimental():
         """The test extension implementation."""
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core22",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         @staticmethod
         def is_experimental(base: Optional[str] = None) -> bool:
             return True
 
-        def get_root_snippet(self) -> Dict[str, Any]:
+        def get_root_snippet(self) -> dict[str, Any]:
             return {}
 
-        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
             return {}
 
-        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
             return {}
 
-        def get_parts_snippet(self) -> Dict[str, Any]:
+        def get_parts_snippet(self) -> dict[str, Any]:
             return {}
 
     register("fake-extension-experimental", ExtensionImpl)
@@ -229,27 +229,27 @@ def fake_extension_name_from_legacy():
         """The test extension implementation."""
 
         @staticmethod
-        def get_supported_bases() -> Tuple[str, ...]:
+        def get_supported_bases() -> tuple[str, ...]:
             return ("core22",)
 
         @staticmethod
-        def get_supported_confinement() -> Tuple[str, ...]:
+        def get_supported_confinement() -> tuple[str, ...]:
             return ("strict",)
 
         @staticmethod
         def is_experimental(base: Optional[str] = None) -> bool:
             return False
 
-        def get_root_snippet(self) -> Dict[str, Any]:
+        def get_root_snippet(self) -> dict[str, Any]:
             return {}
 
-        def get_app_snippet(self, *, app_name: str) -> Dict[str, Any]:
+        def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
             return {"plugs": ["fake-plug", "fake-plug-extra"]}
 
-        def get_part_snippet(self, *, plugin_name: str) -> Dict[str, Any]:
+        def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
             return {"after": ["fake-extension-extra/fake-part"]}
 
-        def get_parts_snippet(self) -> Dict[str, Any]:
+        def get_parts_snippet(self) -> dict[str, Any]:
             return {"fake-extension-extra/fake-part": {"plugin": "nil"}}
 
     yield ExtensionImpl

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,7 +18,7 @@ import base64
 import contextlib
 import textwrap
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -92,7 +92,7 @@ def fake_extension():
             return ("strict",)
 
         @staticmethod
-        def is_experimental(base: Optional[str] = None) -> bool:
+        def is_experimental(base: str | None = None) -> bool:
             return False
 
         def get_root_snippet(self) -> dict[str, Any]:
@@ -131,7 +131,7 @@ def fake_extension_extra():
             return ("strict",)
 
         @staticmethod
-        def is_experimental(base: Optional[str] = None) -> bool:
+        def is_experimental(base: str | None = None) -> bool:
             return False
 
         def get_root_snippet(self) -> dict[str, Any]:
@@ -165,7 +165,7 @@ def fake_extension_invalid_parts():
             return ("strict",)
 
         @staticmethod
-        def is_experimental(base: Optional[str] = None) -> bool:
+        def is_experimental(base: str | None = None) -> bool:
             return False
 
         def get_root_snippet(self) -> dict[str, Any]:
@@ -201,7 +201,7 @@ def fake_extension_experimental():
             return ("strict",)
 
         @staticmethod
-        def is_experimental(base: Optional[str] = None) -> bool:
+        def is_experimental(base: str | None = None) -> bool:
             return True
 
         def get_root_snippet(self) -> dict[str, Any]:
@@ -237,7 +237,7 @@ def fake_extension_name_from_legacy():
             return ("strict",)
 
         @staticmethod
-        def is_experimental(base: Optional[str] = None) -> bool:
+        def is_experimental(base: str | None = None) -> bool:
             return False
 
         def get_root_snippet(self) -> dict[str, Any]:
@@ -374,7 +374,7 @@ def fake_provider(mock_instance):
             project_name: str,
             project_path: Path,
             base_configuration: Base,
-            build_base: Optional[str] = None,
+            build_base: str | None = None,
             instance_name: str,
             allow_unstable: bool = False,
         ):

--- a/tests/unit/linters/conftest.py
+++ b/tests/unit/linters/conftest.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
 
 import pytest
 
@@ -26,9 +25,9 @@ def linter_issue():
     def _create_issue(
         *,
         result: LinterResult = LinterResult.OK,
-        filename: Optional[str] = None,
+        filename: str | None = None,
         text: str = "Linter message text",
-        url: Optional[str] = "https://some/url",
+        url: str | None = "https://some/url",
     ):
         return LinterIssue(
             name="test",

--- a/tests/unit/linters/test_linters.py
+++ b/tests/unit/linters/test_linters.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from typing import List
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -130,7 +129,7 @@ class TestLinterStatus:
 
 class _TestLinter(Linter):
     @overrides
-    def run(self) -> List[linters.LinterIssue]:
+    def run(self) -> list[linters.LinterIssue]:
         assert self._snap_metadata.name == "mytest"
         return [
             linters.LinterIssue(
@@ -142,7 +141,7 @@ class _TestLinter(Linter):
         ]
 
     @staticmethod
-    def get_categories() -> List[str]:
+    def get_categories() -> list[str]:
         return ["test-1", "test-2"]
 
     def is_file_ignored(self, filepath: Path, category: str = "") -> bool:

--- a/tests/unit/meta/test_appstream.py
+++ b/tests/unit/meta/test_appstream.py
@@ -17,7 +17,6 @@
 import os
 import textwrap
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -25,7 +24,7 @@ from snapcraft import errors
 from snapcraft.meta import ExtractedMetadata, appstream
 
 
-def _create_desktop_file(desktop_file_path, icon: Optional[str] = None) -> None:
+def _create_desktop_file(desktop_file_path, icon: str | None = None) -> None:
     dir_name = os.path.dirname(desktop_file_path)
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
@@ -112,9 +111,7 @@ class TestAppstreamData:
 class TestAppstreamIcons:
     """Check extraction of icon-related metadata."""
 
-    def _create_appstream_file(
-        self, icon: Optional[str] = None, icon_type: str = "local"
-    ):
+    def _create_appstream_file(self, icon: str | None = None, icon_type: str = "local"):
         with open("foo.appdata.xml", "w") as f:
             if icon:
                 f.write(

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 import pydantic
 import pytest
@@ -46,7 +46,7 @@ CORE24_DATA = {"base": "core24", "grade": "devel"}
 def project_yaml_data():
     def _project_yaml_data(
         *, name: str = "name", version: str = "0.1", summary: str = "summary", **kwargs
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return {
             "name": name,
             "version": version,
@@ -64,7 +64,7 @@ def project_yaml_data():
 
 @pytest.fixture
 def app_yaml_data(project_yaml_data):
-    def _app_yaml_data(**kwargs) -> Dict[str, Any]:
+    def _app_yaml_data(**kwargs) -> dict[str, Any]:
         data = project_yaml_data()
         data["apps"] = {"app1": {"command": "/bin/true", **kwargs}}
         return data
@@ -74,7 +74,7 @@ def app_yaml_data(project_yaml_data):
 
 @pytest.fixture
 def socket_yaml_data(app_yaml_data):
-    def _socket_yaml_data(**kwargs) -> Dict[str, Any]:
+    def _socket_yaml_data(**kwargs) -> dict[str, Any]:
         data = app_yaml_data()
         data["apps"]["app1"]["sockets"] = {"socket1": {**kwargs}}
         return data

--- a/tests/unit/parts/test_setup_assets.py
+++ b/tests/unit/parts/test_setup_assets.py
@@ -17,7 +17,7 @@
 import shutil
 import textwrap
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import call
 
 import pytest
@@ -53,7 +53,7 @@ def desktop_file():
 
 @pytest.fixture
 def yaml_data():
-    def _yaml_data(extra_data: Dict[str, Any]) -> Dict[str, Any]:
+    def _yaml_data(extra_data: dict[str, Any]) -> dict[str, Any]:
         return {
             "name": "test-project",
             "base": "core22",

--- a/tests/unit/parts/test_update_metadata.py
+++ b/tests/unit/parts/test_update_metadata.py
@@ -16,7 +16,7 @@
 
 import textwrap
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -63,7 +63,7 @@ def appstream_file(new_dir):
 
 @pytest.fixture
 def project_yaml_data():
-    def yaml_data(extra_args: Dict[str, Any]):
+    def yaml_data(extra_args: dict[str, Any]):
         return {
             "name": "name",
             "summary": "summary",
@@ -82,7 +82,7 @@ def project_yaml_data():
     yield yaml_data
 
 
-def _project_app(data: Dict[str, Any]) -> App:
+def _project_app(data: dict[str, Any]) -> App:
     return App(**data)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,7 +16,6 @@
 
 import os
 from pathlib import Path
-from typing import List
 from unittest.mock import call, patch
 
 import pytest
@@ -229,7 +228,7 @@ def fake_exists(mocker):
     class _FileCheck:
         def __init__(self) -> None:
             self._original_exists = os.path.exists
-            self.paths: List[str] = []
+            self.paths: list[str] = []
 
         def exists(self, path: str) -> bool:
             if Path(path) in self.paths:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

This PR some style modernizations for Snapcraft.  

The 2 large commits are entirely machine-generated changes using:
```
# PEP 585
ruff check --select UP006 snapcraft snapcraft_legacy/ tests/unit/ tests/legacy/ --fix  && make format
# PEP 604
ruff check --select UP007 snapcraft snapcraft_legacy/ tests/unit/ tests/legacy/ --fix && make format
```

There is one hand-written commit where mypy was confused by type-hints in a comment.

There are more opportunities for improvement with `--unsafe-fix` and other related rules but I decided to keep this tightly scoped.

Handy links:
* [UP006](https://docs.astral.sh/ruff/rules/non-pep585-annotation/)
* [UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/)
* [PEP 585](https://peps.python.org/pep-0585/)
* [PEP 604](https://peps.python.org/pep-0604/)
