### PR TITLE
test: fix store tests

### DIFF
--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -60,7 +60,7 @@ Store validation sets
 
 .. include:: commands/store-validation-sets-commands.rst
 
-Store confdbs
-----------------
+Store confdb schemas
+--------------------
 
-.. include:: commands/store-confdbs-commands.rst
+.. include:: commands/store-confdbs-schemas-commands.rst

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -141,10 +141,10 @@ COMMAND_GROUPS = [
         ],
     ),
     craft_cli.CommandGroup(
-        "Store Confdbs",
+        "Store Confdb Schemas",
         [
-            commands.StoreEditConfdbsCommand,
-            commands.StoreListConfdbsCommand,
+            commands.StoreEditConfdbSchemaCommand,
+            commands.StoreListConfdbSchemasCommand,
         ],
     ),
     craft_cli.CommandGroup(

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -51,7 +51,7 @@ from .names import (
     StoreRegisterCommand,
 )
 from .plugins import ListPluginsCommand, PluginsCommand
-from .confdbs import StoreEditConfdbsCommand, StoreListConfdbsCommand
+from .confdb_schemas import StoreEditConfdbSchemaCommand, StoreListConfdbSchemasCommand
 from .remote import RemoteBuildCommand
 from .status import (
     StoreListRevisionsCommand,
@@ -75,7 +75,7 @@ __all__ = [
     "SnapCommand",
     "StoreCloseCommand",
     "StoreEditValidationSetsCommand",
-    "StoreEditConfdbsCommand",
+    "StoreEditConfdbSchemaCommand",
     "StoreExportLoginCommand",
     "StoreLegacyCreateKeyCommand",
     "StoreLegacyGatedCommand",
@@ -92,7 +92,7 @@ __all__ = [
     "StoreLegacyUploadMetadataCommand",
     "StoreLegacyValidateCommand",
     "StoreListRevisionsCommand",
-    "StoreListConfdbsCommand",
+    "StoreListConfdbSchemasCommand",
     "StoreListTracksCommand",
     "StoreLoginCommand",
     "StoreLogoutCommand",

--- a/snapcraft/commands/confdb_schemas.py
+++ b/snapcraft/commands/confdb_schemas.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Snapcraft Store Confdb Sets commands."""
+"""Snapcraft Store Confdb Schemas commands."""
 
 import argparse
 import textwrap
@@ -25,20 +25,20 @@ import craft_application.commands
 from snapcraft import const, services
 
 
-class StoreListConfdbsCommand(craft_application.commands.AppCommand):
-    """List confdbs."""
+class StoreListConfdbSchemasCommand(craft_application.commands.AppCommand):
+    """List confdb schemas."""
 
-    name = "list-confdbs"
-    help_msg = "List confdbs sets"
+    name = "list-confdb-schemas"
+    help_msg = "List confdb schemas"
     overview = textwrap.dedent(
         """
-        List all confdbs for the authenticated account.
+        List all confdb schemas for the authenticated account.
 
-        Shows the account ID, name, revision, and last modified date of each confdb.
+        Shows the account ID, name, revision, and last modified date of each confdb-schema.
 
-        If a name is provided, only the confdb with that name will be listed.
+        If a name is provided, only the confdb schema with that name will be listed.
 
-        Use the ``edit-confdbs`` command create and edit confdbs.
+        Use the ``edit-confdb-schema`` command create and edit confdb schemas.
         """
     )
     _services: services.SnapcraftServiceFactory  # type: ignore[reportIncompatibleVariableOverride]
@@ -50,7 +50,7 @@ class StoreListConfdbsCommand(craft_application.commands.AppCommand):
             metavar="name",
             required=False,
             type=str,
-            help="Name of the confdb to list",
+            help="Name of the confb schema to list",
         )
         parser.add_argument(
             "--format",
@@ -65,29 +65,29 @@ class StoreListConfdbsCommand(craft_application.commands.AppCommand):
 
     @override
     def run(self, parsed_args: "argparse.Namespace"):
-        self._services.confdbs.list_assertions(
+        self._services.confdb_schemas.list_assertions(
             name=parsed_args.name,
             output_format=parsed_args.format,
         )
 
 
-class StoreEditConfdbsCommand(craft_application.commands.AppCommand):
-    """Edit a confdbs set."""
+class StoreEditConfdbSchemaCommand(craft_application.commands.AppCommand):
+    """Edit a confdb schema."""
 
-    name = "edit-confdbs"
-    help_msg = "Edit or create a confdbs set"
+    name = "edit-confdb-schema"
+    help_msg = "Edit or create a confb-schema"
     overview = textwrap.dedent(
         """
-        Edit a confdbs set.
+        Edit a confdb schema.
 
-        If the confdbs set does not exist, then a new confdbs set will be created.
+        If the confdb schema does not exist, then a new confdb schema will be created.
 
         If a key name is not provided, the default key is used.
 
         The account ID of the authenticated account can be determined with the
         ``snapcraft whoami`` command.
 
-        Use the ``list-confdbs`` command to view existing confdbs.
+        Use the ``list-confdb-schemas`` command to view existing confdb schemas.
         """
     )
     _services: services.SnapcraftServiceFactory  # type: ignore[reportIncompatibleVariableOverride]
@@ -97,18 +97,18 @@ class StoreEditConfdbsCommand(craft_application.commands.AppCommand):
         parser.add_argument(
             "account_id",
             metavar="account-id",
-            help="The account ID of the confdbs set to edit",
+            help="The account ID of the confb schema to edit",
         )
         parser.add_argument(
-            "name", metavar="name", help="Name of the confdbs set to edit"
+            "name", metavar="name", help="Name of the confb schema to edit"
         )
         parser.add_argument(
-            "--key-name", metavar="key-name", help="Key used to sign the confdbs set"
+            "--key-name", metavar="key-name", help="Key used to sign the confb schema"
         )
 
     @override
     def run(self, parsed_args: "argparse.Namespace"):
-        self._services.confdbs.edit_assertion(
+        self._services.confdb_schemas.edit_assertion(
             name=parsed_args.name,
             account_id=parsed_args.account_id,
             key_name=parsed_args.key_name,

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -176,7 +176,7 @@ class StoreCredentialsUnauthorizedError(SnapcraftError):
 
 
 class SnapcraftAssertionError(SnapcraftError):
-    """Error raised when an assertion (validation or confdbs set) is invalid.
+    """Error raised when an assertion (validation set or confdb schema) is invalid.
 
     Not to be confused with Python's built-in AssertionError.
     """

--- a/snapcraft/models/__init__.py
+++ b/snapcraft/models/__init__.py
@@ -18,9 +18,9 @@
 from .assertions import (
     Assertion,
     EditableAssertion,
-    EditableConfdbAssertion,
-    Confdb,
-    ConfdbAssertion,
+    EditableConfdbSchemaAssertion,
+    ConfdbSchema,
+    ConfdbSchemaAssertion,
 )
 from .manifest import Manifest
 from .project import (
@@ -50,15 +50,15 @@ __all__ = [
     "ComponentProject",
     "ContentPlug",
     "EditableAssertion",
-    "EditableConfdbAssertion",
+    "EditableConfdbSchemaAssertion",
     "GrammarAwareProject",
     "Hook",
     "Lint",
     "Manifest",
     "Platform",
     "Project",
-    "Confdb",
-    "ConfdbAssertion",
+    "ConfdbSchema",
+    "ConfdbSchemaAssertion",
     "SnapcraftBuildPlanner",
     "Socket",
 ]

--- a/snapcraft/models/assertions.py
+++ b/snapcraft/models/assertions.py
@@ -53,7 +53,7 @@ def _to_string(data: Any) -> Any:
     return data
 
 
-class Confdb(models.CraftBaseModel):
+class ConfdbSchema(models.CraftBaseModel):
     """Access and data definitions for a specific facet of a snap or system."""
 
     request: str | None = None
@@ -70,16 +70,16 @@ class Confdb(models.CraftBaseModel):
 
 
 class Rules(models.CraftBaseModel):
-    """A list of confdbs for a particular view."""
+    """A list of confdb schemas for a particular view."""
 
-    rules: list[Confdb]
+    rules: list[ConfdbSchema]
 
 
-class EditableConfdbAssertion(models.CraftBaseModel):
-    """Subset of a confdbs assertion that can be edited by the user."""
+class EditableConfdbSchemaAssertion(models.CraftBaseModel):
+    """Subset of a confdb-schema assertion that can be edited by the user."""
 
     account_id: str
-    """Issuer of the confdb assertion and owner of the signing key."""
+    """Issuer of the confdb-schema assertion and owner of the signing key."""
 
     name: str
     revision: int | None = 0
@@ -95,13 +95,13 @@ class EditableConfdbAssertion(models.CraftBaseModel):
         return cast_dict_scalars_to_strings(self.marshal())
 
 
-class ConfdbAssertion(EditableConfdbAssertion):
-    """A full confdbs assertion containing editable and non-editable fields."""
+class ConfdbSchemaAssertion(EditableConfdbSchemaAssertion):
+    """A full confdb-schema assertion containing editable and non-editable fields."""
 
-    type: Literal["confdb"]
+    type: Literal["confdb-schema"]
 
     authority_id: str
-    """Issuer of the confdb assertion and owner of the signing key."""
+    """Issuer of the confdb-schema assertion and owner of the signing key."""
 
     timestamp: str
     """Timestamp of when the assertion was issued."""
@@ -113,16 +113,18 @@ class ConfdbAssertion(EditableConfdbAssertion):
     """Signing key ID."""
 
 
-class ConfdbsList(models.CraftBaseModel):
+class ConfdbSchemasList(models.CraftBaseModel):
     """A list of confdb assertions."""
 
-    confdb_list: list[ConfdbAssertion] = pydantic.Field(default_factory=list)
+    confdb_schema_list: list[ConfdbSchemaAssertion] = pydantic.Field(
+        default_factory=list
+    )
 
 
-# this will be a union for validation sets and confdbs once
+# this will be a union for validation sets and confdb schemas once
 # validation sets are migrated from the legacy codebase
-Assertion = ConfdbAssertion
+Assertion = ConfdbSchemaAssertion
 
-# this will be a union for editable validation sets and editable confdbs once
+# this will be a union for editable validation sets and editable confdb schemas once
 # validation sets are migrated from the legacy codebase
-EditableAssertion = EditableConfdbAssertion
+EditableAssertion = EditableConfdbSchemaAssertion

--- a/snapcraft/services/__init__.py
+++ b/snapcraft/services/__init__.py
@@ -21,7 +21,7 @@ from snapcraft.services.init import Init
 from snapcraft.services.lifecycle import Lifecycle
 from snapcraft.services.package import Package
 from snapcraft.services.provider import Provider
-from snapcraft.services.confdbs import Confdbs
+from snapcraft.services.confdbschemas import ConfdbSchemas
 from snapcraft.services.remotebuild import RemoteBuild
 from snapcraft.services.service_factory import (
     SnapcraftServiceFactory,
@@ -34,7 +34,7 @@ __all__ = [
     "Lifecycle",
     "Package",
     "Provider",
-    "Confdbs",
+    "ConfdbSchemas",
     "register_snapcraft_services",
     "RemoteBuild",
     "SnapcraftServiceFactory",

--- a/snapcraft/services/assertions.py
+++ b/snapcraft/services/assertions.py
@@ -273,7 +273,7 @@ class Assertion(base.AppService):
          If the assertion does not exist, a new assertion is created from a template.
 
         :param name: The name of the assertion to edit.
-        :param account_id: The account ID associated with the confdbs set.
+        :param account_id: The account ID associated with the confdb schema.
         :param key_name: Name of the key to sign the assertion.
         """
         yaml_data = self._get_yaml_data(name=name, account_id=account_id)

--- a/snapcraft/services/confdbschemas.py
+++ b/snapcraft/services/confdbschemas.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Service class for confdbs."""
+"""Service class for confdb schemas."""
 
 from __future__ import annotations
 
@@ -26,11 +26,11 @@ from craft_application.util import dump_yaml
 from snapcraft import models
 from snapcraft.services import Assertion
 
-_REGISTRY_SETS_TEMPLATE = textwrap.dedent(
+_CONFDB_SCHEMA_TEMPLATE = textwrap.dedent(
     """\
     account-id: {account_id}
-    name: {set_name}
-    # The revision for this confdbs set
+    name: {name}
+    # The revision for this confdb-schema
     # revision: {revision}
     {views}
     {body}
@@ -38,7 +38,7 @@ _REGISTRY_SETS_TEMPLATE = textwrap.dedent(
 )
 
 
-_REGISTRY_SETS_VIEWS_TEMPLATE = textwrap.dedent(
+_CONFDB_SCHEMA_VIEWS_TEMPLATE = textwrap.dedent(
     """\
     views:
       wifi-setup:
@@ -50,7 +50,7 @@ _REGISTRY_SETS_VIEWS_TEMPLATE = textwrap.dedent(
 )
 
 
-_REGISTRY_SETS_BODY_TEMPLATE = textwrap.dedent(
+_CONFDB_SCHEMA_BODY_TEMPLATE = textwrap.dedent(
     """\
     body: |-
       {
@@ -66,37 +66,37 @@ _REGISTRY_SETS_BODY_TEMPLATE = textwrap.dedent(
 )
 
 
-class Confdbs(Assertion):
-    """Service for interacting with confdbs."""
+class ConfdbSchemas(Assertion):
+    """Service for interacting with confdb schemas."""
 
     @property
     @override
     def _assertion_name(self) -> str:
-        return "confdbs set"
+        return "confdb-schema"
 
     @property
     @override
     def _editable_assertion_class(self) -> type[models.EditableAssertion]:
-        return models.EditableConfdbAssertion
+        return models.EditableConfdbSchemaAssertion
 
     @override
     def _get_assertions(self, name: str | None = None) -> list[models.Assertion]:
-        return self._store_client.list_confdbs(name=name)
+        return self._store_client.list_confdb_schemas(name=name)
 
     @override
     def _build_assertion(self, assertion: models.EditableAssertion) -> models.Assertion:
-        return self._store_client.build_confdbs(confdbs=assertion)
+        return self._store_client.build_confdb_schema(confdb_schema=assertion)
 
     @override
     def _post_assertion(self, assertion_data: bytes) -> models.Assertion:
-        return self._store_client.post_confdbs(confdbs_data=assertion_data)
+        return self._store_client.post_confdb_schema(confdb_schema_data=assertion_data)
 
     @override
     def _normalize_assertions(
         self, assertions: list[models.Assertion]
     ) -> tuple[list[str], list[list[Any]]]:
         headers = ["Account ID", "Name", "Revision", "When"]
-        confdbs = [
+        confdb_schema = [
             [
                 assertion.account_id,
                 assertion.name,
@@ -106,27 +106,27 @@ class Confdbs(Assertion):
             for assertion in assertions
         ]
 
-        return headers, confdbs
+        return headers, confdb_schema
 
     @override
     def _generate_yaml_from_model(self, assertion: models.Assertion) -> str:
-        return _REGISTRY_SETS_TEMPLATE.format(
+        return _CONFDB_SCHEMA_TEMPLATE.format(
             account_id=assertion.account_id,
             views=dump_yaml(
                 {"views": assertion.marshal().get("views")}, default_flow_style=False
             ),
             body=dump_yaml({"body": assertion.body}, default_flow_style=False),
-            set_name=assertion.name,
+            name=assertion.name,
             revision=assertion.revision,
         )
 
     @override
     def _generate_yaml_from_template(self, name: str, account_id: str) -> str:
-        return _REGISTRY_SETS_TEMPLATE.format(
+        return _CONFDB_SCHEMA_TEMPLATE.format(
             account_id=account_id,
-            views=_REGISTRY_SETS_VIEWS_TEMPLATE,
-            body=_REGISTRY_SETS_BODY_TEMPLATE,
-            set_name=name,
+            views=_CONFDB_SCHEMA_VIEWS_TEMPLATE,
+            body=_CONFDB_SCHEMA_BODY_TEMPLATE,
+            name=name,
             revision=1,
         )
 

--- a/snapcraft/services/service_factory.py
+++ b/snapcraft/services/service_factory.py
@@ -33,7 +33,7 @@ _SERVICES: dict[str, str] = {
     "lifecycle": "Lifecycle",
     "package": "Package",
     "remote_build": "RemoteBuild",
-    "confdbs": "Confdbs",
+    "confdb_schemas": "ConfdbSchemas",
 }
 
 
@@ -44,10 +44,10 @@ class SnapcraftServiceFactory(ServiceFactory):
     project: models.Project | None = None  # type: ignore[reportIncompatibleVariableOverride]
 
     if TYPE_CHECKING:
-        from services import Confdbs
+        from services import ConfdbSchemas
 
         # Allow static type check to report correct types for Snapcraft services
-        confdbs: Confdbs = None  # type: ignore[assignment]
+        confdb_schemas: ConfdbSchemas = None  # type: ignore[assignment]
 
 
 def register_snapcraft_services() -> None:

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -501,27 +501,29 @@ class LegacyStoreClientCLI:
         return Revisions.unmarshal(response.json())
 
     @staticmethod
-    def _unmarshal_confdbs_set(confdbs_data) -> models.ConfdbAssertion:
-        """Unmarshal a confdbs set.
+    def _unmarshal_confdb_schema(confdb_schema_data) -> models.ConfdbSchemaAssertion:
+        """Unmarshal a confdb schema.
 
-        :raises StoreAssertionError: If the confdbs set cannot be unmarshalled.
+        :raises StoreAssertionError: If the confdb schema cannot be unmarshalled.
         """
         try:
-            return models.ConfdbAssertion.unmarshal(confdbs_data)
+            return models.ConfdbSchemaAssertion.unmarshal(confdb_schema_data)
         except pydantic.ValidationError as err:
             raise errors.SnapcraftAssertionError(
-                message="Received invalid confdbs set from the store",
+                message="Received invalid confdb schema from the store",
                 # this is an unexpected failure that the user can't fix, so hide
                 # the response in the details
-                details=f"{format_pydantic_errors(err.errors(), file_name='confdbs set')}",
+                details=f"{format_pydantic_errors(err.errors(), file_name='confdb schema')}",
             ) from err
 
-    def list_confdbs(self, *, name: str | None = None) -> list[models.ConfdbAssertion]:
-        """Return a list of confdbs.
+    def list_confdb_schemas(
+        self, *, name: str | None = None
+    ) -> list[models.ConfdbSchemaAssertion]:
+        """Return a list of confdb schemas.
 
-        :param name: If specified, only list the confdb set with that name.
+        :param name: If specified, only list the confdb schema with that name.
         """
-        endpoint = f"{self._base_url}/api/v2/confdbs"
+        endpoint = f"{self._base_url}/api/v2/confdb-schemas"
         if name:
             endpoint += f"/{name}"
 
@@ -540,60 +542,62 @@ class LegacyStoreClientCLI:
                 # move body into model
                 assertion_data["headers"]["body"] = assertion_data.get("body")
 
-                assertion = self._unmarshal_confdbs_set(assertion_data["headers"])
+                assertion = self._unmarshal_confdb_schema(assertion_data["headers"])
                 confdb_assertions.append(assertion)
-                emit.debug(f"Parsed confdbs set: {assertion.model_dump_json()}")
+                emit.debug(f"Parsed confdb schema: {assertion.model_dump_json()}")
 
         return confdb_assertions
 
-    def build_confdbs(
-        self, *, confdbs: models.EditableConfdbAssertion
-    ) -> models.ConfdbAssertion:
-        """Build a confdbs set.
+    def build_confdb_schema(
+        self, *, confdb_schema: models.EditableConfdbSchemaAssertion
+    ) -> models.ConfdbSchemaAssertion:
+        """Build a confdb schema.
 
-        Sends an edited confdbs set to the store, which validates the data,
-        populates additional fields, and returns the confdbs set.
+        Sends an edited confdb schema to the store, which validates the data,
+        populates additional fields, and returns the confdb schema.
 
-        :param confdbs: The confdbs set to build.
+        :param confdb_schema: The confdb schema to build.
 
-        :returns: The built confdbs set.
+        :returns: The built confdb schema.
         """
         response = self.request(
             "POST",
-            f"{self._base_url}/api/v2/confdbs/build-assertion",
+            f"{self._base_url}/api/v2/confdb-schemas/build-assertion",
             headers={
                 "Content-Type": "application/json",
                 "Accept": "application/json",
             },
-            json=confdbs.marshal(),
+            json=confdb_schema.marshal(),
         )
 
-        assertion = self._unmarshal_confdbs_set(response.json())
-        emit.debug(f"Built confdbs set: {assertion.model_dump_json()}")
+        assertion = self._unmarshal_confdb_schema(response.json())
+        emit.debug(f"Built confdfb schema: {assertion.model_dump_json()}")
         return assertion
 
-    def post_confdbs(self, *, confdbs_data: bytes) -> models.ConfdbAssertion:
-        """Send a confdbs set to be published.
+    def post_confdb_schema(
+        self, *, confdb_schema_data: bytes
+    ) -> models.ConfdbSchemaAssertion:
+        """Send a confdb schema to be published.
 
-        :param confdbs_data: A signed confdbs set represented as bytes.
+        :param confdb_schema_data: A signed confdb schema represented as bytes.
 
         :returns: The published assertion.
         """
         response = self.request(
             "POST",
-            f"{self._base_url}/api/v2/confdbs",
+            f"{self._base_url}/api/v2/confdb-schemas",
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/x.ubuntu.assertion",
             },
-            data=confdbs_data,
+            data=confdb_schema_data,
         )
 
         assertions = response.json().get("assertions")
 
         if not assertions or len(assertions) != 1:
             raise errors.SnapcraftAssertionError(
-                message="Received invalid confdbs set from the store",
+                message="Received invalid confdb schema from the store",
                 # this is an unexpected failure that the user can't fix, so hide
                 # the response in the details
                 details=f"Received data: {assertions}",
@@ -602,8 +606,8 @@ class LegacyStoreClientCLI:
         # move body into model
         assertions[0]["headers"]["body"] = assertions[0]["body"]
 
-        assertion = self._unmarshal_confdbs_set(assertions[0]["headers"])
-        emit.debug(f"Published confdbs set: {assertion.model_dump_json()}")
+        assertion = self._unmarshal_confdb_schema(assertions[0]["headers"])
+        emit.debug(f"Published confdb schema: {assertion.model_dump_json()}")
         return assertion
 
 

--- a/tests/spread/store/basic-workflow/task.yaml
+++ b/tests/spread/store/basic-workflow/task.yaml
@@ -24,7 +24,7 @@ prepare: |
 
   # Do not change the test-snapcraft- prefix. Ensure that you
   # notify the store team if you need to use a different value when
-  # working with the production store.     
+  # working with the production store.
   name="test-snapcraft-$(shuf -i 1-1000000000 -n 1)"
   set_name "$SNAP/snapcraft.yaml" "${name}"
   set_grade "$SNAP/snapcraft.yaml" stable
@@ -76,7 +76,7 @@ execute: |
   # Status
   snapcraft status "${snap_name}"
   snapcraft status "${snap_name}" --track latest --arch amd64
-  
+
   # Progressive Release
   snapcraft release --progressive 50 "${snap_name}" 1 candidate
 
@@ -86,6 +86,6 @@ execute: |
   # List tracks
   snapcraft list-tracks "${snap_name}"
 
-  # Show metrics for a snap that we have registered in the past (empty metrics as no users!).
-  snapcraft metrics fun --format json --name installed_base_by_operating_system
-  snapcraft metrics fun --format table --name installed_base_by_operating_system
+  # Show metrics (empty metrics as no users!).
+  snapcraft metrics "${snap_name}" --format json --name installed_base_by_operating_system
+  snapcraft metrics "${snap_name}" --format table --name installed_base_by_operating_system

--- a/tests/spread/store/confdbs/editor.sh
+++ b/tests/spread/store/confdbs/editor.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-confdbs_file="$1"
+confdb_schema_file="$1"
 
 # flip-flop between 'access' being read and write
-if grep -q "^ *access:.*read" "$confdbs_file"; then
+if grep -q "^ *access:.*read" "$confdb_schema_file"; then
   access="write"
 else
   access="read"
 fi
 
-sed -i "s/^\([[:space:]]*\)access:.*/\1access: $access/g" "$confdbs_file"
+sed -i "s/^\([[:space:]]*\)access:.*/\1access: $access/g" "$confdb_schema_file"

--- a/tests/spread/store/confdbs/task.yaml
+++ b/tests/spread/store/confdbs/task.yaml
@@ -1,4 +1,4 @@
-summary: test the confdbs commands
+summary: test the confdb schema commands
 
 environment:
   SNAPCRAFT_ASSERTION_KEY: "$(HOST: echo ${SNAPCRAFT_ASSERTION_KEY})"
@@ -21,7 +21,7 @@ prepare: |
   gpg --homedir "$HOME/.snap/gnupg" --import <(echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode)
 
   snap install yq
-  # confdbs only available in edge
+  # confdb schemas only available in edge
   snap refresh snapd --edge
 
 execute: |
@@ -31,9 +31,9 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-confdbs "$(snapcraft whoami | yq .id)" testset --key-name testspreadkey
+  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name testspreadkey
 
-  snapcraft list-confdbs | MATCH testset
+  snapcraft list-confdb-schemas | MATCH testset
 
 restore: |
   rm -rf "$HOME/.snap/gnupg"

--- a/tests/spread/store/confdbs/task.yaml
+++ b/tests/spread/store/confdbs/task.yaml
@@ -31,7 +31,7 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name testspreadkey
+  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name test-staging-key
 
   snapcraft list-confdb-schemas | MATCH testset
 

--- a/tests/spread/store/validation-sets/task.yaml
+++ b/tests/spread/store/validation-sets/task.yaml
@@ -29,7 +29,7 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name testspreadkey
+  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name test-staging-key
 
   snapcraft list-validation-sets | MATCH testset
 

--- a/tests/unit/commands/test_confdb_schemas.py
+++ b/tests/unit/commands/test_confdb_schemas.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for confdbs commands."""
+"""Unit tests for confdb schema commands."""
 
 import sys
 
@@ -25,20 +25,22 @@ from snapcraft import application, const
 
 @pytest.fixture
 def mock_list_assertions(mocker):
-    return mocker.patch("snapcraft.services.confdbs.Confdbs.list_assertions")
+    return mocker.patch(
+        "snapcraft.services.confdbschemas.ConfdbSchemas.list_assertions"
+    )
 
 
 @pytest.fixture
 def mock_edit_assertion(mocker):
-    return mocker.patch("snapcraft.services.confdbs.Confdbs.edit_assertion")
+    return mocker.patch("snapcraft.services.confdbschemas.ConfdbSchemas.edit_assertion")
 
 
 @pytest.mark.usefixtures("memory_keyring")
 @pytest.mark.parametrize("output_format", const.OUTPUT_FORMATS)
 @pytest.mark.parametrize("name", [None, "test"])
-def test_list_confdbs(mocker, mock_list_assertions, output_format, name):
-    """Test `snapcraft list-confdbs`."""
-    cmd = ["snapcraft", "list-confdbs", "--format", output_format]
+def test_list_confdb_schemas(mocker, mock_list_assertions, output_format, name):
+    """Test `snapcraft list-confdb-schemas`."""
+    cmd = ["snapcraft", "list-confdb-schemas", "--format", output_format]
     if name:
         cmd.extend(["--name", name])
     mocker.patch.object(sys, "argv", cmd)
@@ -51,9 +53,9 @@ def test_list_confdbs(mocker, mock_list_assertions, output_format, name):
 
 @pytest.mark.usefixtures("memory_keyring")
 @pytest.mark.parametrize("name", [None, "test"])
-def test_list_confdbs_default_format(mocker, mock_list_assertions, name):
+def test_list_confdb_schemas_default_format(mocker, mock_list_assertions, name):
     """Default format is 'table'."""
-    cmd = ["snapcraft", "list-confdbs"]
+    cmd = ["snapcraft", "list-confdb-schemas"]
     if name:
         cmd.extend(["--name", name])
     mocker.patch.object(sys, "argv", cmd)
@@ -66,9 +68,9 @@ def test_list_confdbs_default_format(mocker, mock_list_assertions, name):
 
 @pytest.mark.parametrize("key_name", [None, "test-key"])
 @pytest.mark.usefixtures("memory_keyring")
-def test_edit_confdbs(key_name, mocker, mock_edit_assertion):
-    """Test `snapcraft edit-confdbs`."""
-    cmd = ["snapcraft", "edit-confdbs", "test-account-id", "test-name"]
+def test_edit_confdb_schemas(key_name, mocker, mock_edit_assertion):
+    """Test `snapcraft edit-confdb-schema`."""
+    cmd = ["snapcraft", "edit-confdb-schema", "test-account-id", "test-name"]
     if key_name:
         cmd.extend(["--key-name", key_name])
     mocker.patch.object(sys, "argv", cmd)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -541,11 +541,11 @@ def remote_build_service(default_factory, mocker):
 
 
 @pytest.fixture()
-def confdbs_service(default_factory, mocker):
+def confdb_schemas_service(default_factory, mocker):
     from snapcraft.application import APP_METADATA
-    from snapcraft.services import Confdbs
+    from snapcraft.services import ConfdbSchemas
 
-    service = Confdbs(app=APP_METADATA, services=default_factory)
+    service = ConfdbSchemas(app=APP_METADATA, services=default_factory)
     service._store_client = mocker.patch(
         "snapcraft.store.StoreClientCLI", autospec=True
     )
@@ -554,18 +554,18 @@ def confdbs_service(default_factory, mocker):
 
 
 @pytest.fixture()
-def fake_confdb_assertion():
-    """Returns a fake confdb assertion with required fields."""
-    from snapcraft.models import ConfdbAssertion
+def fake_confdb_schema_assertion():
+    """Returns a fake confdb-schema assertion with required fields."""
+    from snapcraft.models import ConfdbSchemaAssertion
 
-    def _fake_confdb_assertion(**kwargs) -> ConfdbAssertion:
-        return ConfdbAssertion.unmarshal(
+    def _fake_confdb_schema_assertion(**kwargs) -> ConfdbSchemaAssertion:
+        return ConfdbSchemaAssertion.unmarshal(
             {
                 "account_id": "test-account-id",
                 "authority_id": "test-authority-id",
                 "name": "test-confdb",
                 "timestamp": "2024-01-01T10:20:30Z",
-                "type": "confdb",
+                "type": "confdb-schema",
                 "views": {
                     "wifi-setup": {
                         "rules": [
@@ -581,7 +581,7 @@ def fake_confdb_assertion():
             }
         )
 
-    return _fake_confdb_assertion
+    return _fake_confdb_schema_assertion
 
 
 @pytest.fixture()

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -19,7 +19,11 @@
 
 import pytest
 
-from snapcraft.models import Confdb, ConfdbAssertion, EditableConfdbAssertion
+from snapcraft.models import (
+    ConfdbSchema,
+    ConfdbSchemaAssertion,
+    EditableConfdbSchemaAssertion,
+)
 from snapcraft.models.assertions import cast_dict_scalars_to_strings
 
 
@@ -55,18 +59,18 @@ def test_cast_dict_scalars_to_strings(input_dict, expected_dict):
     assert actual == expected_dict
 
 
-def test_confdb_defaults(check):
-    """Test default values of the Confdb model."""
-    confdb = Confdb.unmarshal({"storage": "test-storage"})
+def test_confdb_schema_defaults(check):
+    """Test default values of the ConfdbSchema model."""
+    confdb_schema = ConfdbSchema.unmarshal({"storage": "test-storage"})
 
-    check.is_none(confdb.request)
-    check.is_none(confdb.access)
-    check.is_none(confdb.content)
+    check.is_none(confdb_schema.request)
+    check.is_none(confdb_schema.access)
+    check.is_none(confdb_schema.content)
 
 
-def test_confdb_nested(check):
-    """Test that nested confdbs are supported."""
-    confdb = Confdb.unmarshal(
+def test_confdb_schema_nested(check):
+    """Test that nested confdb schemas are supported."""
+    confdb_schema = ConfdbSchema.unmarshal(
         {
             "request": "test-request",
             "storage": "test-storage",
@@ -81,18 +85,22 @@ def test_confdb_nested(check):
         }
     )
 
-    check.equal(confdb.request, "test-request")
-    check.equal(confdb.storage, "test-storage")
-    check.equal(confdb.access, "read")
+    check.equal(confdb_schema.request, "test-request")
+    check.equal(confdb_schema.storage, "test-storage")
+    check.equal(confdb_schema.access, "read")
     check.equal(
-        confdb.content,
-        [Confdb(request="nested-request", storage="nested-storage", access="write")],
+        confdb_schema.content,
+        [
+            ConfdbSchema(
+                request="nested-request", storage="nested-storage", access="write"
+            )
+        ],
     )
 
 
-def test_editable_confdb_assertion_defaults(check):
-    """Test default values of the EditableConfdbAssertion model."""
-    assertion = EditableConfdbAssertion.unmarshal(
+def test_editable_confdb_schema_assertion_defaults(check):
+    """Test default values of the EditableConfdbSchemaAssertion model."""
+    assertion = EditableConfdbSchemaAssertion.unmarshal(
         {
             "account_id": "test-account-id",
             "name": "test-confdb",
@@ -112,9 +120,9 @@ def test_editable_confdb_assertion_defaults(check):
     check.is_none(assertion.body)
 
 
-def test_editable_confdb_assertion_marshal_as_str():
+def test_editable_confdb_schema_assertion_marshal_as_str():
     """Cast all scalars to string when marshalling."""
-    assertion = EditableConfdbAssertion.unmarshal(
+    assertion = EditableConfdbSchemaAssertion.unmarshal(
         {
             "account_id": "test-account-id",
             "name": "test-confdb",
@@ -136,15 +144,15 @@ def test_editable_confdb_assertion_marshal_as_str():
     assert assertion_dict["revision"] == "10"
 
 
-def test_confdb_assertion_defaults(check):
-    """Test default values of the ConfdbAssertion model."""
-    assertion = ConfdbAssertion.unmarshal(
+def test_confdb_schema_assertion_defaults(check):
+    """Test default values of the ConfdbSchemaAssertion model."""
+    assertion = ConfdbSchemaAssertion.unmarshal(
         {
             "account_id": "test-account-id",
             "authority_id": "test-authority-id",
             "name": "test-confdb",
             "timestamp": "2024-01-01T10:20:30Z",
-            "type": "confdb",
+            "type": "confdb-schema",
             "views": {
                 "wifi-setup": {
                     "rules": [
@@ -165,16 +173,16 @@ def test_confdb_assertion_defaults(check):
     check.equal(assertion.revision, 0)
 
 
-def test_confdb_assertion_marshal_as_str():
+def test_confdb_schema_assertion_marshal_as_str():
     """Cast all scalars to strings when marshalling."""
-    assertion = ConfdbAssertion.unmarshal(
+    assertion = ConfdbSchemaAssertion.unmarshal(
         {
             "account_id": "test-account-id",
             "authority_id": "test-authority-id",
             "name": "test-confdb",
             "revision": 10,
             "timestamp": "2024-01-01T10:20:30Z",
-            "type": "confdb",
+            "type": "confdb-schema",
             "views": {
                 "wifi-setup": {
                     "rules": [

--- a/tests/unit/services/test_assertions.py
+++ b/tests/unit/services/test_assertions.py
@@ -200,7 +200,7 @@ def fake_assertion_service(default_factory):
 def test_list_assertions_table(fake_assertion_service, emitter):
     """List assertions as a table."""
     fake_assertion_service.list_assertions(
-        output_format=const.OutputFormat.table, name="test-registry"
+        output_format=const.OutputFormat.table, name="test-confb"
     )
 
     emitter.assert_message(
@@ -216,7 +216,7 @@ def test_list_assertions_table(fake_assertion_service, emitter):
 def test_list_assertions_json(fake_assertion_service, emitter):
     """List assertions as json."""
     fake_assertion_service.list_assertions(
-        output_format=const.OutputFormat.json, name="test-registry"
+        output_format=const.OutputFormat.json, name="test-confb"
     )
 
     emitter.assert_message(
@@ -244,7 +244,7 @@ def test_list_assertions_unknown_format(fake_assertion_service):
 
     with pytest.raises(errors.FeatureNotImplemented, match=expected):
         fake_assertion_service.list_assertions(
-            output_format="unknown", name="test-registry"
+            output_format="unknown", name="test-confb"
         )
 
 
@@ -269,7 +269,7 @@ def test_edit_assertions_changes_made(
 
     fake_assertion_service.setup()
     fake_assertion_service.edit_assertion(
-        name="test-registry", account_id="test-account-id", key_name="test-key"
+        name="test-confb", account_id="test-account-id", key_name="test-key"
     )
 
     mock_post_assertion.assert_called_once_with(expected_assertion)
@@ -288,7 +288,7 @@ def test_edit_assertions_no_changes_made(
     """Edit an assertion but make no changes to the data."""
     fake_assertion_service.setup()
     fake_assertion_service.edit_assertion(
-        name="test-registry", account_id="test-account-id"
+        name="test-confb", account_id="test-account-id"
     )
 
     emitter.assert_message("No changes made.")
@@ -335,7 +335,7 @@ def test_edit_assertions_build_assertion_error(
 
     fake_assertion_service.setup()
     fake_assertion_service.edit_assertion(
-        name="test-registry", account_id="test-account-id", key_name="test-key"
+        name="test-confb", account_id="test-account-id", key_name="test-key"
     )
 
     assert mock_confirm_with_user.mock_calls == [
@@ -381,7 +381,7 @@ def test_edit_assertions_sign_assertion_error(
 
     fake_assertion_service.setup()
     fake_assertion_service.edit_assertion(
-        name="test-registry", account_id="test-account-id", key_name="test-key"
+        name="test-confb", account_id="test-account-id", key_name="test-key"
     )
 
     assert mock_confirm_with_user.mock_calls == [
@@ -427,7 +427,7 @@ def test_edit_assertions_post_assertion_error(
 
     fake_assertion_service.setup()
     fake_assertion_service.edit_assertion(
-        name="test-registry", account_id="test-account-id", key_name="test-key"
+        name="test-confb", account_id="test-account-id", key_name="test-key"
     )
 
     assert mock_confirm_with_user.mock_calls == [

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -171,7 +171,7 @@ def list_revisions_payload():
 
 
 @pytest.fixture
-def list_confdbs_payload():
+def list_confdb_schemas_payload():
     return {
         "assertions": [
             {
@@ -183,7 +183,7 @@ def list_confdbs_payload():
                     "revision": "9",
                     "sign-key-sha3-384": "test-sign-key",
                     "timestamp": "2024-01-01T10:20:30Z",
-                    "type": "confdb",
+                    "type": "confdb-schema",
                     "views": {
                         "wifi-setup": {
                             "rules": [
@@ -203,7 +203,7 @@ def list_confdbs_payload():
 
 
 @pytest.fixture
-def build_confdbs_payload():
+def build_confdb_schema_payload():
     return {
         "account_id": "test-account-id",
         "authority_id": "test-authority-id",
@@ -221,13 +221,13 @@ def build_confdbs_payload():
             }
         },
         "body": '{\n  "storage": {\n    "schema": {\n      "wifi": {\n        "values": "any"\n      }\n    }\n  }\n}',
-        "type": "confdb",
+        "type": "confdb-schema",
         "timestamp": "2024-01-01T10:20:30Z",
     }
 
 
 @pytest.fixture
-def post_confdbs_payload():
+def post_confdb_schema_payload():
     return {
         "assertions": [
             {
@@ -239,7 +239,7 @@ def post_confdbs_payload():
                     "revision": "10",
                     "sign-key-sha3-384": "test-key",
                     "timestamp": "2024-01-01T10:20:30Z",
-                    "type": "confdb",
+                    "type": "confdb-schema",
                     "views": {
                         "wifi-setup": {
                             "rules": [
@@ -1117,25 +1117,25 @@ def test_list_revisions(fake_client, list_revisions_payload):
     ]
 
 
-################
-# List Confdbs #
-################
+#######################
+# List Confdb Schemas #
+#######################
 
 
 @pytest.mark.parametrize("name", [None, "test-confdb"])
-def test_list_confdbs(name, fake_client, list_confdbs_payload, check):
-    """Test the list confdbs endpoint."""
+def test_list_confdb_schemas(name, fake_client, list_confdb_schemas_payload, check):
+    """Test the list confdb schemas endpoint."""
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(list_confdbs_payload).encode()
+        status_code=200, content=json.dumps(list_confdb_schemas_payload).encode()
     )
 
-    confdbs = client.StoreClientCLI().list_confdbs(name=name)
+    confdb_schemas = client.StoreClientCLI().list_confdb_schemas(name=name)
 
-    check.is_instance(confdbs, list)
-    for confdb in confdbs:
-        check.is_instance(confdb, models.ConfdbAssertion)
+    check.is_instance(confdb_schemas, list)
+    for confdb_schema in confdb_schemas:
+        check.is_instance(confdb_schema, models.ConfdbSchemaAssertion)
         check.equal(
-            confdb.body,
+            confdb_schema.body,
             '{\n  "storage": {\n    "schema": {\n      "wifi": {\n        '
             '"values": "any"\n      }\n    }\n  }\n}',
         )
@@ -1144,7 +1144,7 @@ def test_list_confdbs(name, fake_client, list_confdbs_payload, check):
         [
             call(
                 "GET",
-                f"https://dashboard.snapcraft.io/api/v2/confdbs{f'/{name}' if name else ''}",
+                f"https://dashboard.snapcraft.io/api/v2/confdb-schemas{f'/{name}' if name else ''}",
                 headers={
                     "Content-Type": "application/json",
                     "Accept": "application/json",
@@ -1154,21 +1154,21 @@ def test_list_confdbs(name, fake_client, list_confdbs_payload, check):
     )
 
 
-def test_list_confdbs_empty(fake_client, check):
-    """Test the list confdbs endpoint with no confdbs returned."""
+def test_list_confdb_schemas_empty(fake_client, check):
+    """Test the list confdb schemas endpoint with nothing returned."""
     fake_client.request.return_value = FakeResponse(
         status_code=200, content=json.dumps({"assertions": []}).encode()
     )
 
-    confdbs = client.StoreClientCLI().list_confdbs()
+    confdb_schemas = client.StoreClientCLI().list_confdb_schemas()
 
-    check.equal(confdbs, [])
+    check.equal(confdb_schemas, [])
     check.equal(
         fake_client.request.mock_calls,
         [
             call(
                 "GET",
-                "https://dashboard.snapcraft.io/api/v2/confdbs",
+                "https://dashboard.snapcraft.io/api/v2/confdb-schemas",
                 headers={
                     "Content-Type": "application/json",
                     "Accept": "application/json",
@@ -1178,90 +1178,94 @@ def test_list_confdbs_empty(fake_client, check):
     )
 
 
-def test_list_confdbs_unmarshal_error(fake_client, list_confdbs_payload):
+def test_list_confdb_schemas_unmarshal_error(fake_client, list_confdb_schemas_payload):
     """Raise an error if the response cannot be unmarshalled."""
-    list_confdbs_payload["assertions"][0]["headers"].pop("name")
+    list_confdb_schemas_payload["assertions"][0]["headers"].pop("name")
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(list_confdbs_payload).encode()
+        status_code=200, content=json.dumps(list_confdb_schemas_payload).encode()
     )
 
     with pytest.raises(errors.SnapcraftAssertionError) as raised:
-        client.StoreClientCLI().list_confdbs()
+        client.StoreClientCLI().list_confdb_schemas()
 
-    assert str(raised.value) == "Received invalid confdbs set from the store"
+    assert str(raised.value) == "Received invalid confdb schema from the store"
     assert raised.value.details == (
-        "Bad confdbs set content:\n- field 'name' required in top-level configuration"
+        "Bad confdb schema content:\n- field 'name' required in top-level configuration"
     )
 
 
-#################
-# Build Confdbs #
-#################
+#######################
+# Build Confdb Schema #
+#######################
 
 
-def test_build_confdbs(fake_client, build_confdbs_payload):
-    """Test the build confdbs endpoint."""
-    mock_confdbs = Mock(spec=models.ConfdbAssertion)
-    expected_confdbs = models.ConfdbAssertion(**build_confdbs_payload)
+def test_build_confdb_schema(fake_client, build_confdb_schema_payload):
+    """Test the build confdb schema endpoint."""
+    mock_confdb_schema = Mock(spec=models.ConfdbSchemaAssertion)
+    expected_confdb_schema = models.ConfdbSchemaAssertion(**build_confdb_schema_payload)
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(build_confdbs_payload).encode()
+        status_code=200, content=json.dumps(build_confdb_schema_payload).encode()
     )
 
-    confdbs_set = client.StoreClientCLI().build_confdbs(confdbs=mock_confdbs)
+    confdb_schema = client.StoreClientCLI().build_confdb_schema(
+        confdb_schema=mock_confdb_schema
+    )
 
-    assert confdbs_set == expected_confdbs
+    assert confdb_schema == expected_confdb_schema
     assert fake_client.request.mock_calls == [
         call(
             "POST",
-            "https://dashboard.snapcraft.io/api/v2/confdbs/build-assertion",
+            "https://dashboard.snapcraft.io/api/v2/confdb-schemas/build-assertion",
             headers={
                 "Content-Type": "application/json",
                 "Accept": "application/json",
             },
-            json=mock_confdbs.marshal(),
+            json=mock_confdb_schema.marshal(),
         )
     ]
 
 
-def test_build_confdbs_unmarshal_error(fake_client, build_confdbs_payload):
+def test_build_confdb_schema_unmarshal_error(fake_client, build_confdb_schema_payload):
     """Raise an error if the response cannot be unmarshalled."""
-    mock_confdbs = Mock(spec=models.ConfdbAssertion)
-    build_confdbs_payload.pop("name")
+    mock_confdb_schema = Mock(spec=models.ConfdbSchemaAssertion)
+    build_confdb_schema_payload.pop("name")
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(build_confdbs_payload).encode()
+        status_code=200, content=json.dumps(build_confdb_schema_payload).encode()
     )
 
     with pytest.raises(errors.SnapcraftAssertionError) as raised:
-        client.StoreClientCLI().build_confdbs(confdbs=mock_confdbs)
+        client.StoreClientCLI().build_confdb_schema(confdb_schema=mock_confdb_schema)
 
-    assert str(raised.value) == "Received invalid confdbs set from the store"
+    assert str(raised.value) == "Received invalid confdb schema from the store"
     assert raised.value.details == (
-        "Bad confdbs set content:\n- field 'name' required in top-level configuration"
+        "Bad confdb schema content:\n- field 'name' required in top-level configuration"
     )
 
 
-################
-# Post Confdbs #
-################
+######################
+# Post Confdb Schema #
+######################
 
 
-def test_post_confdbs(fake_client, post_confdbs_payload):
-    """Test the post confdbs endpoint."""
-    expected_confdbs = models.ConfdbAssertion(
-        **post_confdbs_payload["assertions"][0]["headers"],
-        body=post_confdbs_payload["assertions"][0]["body"],
+def test_post_confdb_schema(fake_client, post_confdb_schema_payload):
+    """Test the post confdb schema endpoint."""
+    expected_confdb_schema = models.ConfdbSchemaAssertion(
+        **post_confdb_schema_payload["assertions"][0]["headers"],
+        body=post_confdb_schema_payload["assertions"][0]["body"],
     )
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(post_confdbs_payload).encode()
+        status_code=200, content=json.dumps(post_confdb_schema_payload).encode()
     )
 
-    confdbs_set = client.StoreClientCLI().post_confdbs(confdbs_data=b"test-data")
+    confdb_schema = client.StoreClientCLI().post_confdb_schema(
+        confdb_schema_data=b"test-data"
+    )
 
-    assert confdbs_set == expected_confdbs
+    assert confdb_schema == expected_confdb_schema
     assert fake_client.request.mock_calls == [
         call(
             "POST",
-            "https://dashboard.snapcraft.io/api/v2/confdbs",
+            "https://dashboard.snapcraft.io/api/v2/confdb-schemas",
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/x.ubuntu.assertion",
@@ -1272,36 +1276,36 @@ def test_post_confdbs(fake_client, post_confdbs_payload):
 
 
 @pytest.mark.parametrize("num_assertions", [0, 2])
-def test_post_confdbs_wrong_payload_error(
-    num_assertions, fake_client, post_confdbs_payload
+def test_post_confdb_schema_wrong_payload_error(
+    num_assertions, fake_client, post_confdb_schema_payload
 ):
     """Error if the wrong number of assertions are returned."""
-    post_confdbs_payload["assertions"] = (
-        post_confdbs_payload["assertions"] * num_assertions
+    post_confdb_schema_payload["assertions"] = (
+        post_confdb_schema_payload["assertions"] * num_assertions
     )
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(post_confdbs_payload).encode()
+        status_code=200, content=json.dumps(post_confdb_schema_payload).encode()
     )
 
     with pytest.raises(errors.SnapcraftAssertionError) as raised:
-        client.StoreClientCLI().post_confdbs(confdbs_data=b"test-data")
+        client.StoreClientCLI().post_confdb_schema(confdb_schema_data=b"test-data")
 
-    assert str(raised.value) == "Received invalid confdbs set from the store"
+    assert str(raised.value) == "Received invalid confdb schema from the store"
 
 
-def test_post_confdbs_unmarshal_error(fake_client, post_confdbs_payload):
+def test_post_confdb_schema_unmarshal_error(fake_client, post_confdb_schema_payload):
     """Raise an error if the response cannot be unmarshalled."""
-    post_confdbs_payload["assertions"][0]["headers"].pop("name")
+    post_confdb_schema_payload["assertions"][0]["headers"].pop("name")
     fake_client.request.return_value = FakeResponse(
-        status_code=200, content=json.dumps(post_confdbs_payload).encode()
+        status_code=200, content=json.dumps(post_confdb_schema_payload).encode()
     )
 
     with pytest.raises(errors.SnapcraftAssertionError) as raised:
-        client.StoreClientCLI().post_confdbs(confdbs_data=b"test-data")
+        client.StoreClientCLI().post_confdb_schema(confdb_schema_data=b"test-data")
 
-    assert str(raised.value) == "Received invalid confdbs set from the store"
+    assert str(raised.value) == "Received invalid confdb schema from the store"
     assert raised.value.details == (
-        "Bad confdbs set content:\n- field 'name' required in top-level configuration"
+        "Bad confdb schema content:\n- field 'name' required in top-level configuration"
     )
 
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

All of snapcraft's secrets were re-provisioned from Sergio's credentials to mine and it broke some of the store tests.

This PR adjusts the tests and the secrets. 

 failing test                                     | fix                                                                        |
| -------------------------------------------- | ---------------------------------------------------------------------------- |
| tests/spread/store/basic-workflow:candid | use the testing snap for `snapcraft metrics`                                                                 |
| tests/spread/store/basic-workflow:legacy     | use base64 encoding for the credentials       |
| tests/spread/store/basic-workflow:ubuntu_one | use the testing snap for `snapcraft metrics`                                                                  |
| tests/spread/store/confdbs                   |  use a new key registered on the staging store                                                         |
| tests/spread/store/validation-sets           | use a new key registered on the staging store |


Needs #5356 to land first
(CRAFT-4419)