### PR TITLE
chore(remotebuild): use new build planner

### DIFF
--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -301,7 +301,7 @@ def test_write_metadata_with_project_gui(
 def test_update_project_parse_info(
     default_project, fake_services, setup_project, in_project_path, tmp_path, mocker
 ):
-    setup_project(fake_services, default_project, write_project=True)
+    setup_project(fake_services, default_project.marshal(), write_project=True)
     package_service = fake_services.get("package")
     project_service = fake_services.get("project")
     lifecycle = fake_services.lifecycle


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

* Uses the new `get_launchpad_build_plan()` added in #5368.
* Removes `xfails` from the remote build unit tests.

Passing remote build spread tests: https://github.com/canonical/snapcraft/actions/runs/14386834165/job/40345445458

(SNAPCRAFT-310)