### PR TITLE
fix: format snapcraft-started-at timestamps

### DIFF
--- a/docs/release-notes/snapcraft-8-8.rst
+++ b/docs/release-notes/snapcraft-8-8.rst
@@ -82,6 +82,15 @@ Support for short hashes
 Previously, the ``source-commit`` key for parts only accepted full length (40
 character) hashes. Now, ``source-commit`` also accepts short hashes.
 
+Fixed bugs and issues
+---------------------
+
+The following issues have been resolved in Snapcraft 8.8:
+
+8.8.1
+~~~~~
+
+- `#5413`_ core20 snaps had an improperly formatted timestamp in their manifest.
 
 Contributors
 ------------
@@ -99,3 +108,4 @@ and :literalref:`@sergiusens<https://github.com/sergiusens>`
 
 .. _jlink: https://docs.oracle.com/en/java/javase/21/docs/specs/man/jlink.html
 .. _security policy: https://github.com/canonical/snapcraft/blob/main/SECURITY.md
+.. _#5413: https://github.com/canonical/snapcraft/pull/5413

--- a/snapcraft_legacy/internal/meta/_manifest.py
+++ b/snapcraft_legacy/internal/meta/_manifest.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+import datetime
 import json
 import os
 from collections import OrderedDict
@@ -28,10 +29,20 @@ if TYPE_CHECKING:
     from snapcraft_legacy.project import Project
 
 
+def _format_datetime(dt: datetime) -> str:
+    """Format a datetime object into a string compatible with the store.
+
+    :param dt: The datetime object to format.
+
+    :return: A string representing the datetime.
+    """
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
 def annotate_snapcraft(project: "Project", data: Dict[str, Any]) -> Dict[str, Any]:
     manifest = OrderedDict()  # type: Dict[str, Any]
     manifest["snapcraft-version"] = snapcraft_legacy._get_version()
-    manifest["snapcraft-started-at"] = project._get_start_time().isoformat() + "Z"
+    manifest["snapcraft-started-at"] = _format_datetime(project._get_start_time())
 
     release = os_release.OsRelease()
     with contextlib.suppress(errors.OsReleaseIdError):

--- a/tests/legacy/unit/meta/test_meta.py
+++ b/tests/legacy/unit/meta/test_meta.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+import datetime
 import logging
 import os
 import pathlib
@@ -38,10 +39,18 @@ from testtools.matchers import (
 
 from snapcraft_legacy import extractors, yaml_utils
 from snapcraft_legacy.internal import errors, project_loader, states
-from snapcraft_legacy.internal.meta import _snap_packaging
+from snapcraft_legacy.internal.meta import _snap_packaging, _manifest
 from snapcraft_legacy.internal.meta import errors as meta_errors
 from snapcraft_legacy.project import Project
 from tests.legacy import fixture_setup, unit
+
+
+def test_format_datetime():
+    dt = datetime.datetime(2025, 1, 2, 3, 4, 5, 123456,tzinfo=datetime.UTC)
+
+    formatted = _manifest._format_datetime(dt)
+
+    assert formatted == "2025-01-02T03:04:05.123456Z"
 
 
 @pytest.mark.slow

--- a/tests/spread/core20/manifest/snapcraft.yaml
+++ b/tests/spread/core20/manifest/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: manifest
+base: core20
+version: '0.1'
+summary: test for manifests
+description: test for manifests
+
+grade: devel
+confinement: devmode
+
+parts:
+  my-part:
+    plugin: nil
+    stage-packages:
+      - hello
+  other-part:
+    plugin: nil

--- a/tests/spread/core20/manifest/task.yaml
+++ b/tests/spread/core20/manifest/task.yaml
@@ -1,8 +1,7 @@
 summary: Test manifest file creation
 
 environment:
-  CMD/cmdline: snapcraft --enable-manifest
-  CMD/envvars: env SNAPCRAFT_BUILD_INFO=y snapcraft
+  SNAPCRAFT_BUILD_INFO: y
 
 prepare: |
   snap install review-tools
@@ -10,15 +9,14 @@ prepare: |
 restore: |
   snapcraft clean
   rm -f ./*.snap
-  rm -f ~/manifest_0.1_*.snap
 
 execute: |
-  $CMD
+  snapcraft
 
   test -f manifest_0.1_*.snap
   test -f prime/snap/manifest.yaml
   test "$(grep -c -- '^ *- hello=[0-9]' prime/snap/manifest.yaml)" -eq 2
-  cmp snap/snapcraft.yaml prime/snap/snapcraft.yaml
+  cmp snapcraft.yaml prime/snap/snapcraft.yaml
 
   # regression test for #5413
   grep -E "^snapcraft-started-at: '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z'" prime/snap/manifest.yaml

--- a/tests/spread/core24-suites/manifest/manifest-creation/task.yaml
+++ b/tests/spread/core24-suites/manifest/manifest-creation/task.yaml
@@ -46,6 +46,9 @@ execute: |
     test "${!key}" = "${expected[$key]}"
   done
 
+  # regression test for #5413
+  echo -n $snapcraft_started_at | grep -E "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z"
+
   # account for hello package version change and possible 'build' or 'ubuntu' patch
   echo -n "$parts_my_part_stage_packages_0" | grep -q '^hello=[0-9]\+\.[0-9]\+-[0-9]\+\(build[0-9]\+\|ubuntu[0-9]\+\)\?$'
   echo -n "$primed_stage_packages_0" | grep -q '^hello=[0-9]\+\.[0-9]\+-[0-9]\+\(build[0-9]\+\|ubuntu[0-9]\+\)\?$'


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Fixes a regression where core20 snaps would have an invalid timestamp for `snapcraft-started-at` in their `snap/manifest.yaml`.

This regression occurred when we replaced a [deprecated `datetime.utcnow()` call](https://github.com/canonical/snapcraft/commit/f24c83d6b6e218cf18fe8c0380f964ae2ed09115#diff-fc9be1807504ea06b6c1703a5d6112665cccf6a14148fdfab685188ecfeda857L69).

core22 and core24 are unaffected, but I added regression tests to ensure they don't break in the future.

Fixes #5413 