### PR TITLE
test(spread): update store tests

### DIFF
--- a/tests/spread/store/basic-workflow/task.yaml
+++ b/tests/spread/store/basic-workflow/task.yaml
@@ -24,7 +24,7 @@ prepare: |
 
   # Do not change the test-snapcraft- prefix. Ensure that you
   # notify the store team if you need to use a different value when
-  # working with the production store.     
+  # working with the production store.
   name="test-snapcraft-$(shuf -i 1-1000000000 -n 1)"
   set_name "$SNAP/snapcraft.yaml" "${name}"
   set_grade "$SNAP/snapcraft.yaml" stable
@@ -76,7 +76,7 @@ execute: |
   # Status
   snapcraft status "${snap_name}"
   snapcraft status "${snap_name}" --track latest --arch amd64
-  
+
   # Progressive Release
   snapcraft release --progressive 50 "${snap_name}" 1 candidate
 
@@ -86,6 +86,6 @@ execute: |
   # List tracks
   snapcraft list-tracks "${snap_name}"
 
-  # Show metrics for a snap that we have registered in the past (empty metrics as no users!).
-  snapcraft metrics fun --format json --name installed_base_by_operating_system
-  snapcraft metrics fun --format table --name installed_base_by_operating_system
+  # Show metrics (empty metrics as no users!).
+  snapcraft metrics "${snap_name}" --format json --name installed_base_by_operating_system
+  snapcraft metrics "${snap_name}" --format table --name installed_base_by_operating_system

--- a/tests/spread/store/confdbs/task.yaml
+++ b/tests/spread/store/confdbs/task.yaml
@@ -31,7 +31,7 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name testspreadkey
+  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name test-staging-key
 
   snapcraft list-confdb-schemas | MATCH testset
 

--- a/tests/spread/store/validation-sets/task.yaml
+++ b/tests/spread/store/validation-sets/task.yaml
@@ -29,7 +29,7 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name testspreadkey
+  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name test-staging-key
 
   snapcraft list-validation-sets | MATCH testset
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Only the second commit needs to be reviewed (the tiny one).

All of snapcraft's secrets were re-provisioned from Sergio's credentials to mine and it broke some of the store tests.

This PR adjusts the tests and the secrets. 

| failing test                                     | fix                                                                        |
| -------------------------------------------- | ---------------------------------------------------------------------------- |
| tests/spread/store/basic-workflow:candid | use the testing snap for `snapcraft metrics`                                                                 |
| tests/spread/store/basic-workflow:legacy     | use base64 encoding for the credentials       |
| tests/spread/store/basic-workflow:ubuntu_one | use the testing snap for `snapcraft metrics`                          |
| tests/spread/store/confdbs                   |  use a new key registered on the staging store            |
| tests/spread/store/validation-sets           | use a new key registered on the staging store |

Needs #5356 
(CRAFT-4419)