### PR TITLE
ci: remove config for osv scanner

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,4 +1,0 @@
-[[IgnoredVulns]]
-id = "CVE-2024-35195"
-ignoreUntil = "2025-01-01T00:00:00Z"
-reason = "Needed for requests-unixsocket, which we're replacing with requests-unixsocket2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Removes an OSV scanner config that was both resolved and expired.