### PR TITLE
ci: lock to 24.04 amd64 image on google backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -55,7 +55,7 @@ backends:
           storage: 20G
           image: ubuntu-2204-64
       - ubuntu-24.04-64:
-          image: ubuntu-24.04-64
+          image: ubuntu-2404-64
           storage: 20G
           workers: 6
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
