### PR TITLE
fix(testing): use jailmode in template spread.yaml

### DIFF
--- a/snapcraft/templates/test/spread.yaml.j2
+++ b/snapcraft/templates/test/spread.yaml.j2
@@ -14,7 +14,7 @@ suites:
   spread/general/:
     summary: General integration tests
     prepare: |
-      snap install "$CRAFT_ARTIFACT" --dangerous
+      snap install "$CRAFT_ARTIFACT" --dangerous --jailmode
     restore: |
       snap remove {{ name }} --purge
 

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -15,8 +15,6 @@ execute: |
   cd test-snap
   snapcraft init
   snapcraft init --profile=test
-  # Test defaults assume strict confinement
-  sed -i 's/confinement: devmode/confinement: strict/' snap/snapcraft.yaml
   # Remove once the packing issue is solved
   snapcraft pack
   snapcraft test


### PR DESCRIPTION
Set --jailmode when installing the generated artifact in the template
spread.yaml file, so it will work with both devmode and strict
confinement settings in the snapcraft.yaml file.

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
