### PR TITLE
docs: fix RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ version: 2
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 # formats:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,9 +109,6 @@ exclude_patterns = [
     "how-to/publishing/build-snaps-remotely.rst",
     "how-to/publishing/manage-releases.rst",
     "how-to/publishing/publish-a-snap.rst",
-    "reference/hooks.rst",
-    "reference/advanced-grammar.rst",
-    "reference/package-repositories.rst",
 ]
 
 

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -19,7 +19,7 @@ This section contains an in-depth description of the plugins available in Snapcr
     /common/craft-parts/reference/plugins/gradle_plugin
     /common/craft-parts/reference/plugins/jlink_plugin
     /common/craft-parts/reference/plugins/make_plugin
-    plugins/matter-sdk-plugin
+    plugins/matter_sdk_plugin
     plugins/maven_plugin
     /common/craft-parts/reference/plugins/meson_plugin
     /common/craft-parts/reference/plugins/nil_plugin

--- a/docs/reference/plugins/matter_sdk_plugin.rst
+++ b/docs/reference/plugins/matter_sdk_plugin.rst
@@ -1,4 +1,4 @@
-.. _reference-matter-sdk-plugin:
+.. _reference_matter_sdk_plugin:
 
 Matter SDK plugin
 =================


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

* Renames the matter sdk docs to use underscores to match the other plugins in Snapcraft and Craft Parts.
* Remove migrated docs from the ignored list.  Again, the [build on RTD](https://app.readthedocs.com/projects/canonical-snapcraft/builds/3014663/) doesn't fail on these warnings but fails locally:

![image](https://github.com/user-attachments/assets/45fc9e95-9639-4aa6-8453-52d0509e1f7b)

* Fail on warnings so we catch this in the future.

