### PR TITLE
build: add patchelf to make dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ endif
 ifeq ($(wildcard /usr/share/doc/xdelta3/copyright),)
 APT_PACKAGES += xdelta3
 endif
+ifeq ($(wildcard /usr/share/doc/patchelf/copyright),)
+APT_PACKAGES += patchelf
+endif
 
 # Used for installing build dependencies in CI.
 .PHONY: install-build-deps


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Since switching to the self-hosted runners, tests have been breaking because patchelf wasn't installed on them. For example, see [this workflow](https://github.com/canonical/snapcraft/actions/runs/14932815042). This PR just adds the apt package to be installed during the creation of the development environment.