### PR TITLE
docs: add 'disable a linter'

### DIFF
--- a/docs/how-to/debug/disable-a-linter.rst
+++ b/docs/how-to/debug/disable-a-linter.rst
@@ -1,0 +1,38 @@
+.. _how-to-disable-a-linter:
+
+Disable a linter
+================
+
+You can disable a :ref:`linter <reference-linters>` for a snap by listing it in the
+``lint.ignore`` key.
+
+For example, to disable both built-in linters, add this to your project file:
+
+.. code-block:: yaml
+    :caption: snapcraft.yaml
+
+    lint:
+      ignore:
+        - classic
+        - library
+
+
+Ignore specific files
+---------------------
+
+To disable a linter for a specific file, you can list it under a linter's entry in the
+``lint.ignore`` key. The path is relative to the snap directory tree, and supports
+wildcard characters (*).
+
+In the following example, the ``classic`` linter is disabled entirely, and the
+``library`` linter won't run for the files in ``usr/lib`` that match the specified
+pattern:
+
+.. code-block:: yaml
+    :caption: snapcraft.yaml
+
+    lint:
+      ignore:
+        - classic
+        - library:
+          - usr/lib/**/libfoo.so*

--- a/docs/how-to/debug/index.rst
+++ b/docs/how-to/debug/index.rst
@@ -5,3 +5,5 @@ Debug a snap
 
 .. toctree::
     :hidden:
+
+    disable-a-linter

--- a/docs/how-to/debug/index.rst
+++ b/docs/how-to/debug/index.rst
@@ -1,0 +1,7 @@
+.. _how-to-debug:
+
+Debug a snap
+============
+
+.. toctree::
+    :hidden:

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -10,6 +10,7 @@ How-to guides
    select-a-build-provider
    Craft <craft/index>
    Publish <publish/index>
+   Debug <debug/index>
    architectures
    bases
    components

--- a/docs/reference/linters.rst
+++ b/docs/reference/linters.rst
@@ -3,60 +3,24 @@
 Linters
 =======
 
-A *linter* is an analysis tool that checks for common errors or compatibility
-issues, usually automatically, or as part of some other process.
+A *linter* is an analysis tool that checks for common errors or compatibility issues,
+usually automatically, or as part of some other process.
 
-Snapcraft 7.2 and higher provides built-in linter functionality when the snap
-uses core22 or higher as its :doc:`base </reference/bases>`.
+Snapcraft 7.2 and higher provides built-in linter functionality when the snap uses
+core22 or higher as its :doc:`base </reference/bases>`.
 
-By default, these built-in linters run automatically when a snap is built. If
-they're unneeded, you can disable them in the snap's project file.
+By default, these built-in linters run automatically when a snap is built. If they're
+unneeded, you can disable them in the snap's project file.
 
 Built-in linters
------------------
+----------------
 
 Snapcraft runs the following linters:
 
-- `classic`_. Verifies binary file parameters for snaps using
-  `classic confinement`_.
+- `classic`_. Verifies binary file parameters for snaps using `classic confinement`_.
 
-- `library`_. Verifies that no ELF file dependencies, such as libraries, are
-  missing, and that no extra libraries are included in the snap package.
-
-Disable a linter
-----------------
-
-You can disable a linter by adding it to the ``lint.ignore`` key in
-the project file. For example:
-
-.. code-block:: yaml
-    :caption: snapcraft.yaml
-
-    lint:
-      ignore:
-        - classic
-        - library
-
-
-Ignore specific files
-~~~~~~~~~~~~~~~~~~~~~
-
-To disable a linter for a specific file, you can list it under a linter's entry
-in the ``lint.ignore`` key. The path is relative to the snap directory tree,
-and supports wildcard characters (**\***).
-
-In the following example, the ``classic`` linter is disabled entirely, and the
-``library`` linter won't run for the files in ``usr/lib`` that match the
-specified pattern:
-
-.. code-block:: yaml
-    :caption: snapcraft.yaml
-
-    lint:
-      ignore:
-        - classic
-        - library:
-          - usr/lib/**/libfoo.so*
+- `library`_. Verifies that no ELF file dependencies, such as libraries, are missing,
+  and that no extra libraries are included in the snap package.
 
 
 .. _classic: https://snapcraft.io/docs/linters-classic


### PR DESCRIPTION
Part of the migration effort, but this one involved moving a section out of a page already migrated.


---
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?