### PR TITLE
docs: add explanation for cryptography

### DIFF
--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -31,8 +31,8 @@ available on the system.
 For more information on the use of cryptography for plugins provided by Craft Parts, see
 the `Craft Parts cryptography`_ documentation.
 
-For plugins provided by Snapcraft, the table below summarizes how they provision build
-tools, and which build tools they use to download and verify dependencies.
+For plugins provided by Snapcraft, the following table summarizes how they provision
+build tools, and which build tools they use to download and verify dependencies.
 
 .. list-table::
   :header-rows: 1
@@ -92,8 +92,7 @@ downloads and verifies build dependencies.
 core20
 ------
 
-Snaps using core20 as their base snap depend on various craft libraries to build.
-Snapcraft's cryptographic functionality with these libraries is described below.
+Snaps using core20 as their base snap depend on various external libraries to build.
 
 Creating virtual build environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -163,8 +162,8 @@ Downloading build dependencies
 
 Plugins use build tools to download and verify build dependencies. Some plugins can
 provision their own build tools, while others require the build tools to be available on
-the system. The table below summarizes how plugins provision build tools and which build
-tools are used to download and verify dependencies.
+the system. The following table summarizes how plugins provision build tools and which
+build tools are used to download and verify dependencies.
 
 .. list-table::
   :header-rows: 1

--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -7,28 +7,32 @@ Snapcraft uses cryptographic technologies to fetch arbitrary files over the inte
 communicate with local processes, and store credentials. It does not directly implement
 its own cryptography, but it does depend on external libraries to do so.
 
-When building snaps, Snapcraft uses different codebases and libraries depending on
-the :ref:`base snap <base-snaps>`. This means that the cryptographic techonology used
+When building snaps, Snapcraft uses different codebases and libraries depending on the
+:ref:`base snap <base-snaps>`. This means that the cryptographic technology used also
 depends on the base snap.
+
+.. _explanation_cryptography_core24:
 
 core24 and newer
 ----------------
 
-Snaps using core24 or newer as their base snap depend on Craft Application to build. For
-more information, see the  `Craft Application cryptography`_ documentation.
+Snapcraft is built upon Craft Application and derives much of its functionality from
+it. In particular, snaps using core24 or newer as their base use Craft Application to
+build, so much of Snapcraft's cryptographic functionality is described in the `Craft
+Application cryptography`_ documentation.
 
 Downloading build dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`Plugins <plugins>` use build tools to download and verify build dependencies. Some
 plugins can provision their own build tools, while others require the build tools to be
-available on the system
+available on the system.
 
 For more information on the use of cryptography for plugins provided by Craft Parts, see
 the `Craft Parts cryptography`_ documentation.
 
-For plugins provided by Snapcraft, the table below summarizes how plugins provision
-build tools and which build tools are used to download and verify dependencies.
+For plugins provided by Snapcraft, the table below summarizes how they provision build
+tools, and which build tools they use to download and verify dependencies.
 
 .. list-table::
   :header-rows: 1
@@ -39,7 +43,7 @@ build tools and which build tools are used to download and verify dependencies.
 
   * - :ref:`Colcon <reference_colcon_plugin>`
     - ``colcon`` and ``rosdep``
-    - not provisioned
+    - Not provisioned
 
   * - Conda
     - ``conda``
@@ -56,8 +60,7 @@ build tools and which build tools are used to download and verify dependencies.
 core22
 ------
 
-Snaps using core22 as their base snap depend on various craft libraries to build.
-Snapcraft's cryptographic functionality with these libraries is described below.
+Snaps using core22 as their base snap depend on various external libraries to build.
 
 Public key signing
 ~~~~~~~~~~~~~~~~~~
@@ -69,20 +72,22 @@ The parts system
 ~~~~~~~~~~~~~~~~
 
 Snapcraft makes use of *parts* in project files for declarative builds. Parts specified
-by the user may download arbitrary files, install packages, and more. For more
-information, see the `Craft Parts cryptography`_ documentation.
+by the user may download arbitrary files, install packages, and modify files in
+the build environment. For more information, see the `Craft Parts cryptography`_
+documentation.
 
 Creating virtual build environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Snapcraft instantiates and executes builds on self-allocated virtual instances. For more
-information, see `Craft Providers cryptography`_ documentation.
+information, see the `Craft Providers cryptography`_ documentation.
 
 Downloading build dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Snaps using core22 have the same plugin support as core24. See the core24 section above
-for more information on how Snapcraft downloads and verifies build dependencies.
+Snaps using core22 have the same plugin support as core24. See the :ref:`core24
+<explanation_cryptography_core24>` section for more information on how Snapcraft
+downloads and verifies build dependencies.
 
 core20
 ------
@@ -93,18 +98,17 @@ Snapcraft's cryptographic functionality with these libraries is described below.
 Creating virtual build environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Snapcraft instantiates and executes builds on self-allocated virtual instances. It uses
+Snapcraft instantiates and builds snaps on self-allocated virtual instances. It uses
 the `Requests`_ library to install Multipass on Windows. Build environments for other
-operating systems handled with snapd, as described below.
+operating systems are handled by the local `snap daemon (snapd)`_.
 
 Communication with snapd
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Snapcraft uses the Requests library to communicate over Unix sockets with the local
-`snap daemon (snapd)`_. These requests are used to fetch information about required
-software. If the software is missing, Snapcraft will install it through snapd. This
-is done by querying the `snapd API`_ with URLs built dynamically and sanitized by
-`urllib`_.
+Snapcraft uses the Requests library to communicate over Unix sockets with snapd.
+These requests fetch information about required software. If the software is missing,
+Snapcraft will install it through snapd. This is done by querying the `snapd API`_ with
+URLs built dynamically and sanitized by `urllib`_.
 
 Sources
 ~~~~~~~
@@ -112,9 +116,9 @@ Sources
 Downloading repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-When a part sources a remote repository, Snapcraft uses the appropriate version control
-tool to clone the repository. The protocol used, such as ``SSH`` or ``HTTPS``, depends
-on the source URL and support from the tool.
+When a part sources a remote repository, Snapcraft clones the repository with the
+appropriate version control tool. The protocol used, such as ``SSH`` or ``HTTPS``,
+depends on the source URL and support from the version control tool.
 
 .. list-table::
   :header-rows: 1
@@ -132,7 +136,7 @@ on the source URL and support from the tool.
     - ``hg``
 
   * - `Subversion`_
-    - ``svn```
+    - ``svn``
 
 Downloading source files
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,10 +144,11 @@ Downloading source files
 When a part sources a ``.deb``, ``.rpm``, ``.snap``, ``.tar``, ``.zip``, ``.7z``, or an
 executable file, Snapcraft calls the Requests library to download it.
 
-The integrity of these files can be verified using a :ref:`checksum <source_checksum>`.
-The checksum is verified using hashlib, so all `algorithms available to the hashlib
-library <https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available>`_
-can be used.
+If the part has the :ref:`source_checksum` key, then the integrity
+of the source file will be verified.  The checksum is verified
+using hashlib, so all `algorithms available to the hashlib library
+<https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available>`_ can
+be used.
 
 Dependencies
 ~~~~~~~~~~~~
@@ -151,7 +156,7 @@ Dependencies
 Downloading system packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-System dependencies are downloaded and verified using snapd and `Apt`_.
+System dependencies are downloaded and verified using snapd and `APT`_.
 
 Downloading build dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,11 +179,11 @@ tools are used to download and verify dependencies.
 
   * - Catkin
     - ``catkin`` and ``rosdep``
-    - not provisioned
+    - Not provisioned
 
   * - :ref:`Colcon <reference_colcon_plugin>`
     - ``colcon`` and ``rosdep``
-    - not provisioned
+    - Not provisioned
 
   * - Conda
     - ``conda``
@@ -190,11 +195,11 @@ tools are used to download and verify dependencies.
 
   * - :ref:`Go <craft_parts_go_plugin>`
     - `Go toolchain <https://go.dev/ref/mod>`_
-    - not provisioned
+    - Not provisioned
 
   * - :ref:`Meson <craft_parts_meson_plugin>`
     - `Meson <https://mesonbuild.com>`_
-    - not provisioned
+    - Not provisioned
 
   * - :ref:`NPM <craft_parts_npm_plugin>`
     - `npm <https://www.npmjs.com/>`_
@@ -202,7 +207,7 @@ tools are used to download and verify dependencies.
 
   * - :ref:`Python <craft_parts_python_plugin>`
     - `pip <https://pip.pypa.io>`_
-    - not provisioned
+    - Not provisioned
 
 Public key signing
 ~~~~~~~~~~~~~~~~~~
@@ -215,22 +220,22 @@ A declaration of a package repository includes a mandatory ``key-id`` field that
 specifies the fingerprint of the repository's public key. This public key can either be
 stored locally or automatically fetched by Snapcraft.
 
-If the key file is located as part of the project's assets, Snapcraft uses the GPG as
+If the key file is located as part of the project's assets, Snapcraft uses GPG as
 provided by the official Ubuntu archives to ensure that the file matches the declared
 fingerprint. If the key file is not present locally, Snapcraft uses GPG in conjunction
 with `dirmngr`_ (also from the Ubuntu archives) to fetch the key from the OpenPGP
-keyserver ``keyserver.ubuntu.com``.
+keyserver at ``keyserver.ubuntu.com``.
 
 In either scenario, Snapcraft then creates an APT data source for the package repository
-referencing the identified key. It does not validate that the remote repository is in
-fact signed by the key, as APT itself does it as part of its normal operation.
+referencing the identified key. It does not validate that the remote repository is
+signed with the key, as APT itself does this as part of its normal operation.
 
 
 Remote building
 ---------------
 
-Snapcraft's remote build uses Craft Application. The cryptographic functionality used
-for remote builds is described in the  `Craft Application cryptography`_ documentation.
+Remote snap builds use Craft Application. The cryptographic functionality used for
+remote builds is described in the  `Craft Application cryptography`_ documentation.
 
 Snapcraft's legacy remote builder uses `launchpadlib`_ to interact with the `Launchpad`_
 API and trigger remote builds. Login credentials for Launchpad are stored in a plain
@@ -239,14 +244,13 @@ text file in the XDG data directory.
 Interaction with storefronts
 ----------------------------
 
-Snapcraft is able to interface with the Snap store and private stores over the internet.
-Some store interactions are driven through Craft Store. For more information, see the
-`Craft Store cryptography`_ documentation.
+Snapcraft interfaces with the Snap Store and private stores over the internet. Some
+store interactions are driven through Craft Store, such as authentication and listing
+releases. For more information, see the `Craft Store cryptography`_ documentation.
 
-Other interactions with the store don't use Craft Store. For these interactions,
-Snapcraft uses cryptographic processes to send files between devices and endpoints
-through the internet. It does not directly implement its own cryptography, but it does
-depend on external libraries to do so.
+For interactions that don't use Craft Store, Snapcraft uses cryptographic processes
+to send files between devices and endpoints through the internet. It does not directly
+implement its own cryptography, but it does depend on external libraries to do so.
 
 Authentication
 ~~~~~~~~~~~~~~
@@ -266,14 +270,13 @@ discouraged.
 Network connectivity
 ~~~~~~~~~~~~~~~~~~~~
 
-Snapcraft handles URLs using `urllib`_. The use of this library both simplifies and
-hardens the parsing of URLs.
+Snapcraft uses `urllib`_ to simplify and harden the parsing of URLs.
 
 Connections over the internet are mediated by the Requests or `httpx`_ libraries.
-libraries. These libraries handle cryptographic operations such as the TLS handshake
-that are standard requirements for modern internet connections. These are configured to
+libraries. These libraries handle cryptographic operations, such as the TLS handshake,
+that are standard requirements for modern internet connections. They are configured to
 always attempt HTTPS connections first, but have the ability to communicate over HTTP as
-a fallback. The Snap store does not support HTTP, but this capability is retained to aid
+a fallback. The Snap Store does not support HTTP, but this capability is retained to aid
 with local testing. Between these two libraries, Snapcraft will use whichever of the two
 is invoked by the consuming application.
 

--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -1,0 +1,303 @@
+.. _explanation_cryptographic-technology:
+
+Cryptographic technology in Snapcraft
+=====================================
+
+Snapcraft uses cryptographic technologies to fetch arbitrary files over the internet,
+communicate with local processes, and store credentials. It does not directly implement
+its own cryptography, but it does depend on external libraries to do so.
+
+When building snaps, Snapcraft uses different codebases and libraries depending on
+the :ref:`base snap <base-snaps>`. This means that the cryptographic techonology used
+depends on the base snap.
+
+core24 and newer
+----------------
+
+Snaps using core24 or newer as their base snap depend on Craft Application to build. For
+more information, see the  `Craft Application cryptography`_ documentation.
+
+Downloading build dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:ref:`Plugins <plugins>` use build tools to download and verify build dependencies. Some
+plugins can provision their own build tools, while others require the build tools to be
+available on the system
+
+For more information on the use of cryptography for plugins provided by Craft Parts, see
+the `Craft Parts cryptography`_ documentation.
+
+For plugins provided by Snapcraft, the table below summarizes how plugins provision
+build tools and which build tools are used to download and verify dependencies.
+
+.. list-table::
+  :header-rows: 1
+
+  * - Plugin
+    - Build tools used
+    - Method of provisioning the build tools
+
+  * - :ref:`Colcon <reference_colcon_plugin>`
+    - ``colcon`` and ``rosdep``
+    - not provisioned
+
+  * - Conda
+    - ``conda``
+    - Requests library and `curl`_
+
+  * - Flutter
+    - ``flutter``
+    - Git
+
+  * - :ref:`Matter SDK <reference_matter_sdk_plugin>`
+    - ``matter``
+    - Git
+
+core22
+------
+
+Snaps using core22 as their base snap depend on various craft libraries to build.
+Snapcraft's cryptographic functionality with these libraries is described below.
+
+Public key signing
+~~~~~~~~~~~~~~~~~~
+
+Snapcraft supports the adding and verification of arbitrary package repositories. For
+more information, see the `Craft Archives cryptography`_ documentation.
+
+The parts system
+~~~~~~~~~~~~~~~~
+
+Snapcraft makes use of *parts* in project files for declarative builds. Parts specified
+by the user may download arbitrary files, install packages, and more. For more
+information, see the `Craft Parts cryptography`_ documentation.
+
+Creating virtual build environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Snapcraft instantiates and executes builds on self-allocated virtual instances. For more
+information, see `Craft Providers cryptography`_ documentation.
+
+Downloading build dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Snaps using core22 have the same plugin support as core24. See the core24 section above
+for more information on how Snapcraft downloads and verifies build dependencies.
+
+core20
+------
+
+Snaps using core20 as their base snap depend on various craft libraries to build.
+Snapcraft's cryptographic functionality with these libraries is described below.
+
+Creating virtual build environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Snapcraft instantiates and executes builds on self-allocated virtual instances. It uses
+the `Requests`_ library to install Multipass on Windows. Build environments for other
+operating systems handled with snapd, as described below.
+
+Communication with snapd
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Snapcraft uses the Requests library to communicate over Unix sockets with the local
+`snap daemon (snapd)`_. These requests are used to fetch information about required
+software. If the software is missing, Snapcraft will install it through snapd. This
+is done by querying the `snapd API`_ with URLs built dynamically and sanitized by
+`urllib`_.
+
+Sources
+~~~~~~~
+
+Downloading repositories
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a part sources a remote repository, Snapcraft uses the appropriate version control
+tool to clone the repository. The protocol used, such as ``SSH`` or ``HTTPS``, depends
+on the source URL and support from the tool.
+
+.. list-table::
+  :header-rows: 1
+
+  * - Version control system
+    - Tool used
+
+  * - `Git`_
+    - ``git``
+
+  * - `Bazaar`_
+    - ``bzr``
+
+  * - `Mercurial`_
+    - ``hg``
+
+  * - `Subversion`_
+    - ``svn```
+
+Downloading source files
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a part sources a ``.deb``, ``.rpm``, ``.snap``, ``.tar``, ``.zip``, ``.7z``, or an
+executable file, Snapcraft calls the Requests library to download it.
+
+The integrity of these files can be verified using a :ref:`checksum <source_checksum>`.
+The checksum is verified using hashlib, so all `algorithms available to the hashlib
+library <https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_available>`_
+can be used.
+
+Dependencies
+~~~~~~~~~~~~
+
+Downloading system packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+System dependencies are downloaded and verified using snapd and `Apt`_.
+
+Downloading build dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Plugins use build tools to download and verify build dependencies. Some plugins can
+provision their own build tools, while others require the build tools to be available on
+the system. The table below summarizes how plugins provision build tools and which build
+tools are used to download and verify dependencies.
+
+.. list-table::
+  :header-rows: 1
+
+  * - Plugin
+    - Build tools used
+    - Method of provisioning the build tools
+
+  * - :ref:`Rust <craft_parts_rust_plugin>`
+    - `Cargo <https://doc.rust-lang.org/stable/cargo/>`_
+    - `rustup <https://rustup.rs>`_
+
+  * - Catkin
+    - ``catkin`` and ``rosdep``
+    - not provisioned
+
+  * - :ref:`Colcon <reference_colcon_plugin>`
+    - ``colcon`` and ``rosdep``
+    - not provisioned
+
+  * - Conda
+    - ``conda``
+    - Requests library and curl
+
+  * - Crystal
+    - ``shards``
+    - `Crystal snap`_
+
+  * - :ref:`Go <craft_parts_go_plugin>`
+    - `Go toolchain <https://go.dev/ref/mod>`_
+    - not provisioned
+
+  * - :ref:`Meson <craft_parts_meson_plugin>`
+    - `Meson <https://mesonbuild.com>`_
+    - not provisioned
+
+  * - :ref:`NPM <craft_parts_npm_plugin>`
+    - `npm <https://www.npmjs.com/>`_
+    - Requests library and curl
+
+  * - :ref:`Python <craft_parts_python_plugin>`
+    - `pip <https://pip.pypa.io>`_
+    - not provisioned
+
+Public key signing
+~~~~~~~~~~~~~~~~~~
+
+Snapcraft uses cryptographic processes to parse public keys and optionally retrieve them
+from remote servers. It does not directly implement its own cryptography, but depends on
+`GNU Privacy Guard (GPG)`_ to do so.
+
+A declaration of a package repository includes a mandatory ``key-id`` field that
+specifies the fingerprint of the repository's public key. This public key can either be
+stored locally or automatically fetched by Snapcraft.
+
+If the key file is located as part of the project's assets, Snapcraft uses the GPG as
+provided by the official Ubuntu archives to ensure that the file matches the declared
+fingerprint. If the key file is not present locally, Snapcraft uses GPG in conjunction
+with `dirmngr`_ (also from the Ubuntu archives) to fetch the key from the OpenPGP
+keyserver ``keyserver.ubuntu.com``.
+
+In either scenario, Snapcraft then creates an APT data source for the package repository
+referencing the identified key. It does not validate that the remote repository is in
+fact signed by the key, as APT itself does it as part of its normal operation.
+
+
+Remote building
+---------------
+
+Snapcraft's remote build uses Craft Application. The cryptographic functionality used
+for remote builds is described in the  `Craft Application cryptography`_ documentation.
+
+Snapcraft's legacy remote builder uses `launchpadlib`_ to interact with the `Launchpad`_
+API and trigger remote builds. Login credentials for Launchpad are stored in a plain
+text file in the XDG data directory.
+
+Interaction with storefronts
+----------------------------
+
+Snapcraft is able to interface with the Snap store and private stores over the internet.
+Some store interactions are driven through Craft Store. For more information, see the
+`Craft Store cryptography`_ documentation.
+
+Other interactions with the store don't use Craft Store. For these interactions,
+Snapcraft uses cryptographic processes to send files between devices and endpoints
+through the internet. It does not directly implement its own cryptography, but it does
+depend on external libraries to do so.
+
+Authentication
+~~~~~~~~~~~~~~
+
+Snapcraft uses `macaroons`_, as an authentication mechanism, which are processed by the
+`macaroonbakery`_ library. This library validates and manages macaroons as returned by
+stores and simplifies the inclusion of macaroons in further requests to stores.
+
+Credentials may additionally be stored on-disk using the `keyring`_ library, which
+will use the keyring service provided by the host operating system. If the host does
+not have a keyring service, they will instead be stored in a plain text file called
+:file:`credentials.json` under the application's data storage directory. A warning is
+issued to the terminal when this behavior is triggered. This behavior is available to
+ease the usage of Snapcraft inside virtual machines and containers, but is generally
+discouraged.
+
+Network connectivity
+~~~~~~~~~~~~~~~~~~~~
+
+Snapcraft handles URLs using `urllib`_. The use of this library both simplifies and
+hardens the parsing of URLs.
+
+Connections over the internet are mediated by the Requests or `httpx`_ libraries.
+libraries. These libraries handle cryptographic operations such as the TLS handshake
+that are standard requirements for modern internet connections. These are configured to
+always attempt HTTPS connections first, but have the ability to communicate over HTTP as
+a fallback. The Snap store does not support HTTP, but this capability is retained to aid
+with local testing. Between these two libraries, Snapcraft will use whichever of the two
+is invoked by the consuming application.
+
+.. _Apt: https://wiki.debian.org/AptCLI
+.. _Bazaar: https://launchpad.net/bzr
+.. _Craft Application cryptography: https://canonical-craft-application.readthedocs-hosted.com/en/latest/explanation/cryptography.html
+.. _Craft Archives cryptography: https://canonical-craft-archives.readthedocs-hosted.com/en/latest/explanation/cryptography/
+.. _Craft Parts cryptography: https://canonical-craft-parts.readthedocs-hosted.com/en/latest/explanation/cryptography/
+.. _Craft Providers cryptography: https://canonical-craft-providers.readthedocs-hosted.com/en/latest/explanation/cryptography/
+.. _Craft Store cryptography: https://canonical-craft-store.readthedocs-hosted.com/en/latest/explanation/cryptography/
+.. _Crystal snap: https://snapcraft.io/crystal
+.. _curl: https://curl.se/
+.. _dirmngr: https://manpages.ubuntu.com/manpages/noble/man8/dirmngr.8.html
+.. _Git: https://git-scm.com/
+.. _GNU Privacy Guard (GPG): https://gnupg.org/
+.. _httpx: https://www.python-httpx.org/
+.. _keyring: https://pypi.org/project/keyring/
+.. _Launchpad: https://launchpad.net
+.. _launchpadlib: https://help.launchpad.net/API/launchpadlib
+.. _macaroonbakery: https://pypi.org/project/macaroonbakery/
+.. _macaroons: https://research.google/pubs/macaroons-cookies-with-contextual-caveats-for-decentralized-authorization-in-the-cloud/
+.. _Mercurial: https://www.mercurial-scm.org/
+.. _Requests: https://requests.readthedocs.io/
+.. _snap daemon (snapd): https://snapcraft.io/docs/installing-snapd
+.. _snapd API: https://snapcraft.io/docs/snapd-api
+.. _Subversion: https://subversion.apache.org/
+.. _urllib: https://docs.python.org/3/library/urllib.html

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -10,6 +10,7 @@ and their implementation.
     :titlesonly:
     :maxdepth: 1
 
+    Cryptographic technology <cryptography>
     architectures
     bases
     parts


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Adds an [explanation of cryptography](https://canonical-ubuntu-documentation-library--5478.com.readthedocs.build/snapcraft/5478/explanation/cryptography/) used in Snapcraft.

This doc is tricky to organize because there are 3 overlapping codebases used to build snaps (depending on the base), 2 codebases for interacting with the store, and 2 codebases for remote builds.  The store and remote build codebases aren't tied to any particular base.

I've reused as much upstream documentation is possible.

(SNAPCRAFT-1114)