### PR TITLE
chore(revert): "fix: add all parts as a dep of extension part (#5395)"

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -337,7 +337,6 @@ class GNOME(Extension):
 
         return {
             "gnome/sdk": {
-                "after": list(self.yaml_data["parts"].keys()),
                 "source": str(source),
                 "plugin": "make",
                 **gpu_opts,

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -437,7 +437,6 @@ class KDENeon(Extension):
 
         return {
             "kde-neon/sdk": {
-                "after": list(self.yaml_data["parts"].keys()),
                 "source": str(source),
                 "plugin": "make",
                 **gpu_opts,

--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -448,7 +448,6 @@ class KDENeon6(Extension):
 
         return {
             "kde-neon-6/sdk": {
-                "after": list(self.yaml_data["parts"].keys()),
                 "source": str(source),
                 "plugin": "make",
                 **gpu_opts,

--- a/snapcraft/extensions/kde_neon_qt6.py
+++ b/snapcraft/extensions/kde_neon_qt6.py
@@ -398,7 +398,6 @@ class KDENeonQt6(Extension):
 
         return {
             "kde-neon-qt6/sdk": {
-                "after": list(self.yaml_data["parts"].keys()),
                 "source": str(source),
                 "plugin": "make",
                 **gpu_opts,

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -415,7 +415,6 @@ def test_get_parts_snippet_core24(gnome_extension_core24):
 def test_get_parts_snippet_with_external_sdk(gnome_extension_with_build_snap):
     assert gnome_extension_with_build_snap.get_parts_snippet() == {
         "gnome/sdk": {
-            "after": ["part1"],
             "source": str(get_extensions_data_dir() / "desktop" / "command-chain"),
             "plugin": "make",
         }
@@ -429,7 +428,6 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
         gnome_extension_with_default_build_snap_from_latest_edge.get_parts_snippet()
         == {
             "gnome/sdk": {
-                "after": ["part1"],
                 "source": str(get_extensions_data_dir() / "desktop" / "command-chain"),
                 "plugin": "make",
             }

--- a/tests/unit/extensions/test_kde_neon.py
+++ b/tests/unit/extensions/test_kde_neon.py
@@ -716,7 +716,6 @@ def test_get_parts_snippet_with_external_sdk(kde_neon_extension_with_build_snap)
 
     assert kde_neon_extension_with_build_snap.get_parts_snippet() == {
         "kde-neon/sdk": {
-            "after": ["part1"],
             "make-parameters": [
                 "PLATFORM_PLUG=kf5-core22",
             ],
@@ -734,7 +733,6 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
         kde_neon_extension_with_default_build_snap_from_latest_edge_core24.get_parts_snippet()
         == {
             "kde-neon/sdk": {
-                "after": ["part1"],
                 "source": str(source),
                 "plugin": "make",
                 "make-parameters": [

--- a/tests/unit/extensions/test_kde_neon_6.py
+++ b/tests/unit/extensions/test_kde_neon_6.py
@@ -737,7 +737,6 @@ def test_get_parts_snippet_with_external_sdk(kde_neon_6_extension_with_build_sna
 
     assert kde_neon_6_extension_with_build_snap.get_parts_snippet() == {
         "kde-neon-6/sdk": {
-            "after": ["part1"],
             "source": str(source),
             "plugin": "make",
             "make-parameters": [
@@ -755,7 +754,6 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
         kde_neon_6_extension_with_default_build_snap_from_latest_edge_core24.get_parts_snippet()
         == {
             "kde-neon-6/sdk": {
-                "after": ["part1"],
                 "source": str(source),
                 "plugin": "make",
                 "make-parameters": [

--- a/tests/unit/extensions/test_kde_neon_qt6.py
+++ b/tests/unit/extensions/test_kde_neon_qt6.py
@@ -623,7 +623,6 @@ def test_get_parts_snippet_with_external_sdk(kde_neon_qt6_extension_with_build_s
 
     assert kde_neon_qt6_extension_with_build_snap.get_parts_snippet() == {
         "kde-neon-qt6/sdk": {
-            "after": ["part1"],
             "source": str(source),
             "plugin": "make",
             "make-parameters": [
@@ -641,7 +640,6 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
         kde_neon_qt6_extension_with_default_build_snap_from_latest_edge_core24.get_parts_snippet()
         == {
             "kde-neon-qt6/sdk": {
-                "after": ["part1"],
                 "source": str(source),
                 "plugin": "make",
                 "make-parameters": [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

This reverts #5395.

The purpose of #5395 is good, but it's missing logic for parts that run after the extension's part, such as a "clean up" part. The logic should be to only add parts to the extension's `after` key if they don't depend on the extension's part, directly or indirectly.

For example, here are snaps that would break.  They have parts that run after the [gnome](https://github.com/wasta-linux/lameta-snap/blob/4e995848cd199c951cef6f2ea8d5c6e8b1ff689e/snap/snapcraft.yaml#L124), [ros](https://github.com/canonical/gazebo_snap/blob/8db26ff3ab4dc156dad17730f4e7c2a5f969dc24/snap/snapcraft.yaml), and [kde](https://github.com/canonical/gazebo_snap/blob/8db26ff3ab4dc156dad17730f4e7c2a5f969dc24/snap/snapcraft.yaml#L65) extensions.

We're cutting an 8.9 release so this feature needs to be reverted in the short-term.