### PR TITLE
chore: add deprecation warnings for hidden commands

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -54,3 +54,13 @@
 "reference/parts_steps.rst" "reference/parts/parts-and-steps.rst"
 "reference/snap-build-process.rst" "reference/processes/snap-build-process.rst"
 "reference/snap-publishing-process.rst" "reference/processes/snap-publishing-process.rst"
+
+# reference/commands
+"reference/commands/list.rst" "reference/commands/names.rst"
+"reference/commands/list-registered.rst" "reference/commands/names.rst"
+"reference/commands/extensions.rst" "reference/commands/list-extensions.rst"
+"reference/commands/plugins.rst" "reference/commands/list-plugins.rst"
+"reference/commands/tracks.rst" "reference/commands/list-tracks.rst"
+"reference/commands/revisions.rst" "reference/commands/list-revisions.rst"
+"reference/commands/push.rst" "reference/commands/upload.rst"
+"reference/commands/snap.rst" "reference/commands/pack.rst"

--- a/snapcraft/commands/core22/lifecycle.py
+++ b/snapcraft/commands/core22/lifecycle.py
@@ -298,6 +298,15 @@ class SnapCommand(_LifecycleCommand):
             help="Path to the resulting snap",
         )
 
+    @overrides
+    def run(self, parsed_args: argparse.Namespace):
+        emit.progress(
+            "The 'snap' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)
+
 
 class CleanCommand(_LifecycleStepCommand):
     """Remove part assets."""

--- a/snapcraft/commands/core22/lifecycle.py
+++ b/snapcraft/commands/core22/lifecycle.py
@@ -301,7 +301,7 @@ class SnapCommand(_LifecycleCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace):
         emit.progress(
-            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new="pack"),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/core22/lifecycle.py
+++ b/snapcraft/commands/core22/lifecycle.py
@@ -28,7 +28,7 @@ from craft_application.util import strtobool
 from craft_cli import BaseCommand, emit
 from overrides import overrides
 
-from snapcraft import pack, utils
+from snapcraft import const, pack, utils
 from snapcraft.parts import lifecycle as parts_lifecycle
 
 if TYPE_CHECKING:
@@ -301,8 +301,7 @@ class SnapCommand(_LifecycleCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace):
         emit.progress(
-            "The 'snap' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/extensions.py
+++ b/snapcraft/commands/extensions.py
@@ -28,7 +28,7 @@ from craft_platforms import DebianArchitecture
 from overrides import overrides
 from pydantic import BaseModel
 
-from snapcraft import extensions, models
+from snapcraft import const, extensions, models
 from snapcraft.parts.yaml_utils import (
     apply_yaml,
     extract_parse_info,
@@ -111,8 +111,7 @@ class ExtensionsCommand(ListExtensionsCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace) -> None:
         emit.progress(
-            "The 'extensions' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-extensions' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/extensions.py
+++ b/snapcraft/commands/extensions.py
@@ -108,6 +108,15 @@ class ExtensionsCommand(ListExtensionsCommand):
     name = "extensions"
     hidden = True
 
+    @overrides
+    def run(self, parsed_args: argparse.Namespace) -> None:
+        emit.progress(
+            "The 'extensions' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-extensions' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)
+
 
 class ExpandExtensionsCommand(AppCommand):
     """Expand the extensions in the snapcraft.yaml file."""

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -137,8 +137,8 @@ class SnapCommand(PackCommand):
         **kwargs: Any,
     ) -> None:
         emit.progress(
-            "Warning: the 'snap' command is deprecated and will be removed "
-            "in a future release of Snapcraft. Use 'pack' instead.",
+            "The 'snap' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
             permanent=True,
         )
 

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -25,6 +25,7 @@ from craft_cli import emit
 
 import snapcraft.errors
 import snapcraft.pack
+from snapcraft import const
 
 
 class PackCommand(craft_application.commands.lifecycle.PackCommand):
@@ -137,8 +138,7 @@ class SnapCommand(PackCommand):
         **kwargs: Any,
     ) -> None:
         emit.progress(
-            "The 'snap' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
 

--- a/snapcraft/commands/names.py
+++ b/snapcraft/commands/names.py
@@ -187,13 +187,26 @@ class StoreLegacyListCommand(StoreNamesCommand):
     hidden = True
 
     @overrides
-    def run(self, parsed_args: argparse.Namespace):
-        emit.progress("This command is deprecated: use 'names' instead", permanent=True)
+    def run(self, parsed_args: argparse.Namespace) -> None:
+        emit.progress(
+            "The 'list' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'names' instead.",
+            permanent=True,
+        )
         super().run(parsed_args)
 
 
-class StoreLegacyListRegisteredCommand(StoreLegacyListCommand):
+class StoreLegacyListRegisteredCommand(StoreNamesCommand):
     """Legacy command to list the snap names registered with the current account."""
 
     name = "list-registered"
     hidden = True
+
+    @overrides
+    def run(self, parsed_args: argparse.Namespace) -> None:
+        emit.progress(
+            "The 'list-registered' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'names' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)

--- a/snapcraft/commands/names.py
+++ b/snapcraft/commands/names.py
@@ -28,7 +28,7 @@ from craft_cli import emit
 from overrides import overrides
 from tabulate import tabulate
 
-from snapcraft import store, utils
+from snapcraft import const, store, utils
 
 if TYPE_CHECKING:
     import argparse
@@ -189,8 +189,7 @@ class StoreLegacyListCommand(StoreNamesCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace) -> None:
         emit.progress(
-            "The 'list' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'names' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)
@@ -205,8 +204,7 @@ class StoreLegacyListRegisteredCommand(StoreNamesCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace) -> None:
         emit.progress(
-            "The 'list-registered' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'names' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/plugins.py
+++ b/snapcraft/commands/plugins.py
@@ -111,8 +111,7 @@ class PluginsCommand(ListPluginsCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace) -> None:
         emit.progress(
-            "The 'plugins' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-plugins' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/plugins.py
+++ b/snapcraft/commands/plugins.py
@@ -107,3 +107,12 @@ class PluginsCommand(ListPluginsCommand):
 
     name = "plugins"
     hidden = True
+
+    @overrides
+    def run(self, parsed_args: argparse.Namespace) -> None:
+        emit.progress(
+            "The 'plugins' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-plugins' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -30,7 +30,7 @@ from craft_cli import emit
 from overrides import overrides
 from tabulate import tabulate
 
-from snapcraft import store
+from snapcraft import const, store
 from snapcraft.store.channel_map import ChannelMap, MappedChannel, Revision, SnapChannel
 
 if TYPE_CHECKING:
@@ -433,8 +433,7 @@ class StoreTracksCommand(StoreListTracksCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace):
         emit.progress(
-            "The 'tracks' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-tracks' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)
@@ -562,8 +561,7 @@ class StoreRevisionsCommand(StoreListRevisionsCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace):
         emit.progress(
-            "The 'revisions' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-revisions' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/status.py
+++ b/snapcraft/commands/status.py
@@ -430,6 +430,15 @@ class StoreTracksCommand(StoreListTracksCommand):
     name = "tracks"
     hidden = True
 
+    @overrides
+    def run(self, parsed_args: argparse.Namespace):
+        emit.progress(
+            "The 'tracks' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-tracks' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)
+
 
 class StoreListRevisionsCommand(AppCommand):
     """List revisions of a published snap."""
@@ -549,3 +558,12 @@ class StoreRevisionsCommand(StoreListRevisionsCommand):
 
     name = "revisions"
     hidden = True
+
+    @overrides
+    def run(self, parsed_args: argparse.Namespace):
+        emit.progress(
+            "The 'revisions' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-revisions' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)

--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -29,7 +29,7 @@ from craft_cli.errors import ArgumentParsingError
 from overrides import overrides
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
-from snapcraft import errors, store, utils
+from snapcraft import const, errors, store, utils
 from snapcraft.meta import SnapMetadata
 from snapcraft_legacy._store import get_data_from_snap_file
 
@@ -222,8 +222,7 @@ class StoreLegacyPushCommand(StoreUploadCommand):
     @overrides
     def run(self, parsed_args: argparse.Namespace):
         emit.progress(
-            "The 'push' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'upload' instead.",
+            const.DEPRECATED_COMMAND_WARNING.format(old=self.name, new=super().name),
             permanent=True,
         )
         super().run(parsed_args)

--- a/snapcraft/commands/upload.py
+++ b/snapcraft/commands/upload.py
@@ -218,3 +218,12 @@ class StoreLegacyPushCommand(StoreUploadCommand):
 
     name = "push"
     hidden = True
+
+    @overrides
+    def run(self, parsed_args: argparse.Namespace):
+        emit.progress(
+            "The 'push' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'upload' instead.",
+            permanent=True,
+        )
+        super().run(parsed_args)

--- a/snapcraft/const.py
+++ b/snapcraft/const.py
@@ -18,6 +18,11 @@
 
 import enum
 
+DEPRECATED_COMMAND_WARNING = (
+    "The '{old}' command was renamed to '{new}'. Use '{new}' instead. "
+    "The old name will be removed in a future release."
+)
+
 
 class SnapArch(str, enum.Enum):
     """An architecture for a snap."""

--- a/snapcraft/parts/lifecycle.py
+++ b/snapcraft/parts/lifecycle.py
@@ -134,12 +134,6 @@ def _run_command(  # noqa PLR0913 (too-many-arguments)
     if not managed_mode:
         run_project_checks(project, assets_dir=assets_dir)
 
-        if command_name == "snap":
-            emit.progress(
-                "The 'snap' command is deprecated, use 'pack' instead.",
-                permanent=True,
-            )
-
     if _is_manager(parsed_args):
         if command_name == "clean" and not part_names:
             _clean_provider(project, parsed_args)

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -26,58 +26,77 @@ from snapcraft.commands import lifecycle
 
 
 @pytest.mark.parametrize(
-    "cmd_name,cmd_class",
+    "cmd_class",
     [
-        ("pull", core22_lifecycle.PullCommand),
-        ("build", core22_lifecycle.BuildCommand),
-        ("stage", core22_lifecycle.StageCommand),
-        ("prime", core22_lifecycle.PrimeCommand),
-        ("clean", core22_lifecycle.CleanCommand),
-        ("try", core22_lifecycle.TryCommand),
+        core22_lifecycle.PullCommand,
+        core22_lifecycle.BuildCommand,
+        core22_lifecycle.StageCommand,
+        core22_lifecycle.PrimeCommand,
+        core22_lifecycle.CleanCommand,
+        core22_lifecycle.TryCommand,
     ],
 )
-def test_core22_lifecycle_command(cmd_name, cmd_class, mocker):
+def test_core22_lifecycle_command(cmd_class, mocker):
     lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
     cmd = cmd_class(None)
+
     cmd.run(argparse.Namespace(parts=["part1", "part2"]))
+
     assert lifecycle_run_mock.mock_calls == [
-        call(cmd_name, argparse.Namespace(parts=["part1", "part2"]))
+        call(cmd_class.name, argparse.Namespace(parts=["part1", "part2"]))
     ]
 
 
 @pytest.mark.parametrize(
-    "cmd_name,cmd_class",
+    "cmd_class",
     [
-        ("pack", core22_lifecycle.PackCommand),
-        ("snap", core22_lifecycle.SnapCommand),
+        core22_lifecycle.PackCommand,
+        core22_lifecycle.SnapCommand,
     ],
 )
-def test_core22_pack_command(mocker, cmd_name, cmd_class):
+def test_core22_pack_command(mocker, cmd_class, emitter):
     lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
     cmd = cmd_class(None)
+
     cmd.run(argparse.Namespace(directory=None, output=None, compression=None))
+
+    if cmd_class.hidden:
+        emitter.assert_progress(
+            f"The '{cmd_class.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            permanent=True,
+        )
     assert lifecycle_run_mock.mock_calls == [
         call(
-            cmd_name, argparse.Namespace(directory=None, output=None, compression=None)
+            cmd_class.name,
+            argparse.Namespace(directory=None, output=None, compression=None),
         )
     ]
 
 
 @pytest.mark.parametrize(
-    "cmd_name,cmd_class",
+    "cmd_class",
     [
-        ("pack", core22_lifecycle.PackCommand),
-        ("snap", core22_lifecycle.SnapCommand),
+        core22_lifecycle.PackCommand,
+        core22_lifecycle.SnapCommand,
     ],
 )
-def test_core22_pack_command_with_output(mocker, cmd_name, cmd_class):
+def test_core22_pack_command_with_output(mocker, cmd_class, emitter):
     lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
     cmd = cmd_class(None)
+
     cmd.run(argparse.Namespace(directory=None, output="output", compression=None))
+
+    if cmd_class.hidden:
+        emitter.assert_progress(
+            f"The '{cmd_class.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            permanent=True,
+        )
     assert lifecycle_run_mock.mock_calls == [
         call(
-            cmd_name,
+            cmd_class.name,
             argparse.Namespace(compression=None, directory=None, output="output"),
         )
     ]
@@ -88,7 +107,9 @@ def test_core22_pack_command_with_directory(mocker):
     lifecycle_run_mock = mocker.patch("snapcraft.parts.lifecycle.run")
     pack_mock = mocker.patch("snapcraft.pack.pack_snap")
     cmd = core22_lifecycle.PackCommand(None)
+
     cmd.run(argparse.Namespace(directory=".", output=None, compression=None))
+
     assert lifecycle_run_mock.mock_calls == []
     assert pack_mock.mock_calls[0] == call(".", output=None)
 
@@ -98,11 +119,13 @@ def test_snap_command_fallback(tmp_path, emitter, mocker, fake_services):
     parsed_args = argparse.Namespace(parts=[], output=tmp_path)
     mock_pack = mocker.patch("snapcraft.commands.lifecycle.PackCommand._run")
     cmd = lifecycle.SnapCommand({"app": APP_METADATA, "services": fake_services})
+
     cmd.run(parsed_args=parsed_args)
+
     mock_pack.assert_called_once()
     emitter.assert_progress(
-        "Warning: the 'snap' command is deprecated and will be removed "
-        "in a future release of Snapcraft. Use 'pack' instead.",
+        "The 'snap' command is deprecated and will be removed "
+        "in an upcoming major release of Snapcraft. Use 'pack' instead.",
         permanent=True,
     )
 
@@ -119,3 +142,21 @@ def test_core24_try_command(tmp_path, fake_services):
         'Command or feature not implemented: "snapcraft try" is not '
         "implemented for core24"
     )
+
+
+def test_core24_snap(mocker, emitter, fake_services, tmp_path):
+    parsed_args = argparse.Namespace(
+        destructive_mode=False, directory=tmp_path, output="test-output"
+    )
+    pack_mock = mocker.patch("snapcraft.pack.pack_snap")
+    cmd = lifecycle.SnapCommand({"app": APP_METADATA, "services": fake_services})
+
+    cmd.run(parsed_args)
+
+    if cmd.hidden:
+        emitter.assert_progress(
+            f"The '{cmd.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            permanent=True,
+        )
+    assert pack_mock.mock_calls[0] == call(tmp_path, output="test-output")

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -62,8 +62,8 @@ def test_core22_pack_command(mocker, cmd_class, emitter):
 
     if cmd_class.hidden:
         emitter.assert_progress(
-            f"The '{cmd_class.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            f"The '{cmd_class.name}' command was renamed to 'pack'. Use 'pack' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     assert lifecycle_run_mock.mock_calls == [
@@ -90,8 +90,8 @@ def test_core22_pack_command_with_output(mocker, cmd_class, emitter):
 
     if cmd_class.hidden:
         emitter.assert_progress(
-            f"The '{cmd_class.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            f"The '{cmd_class.name}' command was renamed to 'pack'. Use 'pack' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     assert lifecycle_run_mock.mock_calls == [
@@ -124,8 +124,8 @@ def test_snap_command_fallback(tmp_path, emitter, mocker, fake_services):
 
     mock_pack.assert_called_once()
     emitter.assert_progress(
-        "The 'snap' command is deprecated and will be removed "
-        "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+        "The 'snap' command was renamed to 'pack'. Use 'pack' instead. "
+        "The old name will be removed in a future release.",
         permanent=True,
     )
 
@@ -155,8 +155,8 @@ def test_core24_snap(mocker, emitter, fake_services, tmp_path):
 
     if cmd.hidden:
         emitter.assert_progress(
-            f"The '{cmd.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'pack' instead.",
+            f"The '{cmd.name}' command was renamed to 'pack'. Use 'pack' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     assert pack_mock.mock_calls[0] == call(tmp_path, output="test-output")

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -37,8 +37,8 @@ def test_command(emitter, command, fake_app_config):
 
     if cmd.hidden:
         emitter.assert_progress(
-            f"The '{cmd.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-extensions' instead.",
+            f"The '{cmd.name}' command was renamed to 'list-extensions'. Use 'list-extensions' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     emitter.assert_message(

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -32,7 +32,15 @@ import snapcraft.commands
 )
 def test_command(emitter, command, fake_app_config):
     cmd = command(fake_app_config)
+
     cmd.run(Namespace())
+
+    if cmd.hidden:
+        emitter.assert_progress(
+            f"The '{cmd.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-extensions' instead.",
+            permanent=True,
+        )
     emitter.assert_message(
         dedent(
             """\

--- a/tests/unit/commands/test_names.py
+++ b/tests/unit/commands/test_names.py
@@ -222,8 +222,8 @@ class TestNames:
 
         if command_class.hidden:
             emitter.assert_progress(
-                f"The '{command_class.name}' command is deprecated and will be removed "
-                "in an upcoming major release of Snapcraft. Use 'names' instead.",
+                f"The '{command_class.name}' command was renamed to 'names'. Use 'names' instead. "
+                "The old name will be removed in a future release.",
                 permanent=True,
             )
         emitter.assert_message(
@@ -250,8 +250,8 @@ class TestNames:
 
         if command_class.hidden:
             emitter.assert_progress(
-                f"The '{command_class.name}' command is deprecated and will be removed "
-                "in an upcoming major release of Snapcraft. Use 'names' instead.",
+                f"The '{command_class.name}' command was renamed to 'names'. Use 'names' instead. "
+                "The old name will be removed in a future release.",
                 permanent=True,
             )
 

--- a/tests/unit/commands/test_names.py
+++ b/tests/unit/commands/test_names.py
@@ -222,7 +222,9 @@ class TestNames:
 
         if command_class.hidden:
             emitter.assert_progress(
-                "This command is deprecated: use 'names' instead", permanent=True
+                f"The '{command_class.name}' command is deprecated and will be removed "
+                "in an upcoming major release of Snapcraft. Use 'names' instead.",
+                permanent=True,
             )
         emitter.assert_message(
             dedent(
@@ -248,7 +250,8 @@ class TestNames:
 
         if command_class.hidden:
             emitter.assert_progress(
-                "This command is deprecated: use 'names' instead",
+                f"The '{command_class.name}' command is deprecated and will be removed "
+                "in an upcoming major release of Snapcraft. Use 'names' instead.",
                 permanent=True,
             )
 

--- a/tests/unit/commands/test_plugins.py
+++ b/tests/unit/commands/test_plugins.py
@@ -53,6 +53,12 @@ def test_registered_plugins_default(command, emitter, fake_app_config):
     """Default to core24."""
     command(fake_app_config).run(argparse.Namespace(base=None))
 
+    if command.hidden:
+        emitter.assert_progress(
+            f"The '{command.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-plugins' instead.",
+            permanent=True,
+        )
     emitter.assert_message(
         textwrap.dedent(
             """\

--- a/tests/unit/commands/test_plugins.py
+++ b/tests/unit/commands/test_plugins.py
@@ -55,8 +55,8 @@ def test_registered_plugins_default(command, emitter, fake_app_config):
 
     if command.hidden:
         emitter.assert_progress(
-            f"The '{command.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-plugins' instead.",
+            f"The '{command.name}' command was renamed to 'list-plugins'. Use 'list-plugins' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     emitter.assert_message(

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -695,6 +695,12 @@ def test_list_tracks(emitter, command_class, fake_app_config):
 
     cmd.run(argparse.Namespace(name="test-snap"))
 
+    if command_class.hidden:
+        emitter.assert_progress(
+            f"The '{command_class.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-tracks' instead.",
+            permanent=True,
+        )
     emitter.assert_message(
         "Name    Status    Creation-Date         Version-Pattern\n"
         "latest  active    -                     -\n"
@@ -707,12 +713,25 @@ def test_list_tracks(emitter, command_class, fake_app_config):
 ##########################
 
 
+@pytest.mark.parametrize(
+    "command_class",
+    [
+        commands.StoreListRevisionsCommand,
+        commands.StoreRevisionsCommand,
+    ],
+)
 @pytest.mark.usefixtures("memory_keyring", "fake_store_list_revisions")
-def test_list_revisions(emitter, fake_app_config):
-    cmd = commands.StoreListRevisionsCommand(fake_app_config)
+def test_list_revisions(emitter, command_class, fake_app_config):
+    cmd = command_class(fake_app_config)
 
     cmd.run(argparse.Namespace(snap_name="test-snap", arch=None))
 
+    if command_class.hidden:
+        emitter.assert_progress(
+            f"The '{command_class.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'list-revisions' instead.",
+            permanent=True,
+        )
     emitter.assert_message(
         dedent(
             """\

--- a/tests/unit/commands/test_status.py
+++ b/tests/unit/commands/test_status.py
@@ -697,8 +697,8 @@ def test_list_tracks(emitter, command_class, fake_app_config):
 
     if command_class.hidden:
         emitter.assert_progress(
-            f"The '{command_class.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-tracks' instead.",
+            f"The '{command_class.name}' command was renamed to 'list-tracks'. Use 'list-tracks' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     emitter.assert_message(
@@ -728,8 +728,8 @@ def test_list_revisions(emitter, command_class, fake_app_config):
 
     if command_class.hidden:
         emitter.assert_progress(
-            f"The '{command_class.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'list-revisions' instead.",
+            f"The '{command_class.name}' command was renamed to 'list-revisions'. Use 'list-revisions' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     emitter.assert_message(

--- a/tests/unit/commands/test_upload.py
+++ b/tests/unit/commands/test_upload.py
@@ -104,8 +104,8 @@ def test_default(
 
     if command_class.hidden:
         emitter.assert_progress(
-            f"The '{command_class.name}' command is deprecated and will be removed "
-            "in an upcoming major release of Snapcraft. Use 'upload' instead.",
+            f"The '{command_class.name}' command was renamed to 'upload'. Use 'upload' instead. "
+            "The old name will be removed in a future release.",
             permanent=True,
         )
     assert fake_store_verify_upload.mock_calls == [call(ANY, snap_name="basic")]

--- a/tests/unit/commands/test_upload.py
+++ b/tests/unit/commands/test_upload.py
@@ -102,6 +102,12 @@ def test_default(
         )
     )
 
+    if command_class.hidden:
+        emitter.assert_progress(
+            f"The '{command_class.name}' command is deprecated and will be removed "
+            "in an upcoming major release of Snapcraft. Use 'upload' instead.",
+            permanent=True,
+        )
     assert fake_store_verify_upload.mock_calls == [call(ANY, snap_name="basic")]
     assert fake_store_notify_upload.mock_calls == [
         call(

--- a/tools/docs/gen_cli_docs.py
+++ b/tools/docs/gen_cli_docs.py
@@ -103,6 +103,8 @@ def main(docs_dir):
         g = group_path.open("w")
 
         for cmd_class in sorted(group.commands, key=lambda c: c.name):
+            if cmd_class.hidden:
+                continue
             cmd = cmd_class(app.app_config)
             p = _CustomArgumentParser(help_builder)
             cmd.fill_parser(p)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

#### Changes
* Adds a uniform deprecation warning for all deprecated commands.
* Hides and redirects reference pages for hidden commands.

#### What is not covered
* A deprecation warning for the default command (`snapcraft` defaulting to `snapcraft pack`). See #5525.

Fixes #5428
(SNAPCRAFT-1048)