### PR TITLE
test: drop verbose flags in spread tests

### DIFF
--- a/tests/spread/core22/craftctl/task.yaml
+++ b/tests/spread/core22/craftctl/task.yaml
@@ -22,7 +22,7 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  snapcraft --verbose --destructive-mode
+  snapcraft --destructive-mode
   TESTBIN="${SNAP##*test-}"
   snap install craftctl-*.snap --dangerous
   $TESTBIN | grep hello

--- a/tests/spread/core22/package-repo-archs/task.yaml
+++ b/tests/spread/core22/package-repo-archs/task.yaml
@@ -15,4 +15,4 @@ execute: |
   cp "$SNAP_ARCH".yaml snap/snapcraft.yaml
 
   # The part's build script does the checking.
-  snapcraft build --verbose
+  snapcraft build

--- a/tests/spread/core22/package-repositories/task.yaml
+++ b/tests/spread/core22/package-repositories/task.yaml
@@ -19,7 +19,7 @@ execute: |
   cd "$SNAP"
 
   # Build what we have.
-  snapcraft --verbose --use-lxd
+  snapcraft --use-lxd
 
   # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous
@@ -30,7 +30,7 @@ execute: |
   rm -f ./*.snap
 
   # Also build in destructive mode.
-  snapcraft --verbose --destructive-mode
+  snapcraft --destructive-mode
 
   # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/core22/remove-hook/task.yaml
+++ b/tests/spread/core22/remove-hook/task.yaml
@@ -17,7 +17,7 @@ restore: |
 
 execute: |
   # create a base instance by running snapcraft
-  snapcraft pull --use-lxd --verbosity=trace
+  snapcraft pull --use-lxd
 
   # verify base instance was created
   instances="$(lxc list --project=snapcraft --format=csv --columns="n")"

--- a/tests/spread/core24/craftctl/task.yaml
+++ b/tests/spread/core24/craftctl/task.yaml
@@ -20,7 +20,7 @@ restore: |
 
 execute: |
   cd "$SNAP"
-  snapcraft --verbose --destructive-mode
+  snapcraft --destructive-mode
   TESTBIN="${SNAP##*test-}"
   snap install craftctl-*.snap --dangerous
   $TESTBIN | grep hello

--- a/tests/spread/core24/package-repositories/task.yaml
+++ b/tests/spread/core24/package-repositories/task.yaml
@@ -29,7 +29,7 @@ execute: |
   cd "$SNAP"
 
   # Build what we have.
-  snapcraft --verbose
+  snapcraft
 
   # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous
@@ -41,7 +41,7 @@ execute: |
   rm -f ./*.snap
 
   # Also build in destructive mode.
-  snapcraft --verbose --destructive-mode
+  snapcraft --destructive-mode
 
   # And verify the snap runs as expected.
   snap install "${SNAP}"_1.0_*.snap --dangerous


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Follow up to #5389 to remove verbose flags from spread tests.