### PR TITLE
Add ros2 profile

### DIFF
--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -22,7 +22,7 @@ grade: stable
 apps:
   ros2-talker-listener:
     command: ros2 launch demo_nodes_cpp talker_listener.launch.py
-    # ROS extensions abstracts some common boilerplate configurations.
+    # The ROS extensions establish common settings for all ROS snaps.
     # Learn more about it at https://canonical-robotics.readthedocs-hosted.com/en/latest/references/snapcraft/extensions/
     extensions: [ros2-jazzy-ros-core]
 

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -1,0 +1,37 @@
+# The name of the snap.
+# Use 'snapcraft register <name>' to register the name on the store.
+name: {{ name }}
+# Just for humans, typically '1.2+git' or '1.3.2'
+version: "0.0.1"
+summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+description: |
+  This is {{ name }}'s description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  so that it looks good in the snap store.
+
+# The base snap is the runtime environment for this snap.
+# Bases have a 1:1 correspondence with ROS 2 LTS distributions.
+base: core24
+
+# Use 'devmode' while developing until you have the right plugs and slots.
+confinement: strict
+# Use 'devel' while developing to prevent pushing the snap to either of the 'candidate' or 'stable' track on the store
+grade: stable
+
+# The applications exposed by the snap.
+apps:
+  ros2-talker-listener:
+    command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+    # ROS extensions abstracts some common boilerplate configurations.
+    # Learn more about it at https://canonical-robotics.readthedocs-hosted.com/en/latest/references/snapcraft/extensions/
+    extensions: [ros2-jazzy-ros-core]
+
+# The parts to build the snap.
+parts:
+  ros-demos:
+    # The 'colcon' plugin drives the build process.
+    # Learn more about the ROS plugins at https://canonical-robotics.readthedocs-hosted.com/en/latest/references/snapcraft/plugins/
+    plugin: colcon
+    source: https://github.com/ros2/demos.git
+    source-branch: jazzy
+    source-subdir: demo_nodes_cpp

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -12,10 +12,10 @@ description: |
 # Bases have a 1:1 correspondence with ROS 2 LTS distributions.
 base: core24
 
-# Use 'devmode' while developing until you have the right plugs and slots.
-confinement: strict
-# Use 'devel' while developing to prevent pushing the snap to either of the 'candidate' or 'stable' track on the store
-grade: stable
+# use 'strict' once you have the right plugs and slots
+confinement: devmode
+# must be 'stable' to release into candidate/stable channels
+grade: devel
 
 # The applications exposed by the snap.
 apps:

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -1,5 +1,4 @@
 # The name of the snap.
-# Use 'snapcraft register <name>' to register the name on the store.
 name: {{ name }}
 # Just for humans, typically '1.2+git' or '1.3.2'
 version: "0.0.1"

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -2,7 +2,8 @@
 name: {{ name }}
 # Just for humans, typically '1.2+git' or '1.3.2'
 version: "0.0.1"
-summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+# 79 char long summary
+summary: Single-line elevator pitch for your amazing snap
 description: |
   This is {{ name }}'s description. You have a paragraph or two to tell the
   most important story about your snap. Keep it under 100 words though,

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -10,7 +10,7 @@ description: |
   so that it looks good in the snap store.
 
 # The base snap is the runtime environment for this snap.
-# Bases have a 1:1 correspondence with ROS 2 LTS distributions.
+# Each ROS 2 LTS distribution has a corresponding base in the core** series.
 # View the compatible bases at:
 # https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-extensions
 base: core24

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -11,6 +11,8 @@ description: |
 
 # The base snap is the runtime environment for this snap.
 # Bases have a 1:1 correspondence with ROS 2 LTS distributions.
+# View the compatible bases at:
+# https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-extensions
 base: core24
 
 # use 'strict' once you have the right plugs and slots

--- a/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
+++ b/snapcraft/templates/ros2/snap/snapcraft.yaml.j2
@@ -29,8 +29,8 @@ apps:
 # The parts to build the snap.
 parts:
   ros-demos:
-    # The 'colcon' plugin drives the build process.
-    # Learn more about the ROS plugins at https://canonical-robotics.readthedocs-hosted.com/en/latest/references/snapcraft/plugins/
+    # The colcon plugin builds parts for ROS 2.
+    # Learn more about the plugin at https://documentation.ubuntu.com/snapcraft/stable/reference/plugins/colcon_plugin
     plugin: colcon
     source: https://github.com/ros2/demos.git
     source-branch: jazzy

--- a/tests/spread/general/init/task.yaml
+++ b/tests/spread/general/init/task.yaml
@@ -12,6 +12,9 @@ environment:
   PROJECT_DIR/with_project_dir: test-project-dir
   NAME/with_project_dir_and_name: test-snap-name
   PROJECT_DIR/with_project_dir_and_name: test-project-dir
+  PROFILE/ros2: ros2
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS/ros2: 1
+
 
 restore: |
   unset SNAPCRAFT_BUILD_ENVIRONMENT


### PR DESCRIPTION
Add a `ros2` init profile that create a small, yet functional, ROS 2 snap example.

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
