### PR TITLE
chore(snapcraft_legacy): deduplicate parameter registration

### DIFF
--- a/snapcraft_legacy/cli/_options.py
+++ b/snapcraft_legacy/cli/_options.py
@@ -78,7 +78,7 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         supported_providers=_SUPPORTED_PROVIDERS,
     ),
     dict(
-        param_decls=["--debug"],
+        param_decls=["--debug", "-d"],
         is_flag=True,
         help="Shells into the environment if the build fails.",
         supported_providers=_ALL_PROVIDERS,

--- a/snapcraft_legacy/cli/_runner.py
+++ b/snapcraft_legacy/cli/_runner.py
@@ -91,8 +91,6 @@ def configure_requests_ca() -> None:
 )
 @click.pass_context
 @add_provider_options(hidden=True)
-@click.option("--debug", "-d", is_flag=True)
-@click.option("--verbose", "-v", is_flag=True)
 def run(ctx, debug, catch_exceptions=False, **kwargs):
     """Snapcraft is a delightful packaging tool."""
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

We updated click in https://github.com/canonical/snapcraft/pull/5505 and now it complains when the same parameter is registered more than once:
```
/snap/snapcraft/x6/lib/python3.12/site-packages/click/core.py:1193: UserWarning: The parameter --debug is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
/snap/snapcraft/x6/lib/python3.12/site-packages/click/core.py:1193: UserWarning: The parameter --verbose is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
/snap/snapcraft/x6/lib/python3.12/site-packages/click/core.py:1193: UserWarning: The parameter -v is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
/snap/snapcraft/x6/lib/python3.12/site-packages/click/core.py:1786: UserWarning: The parameter --debug is used more than once. Remove its duplicate as parameters should be unique.
  rest = super().parse_args(ctx, args)
/snap/snapcraft/x6/lib/python3.12/site-packages/click/core.py:1786: UserWarning: The parameter --verbose is used more than once. Remove its duplicate as parameters should be unique.
  rest = super().parse_args(ctx, args)
/snap/snapcraft/x6/lib/python3.12/site-packages/click/core.py:1786: UserWarning: The parameter -v is used more than once. Remove its duplicate as parameters should be unique.
  rest = super().parse_args(ctx, args)
```

This PR drops the double registration of parameters.  There are no behavioral changes.

Fixes #5527