### PR TITLE
chore: add deprecation warning for legacy remote builder

### DIFF
--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -55,8 +55,7 @@ Legacy
 .. admonition:: Deprecation notice
     :class: important
 
-    The legacy remote builder will be removed in an upcoming major release
-    of Snapcraft.
+    The legacy remote builder will be removed in a future release of Snapcraft.
 
 The "fallback" or legacy version of the remote builder can be used for
 ``core20`` and ``core22`` snaps.  It is not available for ``core24`` and newer

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -56,6 +56,9 @@ The "fallback" or legacy version of the remote builder can be used for
 ``core20`` and ``core22`` snaps.  It is not available for ``core24`` and newer
 snaps.
 
+Support for the legacy version of the remote builder for ``core22`` snaps will be
+removed in an upcoming major release of Snapcraft.
+
 The legacy remote builder was deprecated because of its design. It retrieves and
 tarballs remote sources and modifies the project file to point to the local tarballs.
 This caused many unexpected failures that could not be reproduced locally.

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -56,7 +56,7 @@ Legacy
     :class: important
 
     The legacy remote builder will be removed in an upcoming major release
-    of Snapcraft
+    of Snapcraft.
 
 The "fallback" or legacy version of the remote builder can be used for
 ``core20`` and ``core22`` snaps.  It is not available for ``core24`` and newer

--- a/docs/explanation/remote-build.rst
+++ b/docs/explanation/remote-build.rst
@@ -52,12 +52,15 @@ It does not modify the project or project metadata.
 Legacy
 ^^^^^^
 
+.. admonition:: Deprecation notice
+    :class: important
+
+    The legacy remote builder will be removed in an upcoming major release
+    of Snapcraft
+
 The "fallback" or legacy version of the remote builder can be used for
 ``core20`` and ``core22`` snaps.  It is not available for ``core24`` and newer
 snaps.
-
-Support for the legacy version of the remote builder for ``core22`` snaps will be
-removed in an upcoming major release of Snapcraft.
 
 The legacy remote builder was deprecated because of its design. It retrieves and
 tarballs remote sources and modifies the project file to point to the local tarballs.

--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -131,10 +131,10 @@ def remote_build(
 
     if base == "core22":
         echo.warning(
-            "The legacy remote builder for core22 snaps is deprecated and will "
-            "be removed in an upcoming major release of Snapcraft. "
-            "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
-            "for more information."
+            "The legacy remote builder for core22 snaps will be removed in a future release. "
+            "Use the new remote builder instead.\n"
+            "For more information, check out "
+            "https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
         )
 
     if not build_id:

--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -131,7 +131,7 @@ def remote_build(
 
     if base == "core22":
         echo.warning(
-            "Using the legacy remote builder for core22 snaps is deprecated and will "
+            "The legacy remote builder for core22 snaps is deprecated and will "
             "be removed in an upcoming major release of Snapcraft. "
             "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
             "for more information."

--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -125,9 +125,17 @@ def remote_build(
         build_on = build_for
 
     try:
-        project._get_build_base()
+        base = project._get_build_base()
     except RuntimeError:
         raise errors.BaseRequiredError()
+
+    if base == "core22":
+        echo.warning(
+            "Using the legacy remote builder for core22 snaps is deprecated and will "
+            "be removed in an upcoming major release of Snapcraft. "
+            "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
+            "for more information."
+        )
 
     if not build_id:
         # If the option wasn't provided, use the project directory hash

--- a/tests/legacy/unit/commands/test_remote.py
+++ b/tests/legacy/unit/commands/test_remote.py
@@ -79,7 +79,7 @@ class RemoteBuildTests(CommandBaseTestCase):
             result.output,
             Not(
                 Contains(
-                    "Using the legacy remote builder for core22 snaps is deprecated and will "
+                    "The legacy remote builder for core22 snaps is deprecated and will "
                     "be removed in an upcoming major release of Snapcraft. "
                     "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
                     "for more information."
@@ -104,7 +104,7 @@ class RemoteBuildTests(CommandBaseTestCase):
         self.assertThat(
             result.output,
             Contains(
-                "Using the legacy remote builder for core22 snaps is deprecated and will "
+                "The legacy remote builder for core22 snaps is deprecated and will "
                 "be removed in an upcoming major release of Snapcraft. "
                 "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
                 "for more information."

--- a/tests/legacy/unit/commands/test_remote.py
+++ b/tests/legacy/unit/commands/test_remote.py
@@ -17,7 +17,7 @@
 from unittest import mock
 
 import fixtures
-from testtools.matchers import Contains, Equals
+from testtools.matchers import Contains, Equals, Not
 
 import snapcraft_legacy.internal.remote_build.errors as errors
 import snapcraft_legacy.project
@@ -60,6 +60,56 @@ class RemoteBuildTests(CommandBaseTestCase):
         self.mock_lc.start_build.assert_called_once()
         self.mock_lc.cleanup.assert_called_once()
         self.assertThat(result.output, Contains("Building snap package for i386."))
+        self.assertThat(result.exit_code, Equals(0))
+        mock_confirm.assert_not_called()
+
+    @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
+    def test_remote_build_core20_no_deprecation_warning(self, mock_confirm):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path,
+            base="core20",
+            parts={"part0": {"plugin": "nil"}},
+        )
+        self.useFixture(snapcraft_yaml)
+        result = self.run_command(["remote-build", "--launchpad-accept-public-upload"])
+
+        self.mock_lc.start_build.assert_called_once()
+        self.mock_lc.cleanup.assert_called_once()
+        self.assertThat(
+            result.output,
+            Not(
+                Contains(
+                    "Using the legacy remote builder for core22 snaps is deprecated and will "
+                    "be removed in an upcoming major release of Snapcraft. "
+                    "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
+                    "for more information."
+                )
+            )
+        )
+        self.assertThat(result.exit_code, Equals(0))
+        mock_confirm.assert_not_called()
+
+    @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
+    def test_remote_build_core22_deprecation_warning(self, mock_confirm):
+        snapcraft_yaml = fixture_setup.SnapcraftYaml(
+            self.path,
+            base="core22",
+            parts={"part0": {"plugin": "nil"}},
+        )
+        self.useFixture(snapcraft_yaml)
+        result = self.run_command(["remote-build", "--launchpad-accept-public-upload"])
+
+        self.mock_lc.start_build.assert_called_once()
+        self.mock_lc.cleanup.assert_called_once()
+        self.assertThat(
+            result.output,
+            Contains(
+                "Using the legacy remote builder for core22 snaps is deprecated and will "
+                "be removed in an upcoming major release of Snapcraft. "
+                "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
+                "for more information."
+            )
+        )
         self.assertThat(result.exit_code, Equals(0))
         mock_confirm.assert_not_called()
 

--- a/tests/legacy/unit/commands/test_remote.py
+++ b/tests/legacy/unit/commands/test_remote.py
@@ -79,10 +79,10 @@ class RemoteBuildTests(CommandBaseTestCase):
             result.output,
             Not(
                 Contains(
-                    "The legacy remote builder for core22 snaps is deprecated and will "
-                    "be removed in an upcoming major release of Snapcraft. "
-                    "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
-                    "for more information."
+                    "The legacy remote builder for core22 snaps will be removed in a future release. "
+                    "Use the new remote builder instead.\n"
+                    "For more information, check out "
+                    "https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
                 )
             )
         )
@@ -104,10 +104,10 @@ class RemoteBuildTests(CommandBaseTestCase):
         self.assertThat(
             result.output,
             Contains(
-                "The legacy remote builder for core22 snaps is deprecated and will "
-                "be removed in an upcoming major release of Snapcraft. "
-                "See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
-                "for more information."
+                "The legacy remote builder for core22 snaps will be removed in a future release. "
+                "Use the new remote builder instead.\n"
+                "For more information, check out "
+                "https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/#versions "
             )
         )
         self.assertThat(result.exit_code, Equals(0))


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Adds a deprecation notice for core22 snaps using the legacy remote builder.

Fixes #5427 
(SNAPCRAFT-1045)