### PR TITLE
docs: link from changelog to release notes

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -3,6 +3,9 @@
 Changelog
 *********
 
+Starting with Snapcraft 8.7.0, information about releases can be found in the
+:ref:`release notes<release-notes>`.
+
 ..
   release template:
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Adds a notice that the changelog has been superseded by the release notes, based on feedback from @simondeziel.