### PR TITLE
fix(remote): error early for invalid platform usage

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -109,7 +109,7 @@ The second mode of operation is when there isn't a ``platforms`` or
 ``architectures`` key in the project file. In this scenario, ``--build-for``
 defines the architectures to build for.
 
-Launchpad can't parse shorthand :docs:`platforms </reference/architectures>` in
+Launchpad can't parse shorthand :doc:`platforms </reference/architectures>` in
 the project file when ``--build-for`` is provided (`LP#2077005`_,
 `LP#2098811`_). For example, ``--build-for`` can't be used with the following
 project file can't be used:

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -112,7 +112,7 @@ defines the architectures to build for.
 Launchpad can't parse shorthand :doc:`platforms </reference/architectures>` in
 the project file when ``--build-for`` is provided (`LP#2077005`_,
 `LP#2098811`_). For example, ``--build-for`` can't be used with the following
-project file can't be used:
+project file:
 
 .. code-block:: yaml
     :caption: snapcraft.yaml

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -120,7 +120,6 @@ project file can't be used:
     platforms:
       amd64:
       riscv64:
-```
 
 To use ``--build-for``, expand the platforms entries so that the project file
 can be parsed by Launchpad:
@@ -135,7 +134,6 @@ can be parsed by Launchpad:
       riscv64:
         build-on: [riscv64]
         build-for: [riscv64]
-```
 
 ``--launchpad-accept-public-upload``
 ************************************

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -109,6 +109,34 @@ The second mode of operation is when there isn't a ``platforms`` or
 ``architectures`` key in the project file. In this scenario, ``--build-for``
 defines the architectures to build for.
 
+Launchpad can't parse shorthand :docs:`platforms </reference/architectures>` in
+the project file when ``--build-for`` is provided (`LP#2077005`_,
+`LP#2098811`_). For example, ``--build-for`` can't be used with the following
+project file can't be used:
+
+.. code-block:: yaml
+    :caption: snapcraft.yaml
+
+    platforms:
+      amd64:
+      riscv64:
+```
+
+To use ``--build-for``, expand the platforms entries so that the project file
+can be parsed by Launchpad:
+
+.. code-block:: yaml
+    :caption: snapcraft.yaml
+
+    platforms:
+      amd64:
+        build-on: [amd64]
+        build-for: [amd64]
+      riscv64:
+        build-on: [riscv64]
+        build-for: [riscv64]
+```
+
 ``--launchpad-accept-public-upload``
 ************************************
 
@@ -219,3 +247,5 @@ Launchpad is not able to parse this notation (`LP#2042167`_).
 .. _`#4885`: https://github.com/canonical/snapcraft/issues/4885
 .. _`#4996`: https://github.com/canonical/snapcraft/issues/4996
 .. _`#4995`: https://github.com/canonical/snapcraft/issues/4995
+.. _`LP#2077005`: https://bugs.launchpad.net/snapcraft/+bug/2077005
+.. _`LP#2098811`: https://bugs.launchpad.net/snapcraft/+bug/2098811

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -43,7 +43,7 @@ Current
 
 The current remote builder is available for ``core22``, ``core24``,
 and newer snaps.  It is not available for ``core20`` snaps because it cannot
-parse ``core20``'s ``snapcraft.yaml`` schema (`[10]`_).
+parse ``core20``'s ``snapcraft.yaml`` schema (`#4885`_).
 
 It does not modify the project or project metadata.
 
@@ -145,19 +145,19 @@ Snapcraft will request a build for each unique ``build-for`` architecture.
 
 .. note::
 
-   Launchpad does not support cross-compiling (`[13]`_).
+   Launchpad does not support cross-compiling (`#4996`_).
 
 .. note::
 
     Launchpad does not support building multiple snaps on the same
-    ``build-on`` architecture (`[14]`_).
+    ``build-on`` architecture (`#4995`_).
 
 If the project metadata does not contain a ``platforms`` or ``architectures``
 entry and ``--build-for`` is not provided, Snapcraft will request a build on,
 and for, the host's architecture.
 
 The remote builder does not work for ``core20`` snaps because it cannot parse
-the ``run-on`` key in a ``core20`` architecture entry (`[2]`_).
+the ``run-on`` key in a ``core20`` architecture entry (`#4842`_).
 
 Legacy
 ^^^^^^
@@ -186,7 +186,7 @@ key, snapcraft will request a build for each ``build-on`` architecture.
 
 An architecture can only be listed once across all ``build-on`` keys in the
 ``architectures`` key, otherwise Snapcraft will fail to parse the
-project (`[4]`_).
+project (`#4341`_).
 
 If no architectures are defined in the project metadata, snapcraft will
 request a build for the host's architecture.
@@ -194,28 +194,28 @@ request a build for the host's architecture.
 ``--build-for`` and ``--build-on`` cannot be provided when the
 ``architectures`` key is defined in the project metadata. This is because
 Launchpad will ignore the requested architectures and prefer those defined
-in the project file (`[5]`_).
+in the project file (`LP#1885150`_).
 
 The legacy remote builder can be used for ``core20`` and ``core22`` snaps but
 the project is parsed using ``core20``'s ``snapcraft.yaml`` schema. This
 means that snaps using keys introduced in ``core22`` cannot be built with
-the remote builder (`[6]`_ `[7]`_ `[8]`_). This includes the ``core22``
+the remote builder (`#4144`_ `LP#1992557`_ `LP#2007789`_). This includes the ``core22``
 ``architectures`` key change of ``run-on`` to ``build-for``.
 
 Similarly, ``core22`` supports a shorthand notation for ``architectures`` but
-Launchpad is not able to parse this notation (`[9]`_).
+Launchpad is not able to parse this notation (`LP#2042167`_).
 
 .. _`Launchpad account`: https://launchpad.net/+login
 .. _`Launchpad project`: https://launchpad.net/projects/+new
 .. _`Launchpad`: https://launchpad.net/
 .. _`build farm`: https://launchpad.net/builders
-.. _`[2]`: https://github.com/canonical/snapcraft/issues/4842
-.. _`[4]`: https://github.com/canonical/snapcraft/issues/4341
-.. _`[5]`: https://bugs.launchpad.net/snapcraft/+bug/1885150
-.. _`[6]`: https://github.com/canonical/snapcraft/issues/4144
-.. _`[7]`: https://bugs.launchpad.net/snapcraft/+bug/1992557
-.. _`[8]`: https://bugs.launchpad.net/snapcraft/+bug/2007789
-.. _`[9]`: https://bugs.launchpad.net/snapcraft/+bug/2042167
-.. _`[10]`: https://github.com/canonical/snapcraft/issues/4885
-.. _`[13]`: https://github.com/canonical/snapcraft/issues/4996
-.. _`[14]`: https://github.com/canonical/snapcraft/issues/4995
+.. _`#4842`: https://github.com/canonical/snapcraft/issues/4842
+.. _`#4341`: https://github.com/canonical/snapcraft/issues/4341
+.. _`LP#1885150`: https://bugs.launchpad.net/snapcraft/+bug/1885150
+.. _`#4144`: https://github.com/canonical/snapcraft/issues/4144
+.. _`LP#1992557`: https://bugs.launchpad.net/snapcraft/+bug/1992557
+.. _`LP#2007789`: https://bugs.launchpad.net/snapcraft/+bug/2007789
+.. _`LP#2042167`: https://bugs.launchpad.net/snapcraft/+bug/2042167
+.. _`#4885`: https://github.com/canonical/snapcraft/issues/4885
+.. _`#4996`: https://github.com/canonical/snapcraft/issues/4996
+.. _`#4995`: https://github.com/canonical/snapcraft/issues/4995

--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -111,6 +111,9 @@ Fixed bugs and issues
 
 The following issues have been resolved in Snapcraft 8.7:
 
+- `#5270`_ The remote-builder gave an unfriendly error when using the
+  ``--build-for`` argument and shorthand :doc:`platforms </reference/architectures>`
+  entries in the project file.
 - `#5258`_ The Flutter plugin failed to install Flutter for ``core22`` and ``core24``
   snaps.
 - `#5250`_ Resources path for ``QtWebEngineProcess`` wasn't exported for snaps
@@ -148,6 +151,7 @@ and :literalref:`@sergio-costas<https://github.com/sergio-costas>`
 
 .. _#4996: https://github.com/canonical/snapcraft/issues/4996
 .. _#5250: https://github.com/canonical/snapcraft/pull/5250
+.. _#5270: https://github.com/canonical/snapcraft/pull/5270
 .. _#5258: https://github.com/canonical/snapcraft/pull/5258
 .. _#5340: https://github.com/canonical/snapcraft/pull/5340
 .. _#5330: https://github.com/canonical/snapcraft/issues/5330

--- a/tests/spread/core24/remote-build/snaps/build-for-with-shorthand-platforms/arguments.txt
+++ b/tests/spread/core24/remote-build/snaps/build-for-with-shorthand-platforms/arguments.txt
@@ -1,0 +1,1 @@
+--build-for amd64

--- a/tests/spread/core24/remote-build/snaps/build-for-with-shorthand-platforms/expected-failure.txt
+++ b/tests/spread/core24/remote-build/snaps/build-for-with-shorthand-platforms/expected-failure.txt
@@ -1,0 +1,1 @@
+Launchpad can't build snaps when using '--build-for' with a shorthand platforms entry in the project's snapcraft.yaml.

--- a/tests/spread/core24/remote-build/snaps/build-for-with-shorthand-platforms/snapcraft.yaml
+++ b/tests/spread/core24/remote-build/snaps/build-for-with-shorthand-platforms/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: build-for-with-platforms-core24
+base: core24
+version: "1.0"
+summary: Test snap for remote build
+description: Test snap for remote build
+
+grade: stable
+confinement: strict
+
+platforms:
+  amd64:
+  s390x:
+  riscv64:
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/core24/remote-build/task.yaml
+++ b/tests/spread/core24/remote-build/task.yaml
@@ -13,6 +13,7 @@ environment:
   SNAP/no_platforms: no-platforms
   SNAP/build_for: build-for
   SNAP/build_for_with_platforms: build-for-with-platforms
+  SNAP/build_for_with_shorthand_platforms: build-for-with-shorthand-platforms
   CREDENTIALS_FILE: "$HOME/.local/share/snapcraft/launchpad-credentials"
   CREDENTIALS_FILE/new_credentials: "$HOME/.local/share/snapcraft/launchpad-credentials"
   CREDENTIALS_FILE/old_credentials: "$HOME/.local/share/snapcraft/provider/launchpad/credentials"
@@ -55,24 +56,30 @@ execute: |
   if [[ -e "arguments.txt" ]]; then
     call_args=$(cat "arguments.txt")
   fi
-  
-  # shellcheck disable=SC2086
-  snapcraft remote-build --launchpad-accept-public-upload $call_args
 
-  find . -maxdepth 1 -name "*.snap" | MATCH ".snap"
+  if [[ -e "expected-failure.txt" ]]; then
+    # shellcheck disable=SC2086
+    snapcraft remote-build --launchpad-accept-public-upload $call_args 2>&1 | MATCH -f expected-failure.txt
 
-  # confirm the snaps with the expected architectures were built
-  while read -r expected_snap; do
-    if [[ ! -e $expected_snap ]]; then
-      echo "Could not find snap '$expected_snap'"
+  else
+    # shellcheck disable=SC2086
+    snapcraft remote-build --launchpad-accept-public-upload $call_args
+
+    find . -maxdepth 1 -name "*.snap" | MATCH ".snap"
+
+    # confirm the snaps with the expected architectures were built
+    while read -r expected_snap; do
+      if [[ ! -e $expected_snap ]]; then
+        echo "Could not find snap '$expected_snap'"
+        exit 1
+      fi
+    done < "expected-snaps.txt"
+
+    # confirm no other snaps were built
+    expected_number_of_snaps=$(wc -l < "expected-snaps.txt")
+    actual_number_of_snaps=$(find . -wholename "./*.snap" | wc -l)
+    if [[ $expected_number_of_snaps -ne $actual_number_of_snaps ]]; then
+      echo "Expected $expected_number_of_snaps to be built, but $actual_number_of_snaps were built."
       exit 1
     fi
-  done < "expected-snaps.txt"
-
-  # confirm no other snaps were built
-  expected_number_of_snaps=$(wc -l < "expected-snaps.txt")
-  actual_number_of_snaps=$(find . -wholename "./*.snap" | wc -l)
-  if [[ $expected_number_of_snaps -ne $actual_number_of_snaps ]]; then
-    echo "Expected $expected_number_of_snaps to be built, but $actual_number_of_snaps were built."
-    exit 1
   fi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Raises an early error if `--build-for` is used in combination with shorthand `platforms` entries in the project file.

Launchpad fails with an unfriendly error, so Snapcraft now fails early with a friendlier error.

This is designed so that it can be quickly removed once the upstream bug in Launchpad is resolved.

Remote build spread test: https://github.com/canonical/snapcraft/actions/runs/14045570296/job/39326652643

Fixes #5270
(CRAFT-4186) 