### PR TITLE
fix: evaluate variables in project file

### DIFF
--- a/docs/release-notes/snapcraft-8-9.rst
+++ b/docs/release-notes/snapcraft-8-9.rst
@@ -148,6 +148,7 @@ Snapcraft 8.9.2
 
 - YAML issues originating from the project file now emit errors instead of tracebacks,
   making them easier to identify and read.
+- `#5491`_ Project variables weren't being evaluated in project files.
 
 Contributors
 ------------
@@ -172,3 +173,4 @@ and :literalref:`@tigarmo<https://github.com/tigarmo>`
 .. _cargo registry: https://doc.rust-lang.org/cargo/reference/registries.html
 .. _#5107: https://github.com/canonical/snapcraft/pull/5107
 .. _#5272: https://github.com/canonical/snapcraft/pull/5272
+.. _#5491: https://github.com/canonical/snapcraft/pull/5491

--- a/docs/release-notes/snapcraft-8-9.rst
+++ b/docs/release-notes/snapcraft-8-9.rst
@@ -171,6 +171,6 @@ and :literalref:`@tigarmo<https://github.com/tigarmo>`
 .. _Rust crates: https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html
 .. _Spread: https://github.com/snapcore/spread
 .. _cargo registry: https://doc.rust-lang.org/cargo/reference/registries.html
-.. _#5107: https://github.com/canonical/snapcraft/pull/5107
-.. _#5272: https://github.com/canonical/snapcraft/pull/5272
-.. _#5491: https://github.com/canonical/snapcraft/pull/5491
+.. _#5107: https://github.com/canonical/snapcraft/issues/5107
+.. _#5272: https://github.com/canonical/snapcraft/issues/5272
+.. _#5491: https://github.com/canonical/snapcraft/issues/5491

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -36,7 +36,6 @@ from overrides import override
 import snapcraft
 import snapcraft_legacy
 from snapcraft import cli, commands, errors, models, services, store
-from snapcraft.parts import set_global_environment
 from snapcraft.utils import get_effective_base
 from snapcraft_legacy.cli import legacy
 
@@ -411,12 +410,6 @@ class Snapcraft(Application):
             extra_global_args=self._global_arguments,
             default_command=commands.PackCommand,
         )
-
-    @override
-    def _set_global_environment(self, info: craft_parts.ProjectInfo) -> None:
-        """Set global environment variables."""
-        super()._set_global_environment(info)
-        set_global_environment(info)
 
     def _get_project_raw(self) -> dict[str, Any] | None:
         """Get raw project data from the project service."""

--- a/snapcraft/services/project.py
+++ b/snapcraft/services/project.py
@@ -14,8 +14,10 @@
 
 """Snapcraft Project service."""
 
+from __future__ import annotations
+
 import pathlib
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import craft_cli
 import craft_platforms
@@ -25,9 +27,13 @@ from overrides import override
 
 from snapcraft.extensions import apply_extensions
 from snapcraft.models.project import ComponentProject, Platform, apply_root_packages
+from snapcraft.parts import set_global_environment
 from snapcraft.parts.yaml_utils import extract_parse_info, get_snap_project
 from snapcraft.providers import SNAPCRAFT_BASE_TO_PROVIDER_BASE
 from snapcraft.utils import get_effective_base
+
+if TYPE_CHECKING:
+    import craft_parts
 
 
 class Project(ProjectService):
@@ -116,3 +122,9 @@ class Project(ProjectService):
             }
 
         return platforms
+
+    @override
+    def update_project_environment(self, info: craft_parts.ProjectInfo) -> None:
+        """Set global environment variables."""
+        super().update_project_environment(info)
+        set_global_environment(info)

--- a/tests/spread/core22/project-variables/expected.txt
+++ b/tests/spread/core22/project-variables/expected.txt
@@ -1,0 +1,37 @@
+CRAFT_ARCH_BUILD_FOR           = amd64
+CRAFT_ARCH_BUILD_FOR           = amd64
+
+CRAFT_ARCH_BUILD_ON            = amd64
+CRAFT_ARCH_BUILD_ON            = amd64
+
+CRAFT_ARCH_TRIPLET_BUILD_FOR   = x86_64-linux-gnu
+CRAFT_ARCH_TRIPLET_BUILD_FOR   = x86_64-linux-gnu
+
+CRAFT_ARCH_TRIPLET_BUILD_ON    = x86_64-linux-gnu
+CRAFT_ARCH_TRIPLET_BUILD_ON    = x86_64-linux-gnu
+
+SNAPCRAFT_PRIME                = /root/prime
+SNAPCRAFT_PRIME                = /root/prime
+CRAFT_PRIME                    = /root/prime
+CRAFT_PRIME                    = /root/prime
+
+SNAPCRAFT_PROJECT_DIR          = /root/project
+SNAPCRAFT_PROJECT_DIR          = /root/project
+CRAFT_PROJECT_DIR              = /root/project
+CRAFT_PROJECT_DIR              = /root/project
+
+SNAPCRAFT_PROJECT_GRADE        = devel
+SNAPCRAFT_PROJECT_GRADE        = devel
+
+SNAPCRAFT_PROJECT_NAME         = project-variables
+SNAPCRAFT_PROJECT_NAME         = project-variables
+
+SNAPCRAFT_PROJECT_VERSION      = 1.0.0
+SNAPCRAFT_PROJECT_VERSION      = 1.0.0
+CRAFT_PROJECT_VERSION          = 1.0.0
+CRAFT_PROJECT_VERSION          = 1.0.0
+
+SNAPCRAFT_STAGE                = /root/stage
+SNAPCRAFT_STAGE                = /root/stage
+CRAFT_STAGE                    = /root/stage
+CRAFT_STAGE                    = /root/stage

--- a/tests/spread/core22/project-variables/expected.txt
+++ b/tests/spread/core22/project-variables/expected.txt
@@ -25,11 +25,11 @@ SNAPCRAFT_PROJECT_GRADE        = devel
 
 SNAPCRAFT_PROJECT_NAME         = project-variables
 SNAPCRAFT_PROJECT_NAME         = project-variables
+CRAFT_PROJECT_NAME             = project-variables
+CRAFT_PROJECT_NAME             = project-variables
 
 SNAPCRAFT_PROJECT_VERSION      = 1.0.0
 SNAPCRAFT_PROJECT_VERSION      = 1.0.0
-CRAFT_PROJECT_VERSION          = 1.0.0
-CRAFT_PROJECT_VERSION          = 1.0.0
 
 SNAPCRAFT_STAGE                = /root/stage
 SNAPCRAFT_STAGE                = /root/stage

--- a/tests/spread/core22/project-variables/snapcraft.yaml
+++ b/tests/spread/core22/project-variables/snapcraft.yaml
@@ -1,0 +1,57 @@
+name: project-variables
+base: core22
+version: "1.0.0"
+summary: Test evaluation of project variables in keys.
+
+# Description is a convenient key for testing project variables because it is freeform.
+# Note that this test doesn't test project variables in override scriplets,
+# since those variables are set in the build environment and are tested separately.
+description: |
+  CRAFT_ARCH_BUILD_FOR           = $CRAFT_ARCH_BUILD_FOR
+  CRAFT_ARCH_BUILD_FOR           = ${CRAFT_ARCH_BUILD_FOR}
+
+  CRAFT_ARCH_BUILD_ON            = $CRAFT_ARCH_BUILD_ON
+  CRAFT_ARCH_BUILD_ON            = ${CRAFT_ARCH_BUILD_ON}
+
+  CRAFT_ARCH_TRIPLET_BUILD_FOR   = $CRAFT_ARCH_TRIPLET_BUILD_FOR
+  CRAFT_ARCH_TRIPLET_BUILD_FOR   = ${CRAFT_ARCH_TRIPLET_BUILD_FOR}
+
+  CRAFT_ARCH_TRIPLET_BUILD_ON    = $CRAFT_ARCH_TRIPLET_BUILD_ON
+  CRAFT_ARCH_TRIPLET_BUILD_ON    = ${CRAFT_ARCH_TRIPLET_BUILD_ON}
+
+  SNAPCRAFT_PRIME                = $SNAPCRAFT_PRIME
+  SNAPCRAFT_PRIME                = ${SNAPCRAFT_PRIME}
+  CRAFT_PRIME                    = $CRAFT_PRIME
+  CRAFT_PRIME                    = ${CRAFT_PRIME}
+
+  SNAPCRAFT_PROJECT_DIR          = $SNAPCRAFT_PROJECT_DIR
+  SNAPCRAFT_PROJECT_DIR          = ${SNAPCRAFT_PROJECT_DIR}
+  CRAFT_PROJECT_DIR              = $CRAFT_PROJECT_DIR
+  CRAFT_PROJECT_DIR              = ${CRAFT_PROJECT_DIR}
+
+  SNAPCRAFT_PROJECT_GRADE        = $SNAPCRAFT_PROJECT_GRADE
+  SNAPCRAFT_PROJECT_GRADE        = ${SNAPCRAFT_PROJECT_GRADE}
+
+  SNAPCRAFT_PROJECT_NAME         = $SNAPCRAFT_PROJECT_NAME
+  SNAPCRAFT_PROJECT_NAME         = ${SNAPCRAFT_PROJECT_NAME}
+  CRAFT_PROJECT_NAME             = $CRAFT_PROJECT_NAME
+  CRAFT_PROJECT_NAME             = ${CRAFT_PROJECT_NAME}
+
+  SNAPCRAFT_PROJECT_VERSION      = $SNAPCRAFT_PROJECT_VERSION
+  SNAPCRAFT_PROJECT_VERSION      = ${SNAPCRAFT_PROJECT_VERSION}
+
+  SNAPCRAFT_STAGE                = $SNAPCRAFT_STAGE
+  SNAPCRAFT_STAGE                = ${SNAPCRAFT_STAGE}
+  CRAFT_STAGE                    = $CRAFT_STAGE
+  CRAFT_STAGE                    = ${CRAFT_STAGE}
+
+confinement: strict
+grade: devel
+
+parts:
+  craft-parts:
+    plugin: dump
+    source: https://github.com/canonical/craft-parts.git
+    # use a project variable in a realistic scenario
+    source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
+    source-depth: 1

--- a/tests/spread/core22/project-variables/task.yaml
+++ b/tests/spread/core22/project-variables/task.yaml
@@ -1,0 +1,20 @@
+summary: Test project variables on core24
+
+environment:
+  SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
+
+restore: |
+  rm -f ./*.snap
+  snapcraft clean
+
+execute: |
+  snapcraft pack
+
+  actual=$(snap info ./project-variables_1.0.0_amd64.snap | yq ".description")
+  expected=$(< expected.txt)
+
+  if [ "$actual" != "$expected" ]; then
+    echo "Unexpected project variables:"
+    diff -u --label expected <(printf "%s\n" "$expected") --label actual <(printf "%s\n" "$actual")
+    exit 1
+  fi

--- a/tests/spread/core22/project-variables/task.yaml
+++ b/tests/spread/core22/project-variables/task.yaml
@@ -3,7 +3,11 @@ summary: Test project variables on core24
 environment:
   SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
 
+prepare: |
+  snap install yq
+
 restore: |
+  snap remove --purge yq
   rm -f ./*.snap
   snapcraft clean
 

--- a/tests/spread/core24/project-variables/expected.txt
+++ b/tests/spread/core24/project-variables/expected.txt
@@ -1,0 +1,39 @@
+CRAFT_ARCH_BUILD_FOR           = amd64
+CRAFT_ARCH_BUILD_FOR           = amd64
+
+CRAFT_ARCH_BUILD_ON            = amd64
+CRAFT_ARCH_BUILD_ON            = amd64
+
+CRAFT_ARCH_TRIPLET_BUILD_FOR   = x86_64-linux-gnu
+CRAFT_ARCH_TRIPLET_BUILD_FOR   = x86_64-linux-gnu
+
+CRAFT_ARCH_TRIPLET_BUILD_ON    = x86_64-linux-gnu
+CRAFT_ARCH_TRIPLET_BUILD_ON    = x86_64-linux-gnu
+
+SNAPCRAFT_PRIME                = /root/prime
+SNAPCRAFT_PRIME                = /root/prime
+CRAFT_PRIME                    = /root/prime
+CRAFT_PRIME                    = /root/prime
+
+SNAPCRAFT_PROJECT_DIR          = /root/project
+SNAPCRAFT_PROJECT_DIR          = /root/project
+CRAFT_PROJECT_DIR              = /root/project
+CRAFT_PROJECT_DIR              = /root/project
+
+SNAPCRAFT_PROJECT_GRADE        = devel
+SNAPCRAFT_PROJECT_GRADE        = devel
+
+SNAPCRAFT_PROJECT_NAME         = project-variables
+SNAPCRAFT_PROJECT_NAME         = project-variables
+CRAFT_PROJECT_NAME             = project-variables
+CRAFT_PROJECT_NAME             = project-variables
+
+SNAPCRAFT_PROJECT_VERSION      = 1.0.0
+SNAPCRAFT_PROJECT_VERSION      = 1.0.0
+CRAFT_PROJECT_VERSION          = 1.0.0
+CRAFT_PROJECT_VERSION          = 1.0.0
+
+SNAPCRAFT_STAGE                = /root/stage
+SNAPCRAFT_STAGE                = /root/stage
+CRAFT_STAGE                    = /root/stage
+CRAFT_STAGE                    = /root/stage

--- a/tests/spread/core24/project-variables/snapcraft.yaml
+++ b/tests/spread/core24/project-variables/snapcraft.yaml
@@ -1,0 +1,59 @@
+name: project-variables
+base: core24
+version: "1.0.0"
+summary: Test evaluation of project variables in keys.
+
+# Description is a convenient key for testing project variables because it is freeform.
+# Note that this test doesn't test project variables in override scriplets,
+# since those variables are set in the build environment and are tested separately.
+description: |
+  CRAFT_ARCH_BUILD_FOR           = $CRAFT_ARCH_BUILD_FOR
+  CRAFT_ARCH_BUILD_FOR           = ${CRAFT_ARCH_BUILD_FOR}
+
+  CRAFT_ARCH_BUILD_ON            = $CRAFT_ARCH_BUILD_ON
+  CRAFT_ARCH_BUILD_ON            = ${CRAFT_ARCH_BUILD_ON}
+
+  CRAFT_ARCH_TRIPLET_BUILD_FOR   = $CRAFT_ARCH_TRIPLET_BUILD_FOR
+  CRAFT_ARCH_TRIPLET_BUILD_FOR   = ${CRAFT_ARCH_TRIPLET_BUILD_FOR}
+
+  CRAFT_ARCH_TRIPLET_BUILD_ON    = $CRAFT_ARCH_TRIPLET_BUILD_ON
+  CRAFT_ARCH_TRIPLET_BUILD_ON    = ${CRAFT_ARCH_TRIPLET_BUILD_ON}
+
+  SNAPCRAFT_PRIME                = $SNAPCRAFT_PRIME
+  SNAPCRAFT_PRIME                = ${SNAPCRAFT_PRIME}
+  CRAFT_PRIME                    = $CRAFT_PRIME
+  CRAFT_PRIME                    = ${CRAFT_PRIME}
+
+  SNAPCRAFT_PROJECT_DIR          = $SNAPCRAFT_PROJECT_DIR
+  SNAPCRAFT_PROJECT_DIR          = ${SNAPCRAFT_PROJECT_DIR}
+  CRAFT_PROJECT_DIR              = $CRAFT_PROJECT_DIR
+  CRAFT_PROJECT_DIR              = ${CRAFT_PROJECT_DIR}
+
+  SNAPCRAFT_PROJECT_GRADE        = $SNAPCRAFT_PROJECT_GRADE
+  SNAPCRAFT_PROJECT_GRADE        = ${SNAPCRAFT_PROJECT_GRADE}
+
+  SNAPCRAFT_PROJECT_NAME         = $SNAPCRAFT_PROJECT_NAME
+  SNAPCRAFT_PROJECT_NAME         = ${SNAPCRAFT_PROJECT_NAME}
+  CRAFT_PROJECT_NAME             = $CRAFT_PROJECT_NAME
+  CRAFT_PROJECT_NAME             = ${CRAFT_PROJECT_NAME}
+
+  SNAPCRAFT_PROJECT_VERSION      = $SNAPCRAFT_PROJECT_VERSION
+  SNAPCRAFT_PROJECT_VERSION      = ${SNAPCRAFT_PROJECT_VERSION}
+  CRAFT_PROJECT_VERSION          = $CRAFT_PROJECT_VERSION
+  CRAFT_PROJECT_VERSION          = ${CRAFT_PROJECT_VERSION}
+
+  SNAPCRAFT_STAGE                = $SNAPCRAFT_STAGE
+  SNAPCRAFT_STAGE                = ${SNAPCRAFT_STAGE}
+  CRAFT_STAGE                    = $CRAFT_STAGE
+  CRAFT_STAGE                    = ${CRAFT_STAGE}
+
+confinement: strict
+grade: devel
+
+parts:
+  craft-parts:
+    plugin: dump
+    source: https://github.com/canonical/craft-parts.git
+    # use a project variable in a realistic scenario
+    source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
+    source-depth: 1

--- a/tests/spread/core24/project-variables/task.yaml
+++ b/tests/spread/core24/project-variables/task.yaml
@@ -1,0 +1,20 @@
+summary: Test project variables on core24
+
+environment:
+  SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
+
+restore: |
+  rm -f ./*.snap
+  snapcraft clean
+
+execute: |
+  snapcraft pack
+
+  actual=$(snap info ./project-variables_1.0.0_amd64.snap | yq ".description")
+  expected=$(< expected.txt)
+
+  if [ "$actual" != "$expected" ]; then
+    echo "Unexpected project variables:"
+    diff -u --label expected <(printf "%s\n" "$expected") --label actual <(printf "%s\n" "$actual")
+    exit 1
+  fi

--- a/tests/spread/core24/project-variables/task.yaml
+++ b/tests/spread/core24/project-variables/task.yaml
@@ -3,7 +3,11 @@ summary: Test project variables on core24
 environment:
   SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
 
+prepare: |
+  snap install yq
+
 restore: |
+  snap remove --purge yq
   rm -f ./*.snap
   snapcraft clean
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Fixes a bug where project variables weren't being evaluated in project files.

This was a mistake from the craft-application 5 rebase and refactor. It's addressed upstream in https://github.com/canonical/craft-application/pull/762.

### TODO
- [x] add a core22 spread test
- [x] update changelog

Fixes #5491
(SNAPCRAFT-1131)