### PR TITLE
chore(rtd): switch to extensionless URLs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF


### PR DESCRIPTION
Urgent bug fix.

Force Sphinx to remove `.html` extension from page URLs.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
