### PR TITLE
models/project.py: do not download base if build base is set

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -2064,7 +2064,7 @@ class Project(models.Project):
         extra_build_snaps = list(content_snaps - part_build_snaps)
 
         # Always add the base as an extra build snap
-        if self.base is not None:
+        if self.base is not None and self.build_base == self.base:
             extra_build_snaps.append(self.base)
         extra_build_snaps.sort()
 


### PR DESCRIPTION
This breaks build of development pc snap. The core base is not yet stable. If there is a build base, there is probably no reason to download the base.

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
