### PR TITLE
fix: remove test artifact workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "attrs",
     "catkin-pkg==1.0.0 ; sys_platform == 'linux'",
     "click>=8.2",
-    "craft-application[remote]>=5.2.0,<6.0.0",
+    "craft-application[remote]>=5.3.0,<6.0.0",
     "craft-archives~=2.1",
     "craft-cli~=3.0",
     "craft-grammar>=2.0.3,<3.0.0",

--- a/tests/spread/core24/init-test/task.yaml
+++ b/tests/spread/core24/init-test/task.yaml
@@ -15,6 +15,4 @@ execute: |
   cd test-snap
   snapcraft init
   snapcraft init --profile=test
-  # Remove once the packing issue is solved
-  snapcraft pack
   snapcraft test


### PR DESCRIPTION
Fixes in craft-application 3.5 allow `snapcraft test` to run without workarounds to locate the generated artifact.

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
