### PR TITLE
Fix confinement docstring

### DIFF
--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1468,9 +1468,9 @@ class Project(models.Project):
           - Description
         * - ``strict``
           - Default for core20 and older bases. Use strict confinement.
-        * - ``devmode``
+        * - ``classic``
           - Use classic confinement.
-        * - ``strict``
+        * - ``devmode``
           - Use devmode confinement.
 
     """


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Fixed a small typo in the reference documentation of `snapcraft.yaml`, specifically the `confinement` property.

<details>
<summary>I could not run `make test` successfully, it was failing for me on the `main` branch.</summary>

```
❯ uv sync --group dev --group docs --group dev-noble --group lint
Resolved 212 packages in 1ms
Audited 194 packages in 0.45ms
❯ make test VERSION_CODENAME=noble
Makefile:31: warning: overriding recipe for target 'lint-docs'
common.mk:177: warning: ignoring old recipe for target 'lint-docs'
uv run pytest
...
collected 6213 items / 1 error                                                                                                                                                  

========= ERRORS =========
___________ ERROR collecting tests/legacy/unit/repo/test_deb.py ___________
tests/legacy/unit/repo/test_deb.py:63: in <module>
    class TestPackages(unit.TestCase):
tests/legacy/unit/repo/test_deb.py:259: in TestPackages
    @mock.patch.object(repo._deb.Ubuntu, "normalize")
E   AttributeError: module 'snapcraft_legacy.internal.repo' has no attribute '_deb'
...
❯ uv tree
Resolved 212 packages in 3ms
snapcraft
├── attrs v25.3.0
├── catkin-pkg v1.0.0
│   ├── docutils v0.21.2
│   ├── pyparsing v3.2.3
│   ├── python-dateutil v2.9.0.post0
│   │   └── six v1.17.0
│   └── setuptools v80.0.0
├── click v8.1.8
├── craft-application[remote] v5.2.0
│   ├── annotated-types v0.7.0
│   ├── craft-archives v2.1.0
│   │   ├── distro v1.9.0
│   │   ├── launchpadlib v2.1.0
│   │   │   ├── httplib2 v0.22.0
│   │   │   │   └── pyparsing v3.2.3
│   │   │   ├── lazr-restfulclient v0.14.6
│   │   │   │   ├── distro v1.9.0
│   │   │   │   ├── httplib2 v0.22.0 (*)
│   │   │   │   ├── oauthlib v3.2.2
│   │   │   │   ├── setuptools v80.0.0
│   │   │   │   ├── six v1.17.0
│   │   │   │   └── wadllib v2.0.0
│   │   │   │       └── lazr-uri v1.0.7
│   │   │   │           └── setuptools v80.0.0
│   │   │   └── lazr-uri v1.0.7 (*)
│   │   ├── lazr-restfulclient v0.14.6 (*)
│   │   ├── lazr-uri v1.0.7 (*)
│   │   ├── overrides v7.7.0
│   │   ├── pydantic v2.11.3
│   │   │   ├── annotated-types v0.7.0
│   │   │   ├── pydantic-core v2.33.1
│   │   │   │   └── typing-extensions v4.13.2
│   │   │   ├── typing-extensions v4.13.2
│   │   │   └── typing-inspection v0.4.0
│   │   │       └── typing-extensions v4.13.2
│   │   └── python-debian v0.1.49
│   │       └── chardet v5.2.0
│   ├── craft-cli v3.0.0
│   │   ├── jinja2 v3.1.6
│   │   │   └── markupsafe v3.0.2
│   │   ├── overrides v7.7.0
│   │   ├── platformdirs v4.3.7
│   │   └── typing-extensions v4.13.2
│   ├── craft-grammar v2.0.3
│   │   ├── overrides v7.7.0
│   │   └── pydantic v2.11.3 (*)
│   ├── craft-parts v2.10.0
│   │   ├── overrides v7.7.0
│   │   ├── pydantic v2.11.3 (*)
│   │   ├── pyxdg v0.28
│   │   ├── pyyaml v6.0.2
│   │   ├── requests v2.32.3
│   │   │   ├── certifi v2025.4.26
│   │   │   ├── charset-normalizer v3.4.1
│   │   │   ├── idna v3.10
│   │   │   └── urllib3 v2.4.0
│   │   └── requests-unixsocket2 v1.0.0
│   │       ├── requests v2.32.3 (*)
│   │       └── urllib3 v2.4.0
│   ├── craft-platforms v0.8.0
│   │   ├── annotated-types v0.7.0
│   │   ├── distro v1.9.0
│   │   └── typing-extensions v4.13.2
│   ├── craft-providers v2.2.0
│   │   ├── packaging v25.0
│   │   ├── pydantic v2.11.3 (*)
│   │   ├── pyyaml v6.0.2
│   │   ├── requests v2.32.3 (*)
│   │   └── requests-unixsocket2 v1.0.0 (*)
│   ├── jinja2 v3.1.6 (*)
│   ├── license-expression v30.4.1
│   │   └── boolean-py v5.0
│   ├── platformdirs v4.3.7
│   ├── pydantic v2.11.3 (*)
│   ├── pygit2 v1.13.3
│   │   ├── cffi v1.17.1
│   │   │   └── pycparser v2.22
│   │   └── setuptools v80.0.0
│   ├── pyyaml v6.0.2
│   ├── requests v2.32.3 (*)
│   ├── snap-helpers v0.4.2
│   │   └── pyyaml v6.0.2
│   ├── typing-extensions v4.13.2
│   └── launchpadlib v2.1.0 (extra: remote) (*)
├── craft-archives v2.1.0 (*)
├── craft-cli v3.0.0 (*)
├── craft-grammar v2.0.3 (*)
├── craft-parts v2.10.0 (*)
├── craft-platforms v0.8.0 (*)
├── craft-providers v2.2.0 (*)
├── craft-store v3.2.1
│   ├── annotated-types v0.7.0
│   ├── httpx v0.28.1
│   │   ├── anyio v4.9.0
│   │   │   ├── idna v3.10
│   │   │   ├── sniffio v1.3.1
│   │   │   └── typing-extensions v4.13.2
│   │   ├── certifi v2025.4.26
│   │   ├── httpcore v1.0.9
│   │   │   ├── certifi v2025.4.26
│   │   │   └── h11 v0.16.0
│   │   └── idna v3.10
│   ├── jaraco-classes v3.4.0
│   │   └── more-itertools v10.7.0
│   ├── keyring v25.6.0
│   │   ├── jaraco-classes v3.4.0 (*)
│   │   ├── jaraco-context v6.0.1
│   │   ├── jaraco-functools v4.1.0
│   │   │   └── more-itertools v10.7.0
│   │   ├── jeepney v0.9.0
│   │   └── secretstorage v3.3.3
│   │       ├── cryptography v44.0.2
│   │       │   └── cffi v1.17.1 (*)
│   │       └── jeepney v0.9.0
│   ├── macaroonbakery v1.3.4
│   │   ├── protobuf v6.30.2
│   │   ├── pymacaroons v0.13.0
│   │   │   ├── pynacl v1.5.0
│   │   │   │   └── cffi v1.17.1 (*)
│   │   │   └── six v1.17.0
│   │   ├── pynacl v1.5.0 (*)
│   │   ├── pyrfc3339 v1.1
│   │   │   └── pytz v2025.2
│   │   ├── requests v2.32.3 (*)
│   │   └── six v1.17.0
│   ├── overrides v7.7.0
│   ├── pydantic v2.11.3 (*)
│   ├── pyxdg v0.28
│   ├── requests v2.32.3 (*)
│   ├── requests-toolbelt v1.0.0
│   │   └── requests v2.32.3 (*)
│   └── typing-extensions v4.13.2
├── cryptography v44.0.2 (*)
├── gnupg v2.3.1
│   └── psutil v7.0.0
├── jsonschema v2.5.1
├── launchpadlib v2.1.0 (*)
├── lazr-restfulclient v0.14.6 (*)
├── lxml v5.4.0
├── macaroonbakery v1.3.4 (*)
├── mypy-extensions v1.1.0
├── overrides v7.7.0
├── packaging v25.0
├── progressbar v2.5
├── pydantic v2.11.3 (*)
├── pyelftools v0.32
├── pygit2 v1.13.3 (*)
├── pylxd v2.3.5
│   ├── cryptography v44.0.2 (*)
│   ├── python-dateutil v2.9.0.post0 (*)
│   ├── requests v2.32.3 (*)
│   ├── requests-toolbelt v1.0.0 (*)
│   └── ws4py v0.6.0
├── python-debian v0.1.49 (*)
├── pyxdg v0.28
├── pyyaml v6.0.2
├── raven v6.10.0
├── requests v2.32.3 (*)
├── requests-toolbelt v1.0.0 (*)
├── requests-unixsocket2 v1.0.0 (*)
├── simplejson v3.20.1
├── snap-helpers v0.4.2 (*)
├── tabulate v0.9.0
├── tinydb v4.8.2
├── toml v0.10.2
├── typing-extensions v4.13.2
├── validators v0.34.0
├── coverage v7.8.0 (group: dev)
├── fixtures v4.2.5 (group: dev)
├── mccabe v0.7.0 (group: dev)
├── pexpect v4.9.0 (group: dev)
│   └── ptyprocess v0.7.0
├── pip v25.1 (group: dev)
├── pycodestyle v2.13.0 (group: dev)
├── pyflakes v3.3.2 (group: dev)
├── pyftpdlib v2.0.1 (group: dev)
│   ├── pyasynchat v1.0.4
│   │   └── pyasyncore v1.0.4
│   └── pyasyncore v1.0.4
├── pymacaroons v0.13.0 (group: dev) (*)
├── pyramid v2.0.2 (group: dev)
│   ├── hupper v1.12.1
│   ├── plaster v1.1.2
│   ├── plaster-pastedeploy v1.0.1
│   │   ├── pastedeploy v3.1.0
│   │   └── plaster v1.1.2
│   ├── setuptools v80.0.0
│   ├── translationstring v1.4
│   ├── venusian v3.1.1
│   ├── webob v1.8.9
│   ├── zope-deprecation v5.1
│   │   └── setuptools v80.0.0
│   └── zope-interface v7.2
│       └── setuptools v80.0.0
├── pytest v8.3.5 (group: dev)
│   ├── iniconfig v2.1.0
│   ├── packaging v25.0
│   └── pluggy v1.5.0
├── pytest-check v2.5.3 (group: dev)
│   └── pytest v8.3.5 (*)
├── pytest-cov v6.1.1 (group: dev)
│   ├── coverage v7.8.0
│   └── pytest v8.3.5 (*)
├── pytest-mock v3.14.0 (group: dev)
│   └── pytest v8.3.5 (*)
├── pytest-subprocess v1.5.3 (group: dev)
│   └── pytest v8.3.5 (*)
└── testscenarios v0.5.0 (group: dev)
    ├── pbr v6.1.1
    │   └── setuptools v80.0.0
    └── testtools v2.7.2
        └── setuptools v80.0.0
(*) Package tree already displayed
```