### PR TITLE
fix: don't fail when checking the base

### DIFF
--- a/snapcraft/services/project.py
+++ b/snapcraft/services/project.py
@@ -19,6 +19,7 @@ from typing import Any, cast
 
 import craft_cli
 import craft_platforms
+import craft_providers.bases
 from craft_application import ProjectService
 from overrides import override
 
@@ -82,7 +83,7 @@ class Project(ProjectService):
     @override
     def _app_render_legacy_platforms(self) -> dict[str, craft_platforms.PlatformDict]:
         project = self.get_raw()
-        effective_base = SNAPCRAFT_BASE_TO_PROVIDER_BASE[
+        effective_base = SNAPCRAFT_BASE_TO_PROVIDER_BASE.get(
             str(
                 get_effective_base(
                     base=project.get("base"),
@@ -92,10 +93,13 @@ class Project(ProjectService):
                     translate_devel=False,
                 )
             )
-        ].value
+        )
 
         # For backwards compatibility with core22, convert the platforms.
-        if effective_base == "22.04" and project.get("architectures"):
+        if (
+            effective_base == craft_providers.bases.BuilddBaseAlias.JAMMY
+            and project.get("architectures")
+        ):
             platforms: dict[str, craft_platforms.PlatformDict] = {
                 key: cast(craft_platforms.PlatformDict, value.marshal())
                 for key, value in Platform.from_architectures(

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -215,19 +215,7 @@ def test_generate_manifest(
     ]
 
 
-@pytest.mark.parametrize(
-    "base",
-    [
-        "core24",
-        pytest.param(
-            None,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="needs error handling in snapcraft.services.project.Project._app_render_legacy_platforms",
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("base", ["core24", None])
 @pytest.mark.parametrize("confinement", ["strict", "devmode", "classic"])
 def test_lifecycle_custom_arguments(
     default_project, fake_services, setup_project, base, confinement
@@ -240,6 +228,7 @@ def test_lifecycle_custom_arguments(
     new_attrs = {"base": base, "confinement": confinement}
     if base is None:
         new_attrs["type"] = "base"
+        new_attrs["build-base"] = "core24"
     setup_project(fake_services, {**default_project.marshal(), **new_attrs})
     lifecycle_service = fake_services.get("lifecycle")
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -373,20 +373,7 @@ def test_default_command_integrated(monkeypatch, mocker, new_dir):
     assert mocked_pack_run.called
 
 
-# TODO: replace {"core", "core18"} with const.ESM_BASES
-@pytest.mark.parametrize(
-    "base",
-    [
-        pytest.param(
-            "core",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="needs error handling in snapcraft.services.project.Project._app_render_legacy_platforms",
-            ),
-        ),
-        "core18",
-    ],
-)
+@pytest.mark.parametrize("base", const.ESM_BASES)
 def test_esm_error(snapcraft_yaml, base, monkeypatch, capsys):
     """Test that an error is raised when using an ESM base."""
     snapcraft_yaml_dict = {"base": base}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Minor improvement to keep snapcraft from failing early on incorrect base definitions before getting a chance to raise user-friendly errors.

(SNAPCRAFT-313)