### PR TITLE
docs: migrate 'snapcraft.yaml'

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -17,11 +17,10 @@ Snapcraft is operated from the command line, with a command for each function.
 Project file
 ------------
 
-The main object inside a snap project is a configurable project file. These pages detail
-what goes inside it.
+The main object inside a snap project is a configurable project file. Read on for a
+complete reference of the structure and contents of this file.
 
-- :ref:`reference-snapcraft-yaml`
-- :ref:`reference-anatomy-of-snapcraft-yaml`
+:ref:`Project file references <reference-project-file>`
 
 
 Bases and architectures

--- a/docs/reference/project-file/index.rst
+++ b/docs/reference/project-file/index.rst
@@ -3,9 +3,41 @@
 Project file
 ============
 
+Every snap project depends on a file called :ref:`reference-snapcraft-yaml` which
+instructs Snapcraft how to build the snap.
+
+This project file is written in `YAML <https://yaml.org/>`_ and can be located in
+any of the following locations in the root directory of the project where Snapcraft
+is run:
+
+* ``snapcraft.yaml``
+* ``snap/snapcraft.yaml``
+* ``.snapcraft.yaml``
+* ``build-aux/snap/snapcraft.yaml``
+
+The project file is organised into three main sections:
+
+* Top-level directives and information about the snap, which describe its base
+  properties and publication details.
+* App directives, which describe the execution, interfaces, and resources available
+  to each app in the snap.
+* Part directives, which describe how to import and build the apps inside the snap.
+
+You can create a project file manually or you can run the init command to create a
+basic template:
+
+.. code-block::
+
+    snapcraft init
+
+For a complete reference of the keys in a project file, see
+:ref:`reference-snapcraft-yaml`.
+
+For a description of the project file's structure, see
+:ref:`reference-anatomy-of-snapcraft-yaml`.
+
 .. toctree::
-    :titlesonly:
-    :maxdepth: 1
+    :hidden:
 
     snapcraft-yaml
     anatomy-of-snapcraft-yaml

--- a/docs/reference/project-file/index.rst
+++ b/docs/reference/project-file/index.rst
@@ -15,16 +15,16 @@ is run:
 * ``.snapcraft.yaml``
 * ``build-aux/snap/snapcraft.yaml``
 
-The project file is organised into three main sections:
+The project file is organized into three main sections:
 
-* Top-level directives and information about the snap, which describe its base
+* Top-level directives, which provide information about the snap and describe its base
   properties and publication details.
 * App directives, which describe the execution, interfaces, and resources available
   to each app in the snap.
 * Part directives, which describe how to import and build the apps inside the snap.
 
-You can create a project file manually or you can run the init command to create a
-basic template:
+You can create a project file manually or by running the ``init`` command, which
+creates a basic template:
 
 .. code-block::
 

--- a/docs/reference/project-file/index.rst
+++ b/docs/reference/project-file/index.rst
@@ -10,23 +10,23 @@ This project file is written in `YAML <https://yaml.org/>`_ and can be located i
 any of the following locations in the root directory of the project where Snapcraft
 is run:
 
-* ``snapcraft.yaml``
-* ``snap/snapcraft.yaml``
-* ``.snapcraft.yaml``
-* ``build-aux/snap/snapcraft.yaml``
+- ``snapcraft.yaml``
+- ``snap/snapcraft.yaml``
+- ``.snapcraft.yaml``
+- ``build-aux/snap/snapcraft.yaml``
 
 The project file is organized into three main sections:
 
-* Top-level directives, which provide information about the snap and describe its base
+- Top-level directives, which provide information about the snap and describe its base
   properties and publication details.
-* App directives, which describe the execution, interfaces, and resources available
+- App directives, which describe the execution, interfaces, and resources available
   to each app in the snap.
-* Part directives, which describe how to import and build the apps inside the snap.
+- Part directives, which describe how to import and build the apps inside the snap.
 
 You can create a project file manually or by running the ``init`` command, which
 creates a basic template:
 
-.. code-block::
+.. code-block:: bash
 
     snapcraft init
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Migrates https://snapcraft.io/docs/build-configuration and the "snapcraft.yaml" section from https://snapcraft.io/docs/how-snapcraft-builds to [RTD](https://canonical-snapcraft--5466.com.readthedocs.build/en/5466/reference/project-file/).

I added the content to the project file index since it serves as a brief overview and didn't fit perfectly into either of the subpages.

(SNAPCRAFT-394)