### PR TITLE
feat(testing): add names to resource files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "attrs",
     "catkin-pkg==1.0.0 ; sys_platform == 'linux'",
     "click==8.1.8",
-    "craft-application[remote]>=5.0.3,<6.0.0",
+    "craft-application[remote]>=5.2.0,<6.0.0",
     "craft-archives~=2.1",
     "craft-cli~=3.0",
     "craft-grammar>=2.0.3,<3.0.0",

--- a/snapcraft/services/init.py
+++ b/snapcraft/services/init.py
@@ -66,17 +66,19 @@ class Init(services.InitService):
         project_dir: pathlib.Path,
         template_dir: pathlib.Path,
     ) -> None:
-        try:
-            craft_cli.emit.progress("Checking for an existing 'snapcraft.yaml'.")
-            project = get_snap_project(project_dir)
-        # the `ProjectMissing` error means a new project can be initialised
-        except craft_application.errors.ProjectFileError:
-            craft_cli.emit.debug("Could not find an existing 'snapcraft.yaml'.")
-        else:
-            raise errors.SnapcraftError(
-                "Could not initialise a new snapcraft project because "
-                f"{str(project.project_file)!r} already exists"
-            )
+        init_profile = template_dir.name
+        if init_profile != "test":
+            try:
+                craft_cli.emit.progress("Checking for an existing 'snapcraft.yaml'.")
+                project = get_snap_project(project_dir)
+            # the `ProjectMissing` error means a new project can be initialised
+            except craft_application.errors.ProjectFileError:
+                craft_cli.emit.debug("Could not find an existing 'snapcraft.yaml'.")
+            else:
+                raise errors.SnapcraftError(
+                    "Could not initialise a new snapcraft project because "
+                    f"{str(project.project_file)!r} already exists"
+                )
 
         super().check_for_existing_files(
             project_dir=project_dir,

--- a/snapcraft/templates/test/spread.yaml.j2
+++ b/snapcraft/templates/test/spread.yaml.j2
@@ -10,7 +10,6 @@ backends:
       #- ubuntu-20.04
       #- fedora-40
 
-
 suites:
   spread/general/:
     summary: General integration tests

--- a/tests/spread/core24/craft-test/task.yaml
+++ b/tests/spread/core24/craft-test/task.yaml
@@ -4,4 +4,4 @@ environment:
   CI: "1"
 
 execute: |
-  snapcraft test --verbose
+  snapcraft test --verbose 2>&1 | MATCH "Successful tasks: 1"

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -1,0 +1,14 @@
+summary: Init and execute tests
+
+prepare: |
+  mkdir test-snap
+  cd test-snap
+  snapcraft init
+
+restore: |
+  rm -rf test-snap
+  rm -rf ./*.snap
+
+execute: |
+  snapcraft init --profile=test
+  snapcraft test

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -1,14 +1,15 @@
 summary: Init and execute tests
 
 prepare: |
-  mkdir test-snap
-  cd test-snap
-  snapcraft init
+  rm -rf test-snap
 
 restore: |
   rm -rf test-snap
   rm -rf ./*.snap
 
 execute: |
+  mkdir test-snap
+  cd test-snap
+  snapcraft init
   snapcraft init --profile=test
   snapcraft test

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -12,4 +12,8 @@ execute: |
   cd test-snap
   snapcraft init
   snapcraft init --profile=test
+  # Test defaults assume strict confinement
+  sed -i 's/confinement: devmode/confinement: strict/' snap/snapcraft.yaml
+  # Remove once the packing issue is solved
+  snapcraft pack
   snapcraft test

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -10,5 +10,6 @@ restore: |
 execute: |
   mkdir test-snap
   cd test-snap
+  snapcraft init
   snapcraft init --profile=test
   snapcraft test

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -1,5 +1,8 @@
 summary: Init and execute tests
 
+environment:
+  CI: "1"
+
 prepare: |
   rm -rf test-snap
 

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -10,6 +10,5 @@ restore: |
 execute: |
   mkdir test-snap
   cd test-snap
-  snapcraft init
   snapcraft init --profile=test
   snapcraft test


### PR DESCRIPTION
Craft-application needs a map of resource names to filenames to set
environment variables exported to the testing service. This allows the
user to use the variables to refer to the newly created artifact and
resource files in test scriptlets.

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
