### PR TITLE
test: fix extension tests

### DIFF
--- a/snapcraft/extensions/_utils.py
+++ b/snapcraft/extensions/_utils.py
@@ -33,9 +33,7 @@ def apply_extensions(yaml_data: dict[str, Any], *, arch: str, target_arch: str) 
     :param dict yaml_data: Loaded, unprocessed snapcraft.yaml
     :param arch: the host architecture.
     :param target_arch: the target architecture.
-    :returns: Modified snapcraft.yaml data with extensions applied
     """
-
     # Mapping of extension names to set of app names to which the extension needs to be
     # applied.
     declared_extensions: dict[str, set[str]] = collections.defaultdict(set)
@@ -66,6 +64,12 @@ def _apply_extension(
     app_names: set[str],
     extension: "Extension",
 ) -> None:
+    """Apply an extension to the YAML data, in place.
+
+    :param yaml_data: Loaded, unprocessed snapcraft.yaml.
+    :param app_names: The app names to which the extension should be applied.
+    :param extension: The extension to apply.
+    """
     # Apply the root components of the extension (if any)
     root_extension = extension.get_root_snippet()
     for property_name, property_value in root_extension.items():

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -21,7 +21,6 @@ from snapcraft import errors, extensions
 from snapcraft.extensions.extension import append_to_env, prepend_to_env
 
 
-@pytest.mark.xfail(strict=True, reason="returns None, needs investigation")
 @pytest.mark.usefixtures("fake_extension")
 def test_apply_extension():
     yaml_data = {
@@ -39,9 +38,9 @@ def test_apply_extension():
         "parts": {"fake-part": {"source": ".", "plugin": "dump"}},
     }
 
-    assert extensions.apply_extensions(
-        yaml_data, arch="amd64", target_arch="amd64"
-    ) == {
+    extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert yaml_data == {
         "name": "fake-snap",
         "summary": "fake summary",
         "description": "fake description",
@@ -64,7 +63,6 @@ def test_apply_extension():
     }
 
 
-@pytest.mark.xfail(strict=True, reason="Returns None, needs investigation")
 @pytest.mark.usefixtures("fake_extension")
 def test_apply_extension_plugin_dependent():
     yaml_data = {
@@ -85,9 +83,9 @@ def test_apply_extension_plugin_dependent():
         },
     }
 
-    assert extensions.apply_extensions(
-        yaml_data, arch="amd64", target_arch="amd64"
-    ) == {
+    extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert yaml_data == {
         "name": "fake-snap",
         "summary": "fake summary",
         "description": "fake description",
@@ -111,7 +109,6 @@ def test_apply_extension_plugin_dependent():
     }
 
 
-@pytest.mark.xfail(strict=True, reason="returns None, needs investigation")
 @pytest.mark.usefixtures("fake_extension")
 @pytest.mark.usefixtures("fake_extension_extra")
 def test_apply_multiple_extensions():
@@ -130,9 +127,9 @@ def test_apply_multiple_extensions():
         "parts": {"fake-part": {"source": ".", "plugin": "dump"}},
     }
 
-    assert extensions.apply_extensions(
-        yaml_data, arch="amd64", target_arch="amd64"
-    ) == {
+    extensions.apply_extensions(yaml_data, arch="amd64", target_arch="amd64")
+
+    assert yaml_data == {
         "name": "fake-snap",
         "summary": "fake summary",
         "description": "fake description",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Unit test fixes for `expand_extensions()`.  This ended up being simpler than expected, as `expand_extensions()` and `apply_root_packages()` are working as expected for core22 and core24 and no code changes were needed.

(CRAFT-4416)