### PR TITLE
feat(gnome): Add SNAPCRAFT_GNOME_SDK env

### DIFF
--- a/docs/reference/extensions/gnome-extension.rst
+++ b/docs/reference/extensions/gnome-extension.rst
@@ -145,6 +145,7 @@ The paths differ slightly between core24 and core22 bases.
                 :caption: snapcraft.yaml
 
                 build-environment:
+                  - SNAPCRAFT_GNOME_SDK: /snap/gnome-46-2404-sdk/current/
                   - PATH: /snap/gnome-46-2404-sdk/current/usr/bin${PATH:+:$PATH}
                   - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/snap/gnome-46-2404-sdk/current/usr/share:/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
                   - LD_LIBRARY_PATH: /snap/gnome-46-2404-sdk/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/gnome-46-2404-sdk/current/usr/lib:/snap/gnome-46-2404-sdk/current/usr/lib/vala-current:/snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -221,6 +221,9 @@ class GNOME(Extension):
         return {
             "build-environment": [
                 {
+                    "SNAPCRAFT_GNOME_SDK": f"/snap/{sdk_snap}/current/",
+                },
+                {
                     "PATH": prepend_to_env(
                         "PATH", [f"/snap/{sdk_snap}/current/usr/bin"]
                     ),

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -238,6 +238,7 @@ class TestGetPartSnippet:
     def assert_get_part_snippet(gnome_instance):
         assert gnome_instance.get_part_snippet(plugin_name="autotools") == {
             "build-environment": [
+                {"SNAPCRAFT_GNOME_SDK": "/snap/gnome-42-2204-sdk/current/"},
                 {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin${PATH:+:$PATH}"},
                 {
                     "XDG_DATA_DIRS": (
@@ -323,6 +324,7 @@ class TestGetPartSnippet:
 def test_get_part_snippet_with_external_sdk(gnome_extension_with_build_snap):
     assert gnome_extension_with_build_snap.get_part_snippet(plugin_name="meson") == {
         "build-environment": [
+            {"SNAPCRAFT_GNOME_SDK": "/snap/gnome-44-2204-sdk/current/"},
             {"PATH": "/snap/gnome-44-2204-sdk/current/usr/bin${PATH:+:$PATH}"},
             {
                 "XDG_DATA_DIRS": (


### PR DESCRIPTION
While building package using the gnome extension it's often required to define new environment paths that are based on the gnome sdk snap path.

Instead of having to make such path a static string, expose it as an env variable to make it easier to set new variables and to simplify updates on core changes

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
