### PR TITLE
build(deps): bump craft-application to 5.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "attrs",
     "catkin-pkg==1.0.0 ; sys_platform == 'linux'",
     "click==8.1.8",
-    "craft-application[remote]>=5.0.1,<6.0.0",
+    "craft-application[remote]>=5.0.3,<6.0.0",
     "craft-archives~=2.1",
     "craft-cli~=3.0",
     "craft-grammar>=2.0.3,<3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -386,7 +386,7 @@ wheels = [
 
 [[package]]
 name = "craft-application"
-version = "5.0.1"
+version = "5.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -406,9 +406,9 @@ dependencies = [
     { name = "snap-helpers" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/2f/ad297bdd8402d4e4932404fc08ed89f9eca3f35c0e620d09fc6e4ffbfb76/craft_application-5.0.1.tar.gz", hash = "sha256:a268ee6b70bb57320f35fe578aec52e0c4ca427b6df527b1752517911a358f6c", size = 340203 }
+sdist = { url = "https://files.pythonhosted.org/packages/24/d9/cceb011d0a714d5e5c78bc181bbbf19ec0d6c8e064c602fddb6fc6226afc/craft_application-5.0.3.tar.gz", hash = "sha256:b10f4d9a9198510a88291b978fd5c95b485ecf86bc57bc1fbad3049e63488a5d", size = 342091 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/43/70bf3ef434b6df2c928269a8dc6f2a0f2a27e62b2785d3f5b2e09955fc1f/craft_application-5.0.1-py3-none-any.whl", hash = "sha256:b0fb49a54bd9e37f911ce0f84f1fd13f99cf702ee6350bd0706fbaccfbe3916b", size = 171976 },
+    { url = "https://files.pythonhosted.org/packages/0e/58/88f6c34661199a0e305e5772ba23bf40469eaca6213a033a7b679a29e5fb/craft_application-5.0.3-py3-none-any.whl", hash = "sha256:b3a0fd2f66f33fbd9543ad3376b48bbce8207a7f2455cd4a474fb8290a6d5024", size = 172921 },
 ]
 
 [package.optional-dependencies]
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "attrs" },
     { name = "catkin-pkg", marker = "sys_platform == 'linux'", specifier = "==1.0.0" },
     { name = "click", specifier = "==8.1.8" },
-    { name = "craft-application", extras = ["remote"], specifier = ">=5.0.1,<6.0.0" },
+    { name = "craft-application", extras = ["remote"], specifier = ">=5.0.3,<6.0.0" },
     { name = "craft-archives", specifier = "~=2.1" },
     { name = "craft-cli", specifier = "~=3.0" },
     { name = "craft-grammar", specifier = ">=2.0.3,<3.0.0" },


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Updates craft-application to fix:
- spread test failures related to `snapcraft prime` (https://github.com/canonical/craft-application/issues/716)
- pygit2 failing to import on systems without core22 installed
- possibly the spread test failure for `snapcraft test`

Fixes #5321 
(SNAPCRAFT-932)