### PR TITLE
docs: migrate library linting tips

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,6 @@ exclude_patterns = [
     "how-to/debug/debug-a-snap.rst",
     "how-to/debug/debug-with-gdb.rst",
     "how-to/debug/use-the-classic-linter.rst",
-    "how-to/debug/use-the-library-linter.rst",
     "how-to/publish/build-snaps-remotely.rst",
     "how-to/publish/gather-snap-metrics-and-statistics.rst",
     "how-to/publish/manage-releases.rst",

--- a/docs/how-to/debug/index.rst
+++ b/docs/how-to/debug/index.rst
@@ -7,3 +7,4 @@ Debug a snap
     :hidden:
 
     disable-a-linter
+    use-the-library-linter

--- a/docs/how-to/debug/use-the-library-linter.rst
+++ b/docs/how-to/debug/use-the-library-linter.rst
@@ -12,6 +12,7 @@ To resolve an unused library:
 
 .. list-table::
    :header-rows: 1
+   :widths: 1 3
 
    * - Library type
      - Resolution

--- a/docs/how-to/debug/use-the-library-linter.rst
+++ b/docs/how-to/debug/use-the-library-linter.rst
@@ -3,4 +3,40 @@
 Use the library linter
 ======================
 
-.. copy "Fix flagged issues" section
+The following guidelines describe how to address issues flagged by the library linter.
+
+To resolve a missing dependency, add the missing package to the part's
+``stage-packages`` key.
+
+To resolve an unused library:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Library type
+     - Resolution
+
+   * - Dynamic linking
+     - If the ``stage-packages`` key of the part contains the unused library and no
+       other entries, remove the library from the key. If the library contains other
+       assets the snap needs, then instead move it to the part's ``stage`` key and
+       prefix it with a minus sign (``-``). It's then excluded from the stage step of
+       the build.
+
+   * - Static linking
+     - Static linking libraries must only be present at build time. So, the part should
+       list the libnrary in its ``build-packages`` key, not ``stage-packages``. Again,
+       if the library contains other necessary assets for the snap, then move it into
+       the part's ``stage`` key and prefix it with a minus sign (``-``).
+
+   * - Dynamic loading
+     - Snapcraft may falsely flag dynamic loading libraries as unused. In this case,
+       don't change its declaration in the recipe. Moving or removing it has a high risk
+       of causing your app to malfunction at runtime. Instead, list it in the
+       `lint.ignore.<linter> key <https://snapcraft.io/docs/linters>`_ to suppress the
+       warning for this library.
+
+
+See `Build and staging dependencies
+<https://snapcraft.io/docs/build-and-staging-dependencies>`_ for further details about
+the ``stage-packages`` key.


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Migrates the page at https://snapcraft.io/docs/linters-library under the "linter warnings" header.
CRAFT-4235.