### PR TITLE
docs(config): switch to ubuntu.com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ snapcraft upload
 ```
 
 If you're interested in learning more about the Snapcraft commands and how to compose a
-project file, try [creating your first
-snap](https://snapcraft.io/docs/create-a-new-snap).
+project file, try [crafting your first
+snap](https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap).
 
 ## Installation
 
@@ -65,17 +65,13 @@ sudo snap install snapcraft --classic
 For complete installation, you need an additional Linux container tool. Snapcraft can
 also be installed as a traditional package on many popular Linux repositories. If you
 need help with either, the documentation covers how to [set up
-Snapcraft](https://canonical-snapcraft.readthedocs-hosted.com/en/stable/howto/set-up-snapcraft).
+Snapcraft](https://documentation.ubuntu.com/snapcraft/stable/how-to/setup/set-up-snapcraft).
 
 ## Documentation
 
-The Snapcraft docs provide guidance and learning material about the full process of
-building a project file, debugging snaps, resolving interfaces, the command reference,
-and much more:
-
-- [Snapcraft build guide on snapcraft.io](https://snapcraft.io/docs)
-- [Snapcraft documentation on
-  ReadTheDocs](https://canonical-snapcraft.readthedocs-hosted.com/en/stable/)
+The [Snapcraft documentation](https://documentation.ubuntu.com/snapcraft/stable)
+provides guidance and learning material about the full process of building a project
+file, debugging snaps, resolving interfaces, the command reference, and much more.
 
 ## Community and support
 
@@ -110,7 +106,7 @@ Snapcraft is released under the [GPL-3.0 license](LICENSE).
 [snapcraft-badge]: https://snapcraft.io/snapcraft/badge.svg
 [snapcraft-site]: https://snapcraft.io/snapcraft
 [rtd-badge]: https://readthedocs.com/projects/canonical-snapcraft/badge/?version=latest
-[rtd-latest]: https://canonical-snapcraft.readthedocs-hosted.com/en/latest/?badge=latest
+[rtd-latest]: https://documentation.ubuntu.com/snapcraft/latest/?badge=latest
 [gha-spread-badge]: https://github.com/canonical/snapcraft/actions/workflows/spread-scheduled.yaml/badge.svg?branch=main
 [gha-spread]: https://github.com/canonical/snapcraft/actions/workflows/spread-scheduled.yaml
 [ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,8 @@ mitigations for the issue.
 The [Ubuntu Security disclosure and embargo policy] contains more information about
 what you can expect when you contact us and what we expect from you.
 
-[current major release]: https://canonical-snapcraft.readthedocs-hosted.com/en/latest/release-notes#current-releases
-[Bases]: https://canonical-snapcraft.readthedocs-hosted.com/en/latest/reference/bases.html#base-snaps
+[current major release]: https://documentation.ubuntu.com/snapcraft/stable/release-notes#current-releases
+[Bases]: https://documentation.ubuntu.com/snapcraft/stable/reference/bases#base-snaps
 [Private Security Report]: https://github.com/canonical/snapcraft/security/advisories/new
 [Ubuntu Security disclosure and embargo policy]: https://ubuntu.com/security/disclosure-policy
 [Ubuntu LTS release cycle]: https://ubuntu.com/about/release-cycle

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,8 +39,15 @@ copyright = "%s, %s" % (datetime.date.today().year, author)
 release = snapcraft.__version__
 
 # region Configuration for canonical-sphinx
-ogp_site_url = "https://canonical-snapcraft.readthedocs-hosted.com/"
+ogp_site_url = "https://documentation.ubuntu.com/snapcraft"
 ogp_site_name = project
+
+# Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
+#
+# TODO: If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = "snapcraft"
 
 html_context = {
     "product_page": "snapcraft.io",

--- a/docs/release-notes/snapcraft-8-9.rst
+++ b/docs/release-notes/snapcraft-8-9.rst
@@ -61,6 +61,25 @@ products. It's also versioned with each Snapcraft release.
 
 We're working to retire the remaining documentation on snapcraft.io.
 
+
+New documentation domain
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The second Snapcraft documentation set -- the one you're reading now -- was first
+deployed to the ReadTheDocs domain.
+
+Snapcraft is an important member of the Canonical community and ecosystem, and all its
+site names should demonstrate that. With this release, we gave the docs a new home at
+the Ubuntu domain. You can now reach it at:
+
+`documentation.ubuntu.com/snapcraft <https://documentation.ubuntu.com/snapcraft>`_
+
+We put redirects in place to handle links to the old ReadTheDocs domain.
+
+With this change, we also removed the language subdirectory (``/en``) in the URL, to
+shave a few characters off all links.
+
+
 Minor features
 --------------
 
@@ -95,25 +114,6 @@ The existing confdb schema commands have been renamed as follows:
       - ``list-confdb-schemas``
     * - ``edit-confdbs``
       - ``edit-confdb-schema``
-
-
-New documentation domain
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Snapcraft documentation was first hosted with the forum on snapcraft.io. Later, a
-new documentation set -- the one you're reading now -- was developed in parallel on the
-ReadTheDocs platform and domain.
-
-Snapcraft is an important member of the Canonical community and ecosystem, and all its
-site names should demonstrate that. With this release, we gave the docs a new home at
-the Ubuntu domain. You can now reach it at:
-
-`documentation.ubuntu.com/snapcraft <https://documentation.ubuntu.com/snapcraft>`_
-
-We put redirects in place to handle links to the old ReadTheDocs domain.
-
-With this change, we also removed the language subdirectory (``/en``) in the URL, to
-shave a few characters off all links.
 
 
 Known issues

--- a/docs/release-notes/snapcraft-8-9.rst
+++ b/docs/release-notes/snapcraft-8-9.rst
@@ -96,6 +96,26 @@ The existing confdb schema commands have been renamed as follows:
     * - ``edit-confdbs``
       - ``edit-confdb-schema``
 
+
+New documentation domain
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Snapcraft documentation was first hosted with the forum on snapcraft.io. Later, a
+new documentation set -- the one you're reading now -- was developed in parallel on the
+ReadTheDocs platform and domain.
+
+Snapcraft is an important member of the Canonical community and ecosystem, and all its
+site names should demonstrate that. With this release, we gave the docs a new home at
+the Ubuntu domain. You can now reach it at:
+
+`documentation.ubuntu.com/snapcraft <https://documentation.ubuntu.com/snapcraft>`_
+
+We put redirects in place to handle links to the old ReadTheDocs domain.
+
+With this change, we also removed the language subdirectory (``/en``) in the URL, to
+shave a few characters off all links.
+
+
 Known issues
 ------------
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ issues:
 source-code:
   - https://github.com/canonical/snapcraft
 website:
-  - https://canonical-snapcraft.readthedocs-hosted.com
+  - https://documentation.ubuntu.com/snapcraft
 
 # https://github.com/canonical/snapcraft/issues/4187
 environment:

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -51,7 +51,7 @@ APP_METADATA = AppMetadata(
     source_ignore_patterns=["*.snap"],
     project_variables=["version", "grade"],
     mandatory_adoptable_fields=["version", "summary", "description"],
-    docs_url="https://canonical-snapcraft.readthedocs-hosted.com/en/{version}",
+    docs_url="https://documentation.ubuntu.com/snapcraft/{version}",
 )
 
 


### PR DESCRIPTION
I ran the tests locally, and didn't see any errors related to the domain.

Also, fixes some links in the README.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
