### PR TITLE
feat(confdb-schema): support optional summary fields

### DIFF
--- a/snapcraft/models/assertions.py
+++ b/snapcraft/models/assertions.py
@@ -72,6 +72,9 @@ class ConfdbSchema(models.CraftBaseModel):
 class Rules(models.CraftBaseModel):
     """A list of confdb schemas for a particular view."""
 
+    summary: str | None = None
+    """Optional summary for this view."""
+
     rules: list[ConfdbSchema]
 
 
@@ -83,6 +86,9 @@ class EditableConfdbSchemaAssertion(models.CraftBaseModel):
 
     name: str
     revision: int | None = 0
+
+    summary: str | None = None
+    """Optional summary for the entire confdb-schema."""
 
     views: dict[str, Rules]
     """A map of logical views of how the storage is accessed."""

--- a/snapcraft/services/confdbschemas.py
+++ b/snapcraft/services/confdbschemas.py
@@ -30,6 +30,7 @@ _CONFDB_SCHEMA_TEMPLATE = textwrap.dedent(
     """\
     account-id: {account_id}
     name: {name}
+    summary: {summary}
     # The revision for this confdb-schema
     # revision: {revision}
     {views}
@@ -42,6 +43,7 @@ _CONFDB_SCHEMA_VIEWS_TEMPLATE = textwrap.dedent(
     """\
     views:
       wifi-setup:
+      summary: Summary of the view.
         rules:
           - request: ssids
             storage: wifi.ssids
@@ -118,6 +120,7 @@ class ConfdbSchemas(Assertion):
             body=dump_yaml({"body": assertion.body}, default_flow_style=False),
             name=assertion.name,
             revision=assertion.revision,
+            summary=assertion.summary,
         )
 
     @override
@@ -128,6 +131,7 @@ class ConfdbSchemas(Assertion):
             body=_CONFDB_SCHEMA_BODY_TEMPLATE,
             name=name,
             revision=1,
+            summary="Summary of the confdb-schema",
         )
 
     @override

--- a/snapcraft/services/confdbschemas.py
+++ b/snapcraft/services/confdbschemas.py
@@ -132,7 +132,7 @@ class ConfdbSchemas(Assertion):
             body=_CONFDB_SCHEMA_BODY_TEMPLATE,
             name=name,
             revision=1,
-            summary="Summary of the confdb-schema",
+            summary="\nsummary: Summary of the confdb-schema",
         )
 
     @override

--- a/snapcraft/services/confdbschemas.py
+++ b/snapcraft/services/confdbschemas.py
@@ -29,8 +29,7 @@ from snapcraft.services import Assertion
 _CONFDB_SCHEMA_TEMPLATE = textwrap.dedent(
     """\
     account-id: {account_id}
-    name: {name}
-    summary: {summary}
+    name: {name}{summary}
     # The revision for this confdb-schema
     # revision: {revision}
     {views}
@@ -43,7 +42,7 @@ _CONFDB_SCHEMA_VIEWS_TEMPLATE = textwrap.dedent(
     """\
     views:
       wifi-setup:
-      summary: Summary of the view.
+        summary: Summary of the view.
         rules:
           - request: ssids
             storage: wifi.ssids
@@ -112,6 +111,8 @@ class ConfdbSchemas(Assertion):
 
     @override
     def _generate_yaml_from_model(self, assertion: models.Assertion) -> str:
+        # Include the summary field only when it's explicitly set (to avoid outputting 'None' in the generated YAML)
+        summary = f"\nsummary: {assertion.summary}" if assertion.summary else ""
         return _CONFDB_SCHEMA_TEMPLATE.format(
             account_id=assertion.account_id,
             views=dump_yaml(
@@ -120,7 +121,7 @@ class ConfdbSchemas(Assertion):
             body=dump_yaml({"body": assertion.body}, default_flow_style=False),
             name=assertion.name,
             revision=assertion.revision,
-            summary=assertion.summary,
+            summary=summary,
         )
 
     @override

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -151,17 +151,19 @@ def test_confdb_schema_assertion_defaults(check):
             "account_id": "test-account-id",
             "authority_id": "test-authority-id",
             "name": "test-confdb",
+            "summary": "This is a test summary.",
             "timestamp": "2024-01-01T10:20:30Z",
             "type": "confdb-schema",
             "views": {
                 "wifi-setup": {
+                    "summary": "This is a test views summary.",
                     "rules": [
                         {
                             "access": "read-write",
                             "request": "ssids",
                             "storage": "wifi.ssids",
                         }
-                    ]
+                    ],
                 }
             },
         }
@@ -171,6 +173,8 @@ def test_confdb_schema_assertion_defaults(check):
     check.is_none(assertion.body_length)
     check.is_none(assertion.sign_key_sha3_384)
     check.equal(assertion.revision, 0)
+    check.equal(assertion.summary, "This is a test summary.")
+    check.equal(assertion.views["wifi-setup"].summary, "This is a test views summary.")
 
 
 def test_confdb_schema_assertion_marshal_as_str():

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -202,7 +202,7 @@ def test_confdb_schema_assertion_marshal_as_str():
     assert assertion_dict["revision"] == "10"
 
 
-def test_confdb_schema_assertion_with_summaries(check):
+def test_confdb_schema_assertion_with_summary(check):
     """Test that summaries are set correctly when provided."""
     assertion = ConfdbSchemaAssertion.unmarshal(
         {

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -151,12 +151,10 @@ def test_confdb_schema_assertion_defaults(check):
             "account_id": "test-account-id",
             "authority_id": "test-authority-id",
             "name": "test-confdb",
-            "summary": "This is a test summary.",
             "timestamp": "2024-01-01T10:20:30Z",
             "type": "confdb-schema",
             "views": {
                 "wifi-setup": {
-                    "summary": "This is a test views summary.",
                     "rules": [
                         {
                             "access": "read-write",
@@ -173,8 +171,8 @@ def test_confdb_schema_assertion_defaults(check):
     check.is_none(assertion.body_length)
     check.is_none(assertion.sign_key_sha3_384)
     check.equal(assertion.revision, 0)
-    check.equal(assertion.summary, "This is a test summary.")
-    check.equal(assertion.views["wifi-setup"].summary, "This is a test views summary.")
+    check.is_none(assertion.summary)
+    check.is_none(assertion.views["wifi-setup"].summary)
 
 
 def test_confdb_schema_assertion_marshal_as_str():
@@ -202,3 +200,32 @@ def test_confdb_schema_assertion_marshal_as_str():
     assertion_dict = assertion.marshal_scalars_as_strings()
 
     assert assertion_dict["revision"] == "10"
+
+
+def test_confdb_schema_assertion_with_summaries(check):
+    """Test that summaries are set correctly when provided."""
+    assertion = ConfdbSchemaAssertion.unmarshal(
+        {
+            "account_id": "test-account-id",
+            "authority_id": "test-authority-id",
+            "name": "test-confdb",
+            "summary": "This is a test confdb-schema summary.",
+            "timestamp": "2024-01-01T10:20:30Z",
+            "type": "confdb-schema",
+            "views": {
+                "wifi-setup": {
+                    "summary": "This is a test views summary.",
+                    "rules": [
+                        {
+                            "access": "read-write",
+                            "request": "ssids",
+                            "storage": "wifi.ssids",
+                        }
+                    ],
+                }
+            },
+        }
+    )
+
+    check.equal(assertion.summary, "This is a test confdb-schema summary.")
+    check.equal(assertion.views["wifi-setup"].summary, "This is a test views summary.")

--- a/tests/unit/services/test_confdbs.py
+++ b/tests/unit/services/test_confdbs.py
@@ -162,6 +162,111 @@ def test_generate_yaml_from_model(fake_confdb_schema_assertion, fake_services):
     )
 
 
+def test_generate_yaml_from_model_with_summary(
+    fake_confdb_schema_assertion, fake_services
+):
+    confdb_schemas_service = fake_services.get("confdb_schemas")
+    assertion = fake_confdb_schema_assertion(
+        revision="10",
+        summary="This is a test confdb-schema summary.",
+        views={
+            "wifi-setup": {
+                "summary": "This is a test views summary.",
+                "rules": [
+                    {
+                        "request": "test-request",
+                        "storage": "test-storage",
+                        "access": "read",
+                        "content": [
+                            {
+                                "request": "nested-request",
+                                "storage": "nested-storage",
+                                "access": "write",
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        body=(
+            "{\n  'storage': {\n    'schema': {\n      'wifi': {\n        "
+            "'values': 'any'\n      }\n    }\n  }\n}"
+        ),
+    )
+    yaml_data = confdb_schemas_service._generate_yaml_from_model(assertion)
+
+    assert yaml_data == textwrap.dedent(
+        """\
+        account-id: test-account-id
+        name: test-confdb
+        summary: This is a test confdb-schema summary.
+        # The revision for this confdb-schema
+        # revision: 10
+        views:
+          wifi-setup:
+            summary: This is a test views summary.
+            rules:
+            - request: test-request
+              storage: test-storage
+              access: read
+              content:
+              - request: nested-request
+                storage: nested-storage
+                access: write
+
+        body: |-
+          {
+            'storage': {
+              'schema': {
+                'wifi': {
+                  'values': 'any'
+                }
+              }
+            }
+          }
+
+          """
+    )
+
+
+def test_generate_yaml_from_template(fake_services):
+    confdb_schemas_service = fake_services.get("confdb_schemas")
+
+    yaml_data = confdb_schemas_service._generate_yaml_from_template(
+        name="test-confdb", account_id="test-account-id"
+    )
+
+    expected_yaml = textwrap.dedent(
+        """\
+        account-id: test-account-id
+        name: test-confdb
+        summary: Summary of the confdb-schema
+        # The revision for this confdb-schema
+        # revision: 1
+        views:
+          wifi-setup:
+            summary: Summary of the view.
+            rules:
+              - request: ssids
+                storage: wifi.ssids
+                access: read
+
+        body: |-
+          {
+            "storage": {
+              "schema": {
+                "wifi": {
+                  "values": "any"
+                }
+              }
+            }
+          }
+        """
+    )
+
+    assert yaml_data.strip() == expected_yaml.strip()
+
+
 def test_get_success_message(fake_confdb_schema_assertion, fake_services):
     confdb_schemas_service = fake_services.get("confdb_schemas")
     message = confdb_schemas_service._get_success_message(

--- a/tests/unit/services/test_confdbs.py
+++ b/tests/unit/services/test_confdbs.py
@@ -134,7 +134,6 @@ def test_generate_yaml_from_model(fake_confdb_schema_assertion, fake_services):
         """\
         account-id: test-account-id
         name: test-confdb
-        summary: None
         # The revision for this confdb-schema
         # revision: 10
         views:

--- a/tests/unit/services/test_confdbs.py
+++ b/tests/unit/services/test_confdbs.py
@@ -134,6 +134,7 @@ def test_generate_yaml_from_model(fake_confdb_schema_assertion, fake_services):
         """\
         account-id: test-account-id
         name: test-confdb
+        summary: None
         # The revision for this confdb-schema
         # revision: 10
         views:


### PR DESCRIPTION
This adds support for the optional `summary` field in the `confdb-schema` assertion, both at the top level and under individual views, in accordance with the updated specification.

An existing unit test was also modified to cover these new optional fields.

Fixes: #5442