### PR TITLE
fix: properly quote environment variables in crystal plugin

### DIFF
--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -117,6 +117,7 @@ The following issues have been resolved in Snapcraft 8.7:
   using the KDE Neon 6 extension.
 - `#5340`_ Always show deprecation warnings for ``snapcraft list`` and
   ``snapcraft list-registered`` commands.
+- `#5330`_ Properly quote environment variables when using the Crystal plugin.
 - `craft-parts#978`_ The ``source-subdir`` field was ignored for the
   :ref:`Go Use plugin<craft_parts_go_use_plugin>`.
 - `craft-parts#991`_ Classic snaps using the
@@ -149,6 +150,7 @@ and :literalref:`@sergio-costas<https://github.com/sergio-costas>`
 .. _#5250: https://github.com/canonical/snapcraft/pull/5250
 .. _#5258: https://github.com/canonical/snapcraft/pull/5258
 .. _#5340: https://github.com/canonical/snapcraft/pull/5340
+.. _#5330: https://github.com/canonical/snapcraft/issues/5330
 .. _craft-application#600: https://github.com/canonical/craft-application/issues/600
 .. _craft-application#618: https://github.com/canonical/craft-application/issues/618
 .. _craft-application#619: https://github.com/canonical/craft-application/issues/619

--- a/snapcraft_legacy/plugins/v2/crystal.py
+++ b/snapcraft_legacy/plugins/v2/crystal.py
@@ -98,9 +98,11 @@ class CrystalPlugin(PluginV2):
 
         # Make sure snap-related environment variables survive through the shell call
         # Filter environment variables for only the ones beginning with "SNAP"
-        snap_dict = {key: os.environ[key] for key in os.environ if key.startswith("SNAP")}
+        snap_dict = {
+            key: os.environ[key] for key in os.environ if key.startswith("SNAP")
+        }
         env = dict(LANG="C.UTF-8", LC_ALL="C.UTF-8", **snap_dict)
-        env_flags = [f"{key}={value}" for key, value in env.items()]
+        env_flags = [f"{key}={shlex.quote(value)}" for key, value in env.items()]
 
         return [
             f"shards build --without-development {build_options}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Closes #5330.