### PR TITLE
fix: give `list` and `list-registered` commands permanent deprecation warnings

### DIFF
--- a/snapcraft/commands/names.py
+++ b/snapcraft/commands/names.py
@@ -186,17 +186,12 @@ class StoreLegacyListCommand(StoreNamesCommand):
 
     @overrides
     def run(self, parsed_args):
-        emit.progress("This command is deprecated: use 'names' instead")
+        emit.progress("This command is deprecated: use 'names' instead", permanent=True)
         super().run(parsed_args)
 
 
-class StoreLegacyListRegisteredCommand(StoreNamesCommand):
+class StoreLegacyListRegisteredCommand(StoreLegacyListCommand):
     """Legacy command to list the snap names registered with the current account."""
 
     name = "list-registered"
     hidden = True
-
-    @overrides
-    def run(self, parsed_args):
-        emit.progress("This command is deprecated: use 'names' instead")
-        super().run(parsed_args)

--- a/tests/unit/commands/test_names.py
+++ b/tests/unit/commands/test_names.py
@@ -217,7 +217,9 @@ class TestNames:
         )
 
         if command_class.hidden:
-            emitter.assert_progress("This command is deprecated: use 'names' instead")
+            emitter.assert_progress(
+                "This command is deprecated: use 'names' instead", permanent=True
+            )
         emitter.assert_message(
             dedent(
                 """\
@@ -241,7 +243,10 @@ class TestNames:
         )
 
         if command_class.hidden:
-            emitter.assert_progress("This command is deprecated: use 'names' instead")
+            emitter.assert_progress(
+                "This command is deprecated: use 'names' instead",
+                permanent=True,
+            )
 
         emitter.assert_message(
             json.dumps(


### PR DESCRIPTION
Fixes #5340

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
