### PR TITLE
feat(validation-sets): warn when the sequence isn't incremented

### DIFF
--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -90,11 +90,12 @@ class StoreEditValidationSetsCommand(AppCommand):
         )
         parser.add_argument("account_id", metavar="account-id")
         parser.add_argument("set_name", metavar="set-name")
-        parser.add_argument("sequence", metavar="sequence")
+        parser.add_argument("sequence", metavar="sequence", type=int)
 
     @overrides
     def run(self, parsed_args: argparse.Namespace):
         store_client = StoreClientCLI()
+        kwargs = {"sequence": parsed_args.sequence}
 
         asserted_validation_sets = store_client.get_validation_sets(
             name=parsed_args.set_name, sequence=str(parsed_args.sequence)
@@ -111,7 +112,7 @@ class StoreEditValidationSetsCommand(AppCommand):
             validation_sets_path = Path(temp_file.name)
 
         validation_sets_path.write_text(validation_sets_template, encoding="utf-8")
-        edited_validation_sets = edit_validation_sets(validation_sets_path)
+        edited_validation_sets = edit_validation_sets(validation_sets_path, **kwargs)
 
         if edited_validation_sets == validation_sets.EditableBuildAssertion(
             **yaml.safe_load(validation_sets_template)
@@ -134,7 +135,9 @@ class StoreEditValidationSetsCommand(AppCommand):
                         raise errors.SnapcraftError(
                             "operation aborted"
                         ) from validation_error
-                    edited_validation_sets = edit_validation_sets(validation_sets_path)
+                    edited_validation_sets = edit_validation_sets(
+                        validation_sets_path, **kwargs
+                    )
         finally:
             validation_sets_path.unlink()
 
@@ -201,9 +204,13 @@ def _generate_template(
 
 
 def edit_validation_sets(
-    validation_sets_path: Path,
+    validation_sets_path: Path, **kwargs: dict[str, Any]
 ) -> validation_sets.EditableBuildAssertion:
-    """Spawn an editor to modify the validation-sets."""
+    """Spawn an editor to modify the assertion.
+
+    :param validation_sets_path: The path to the assertion.
+    :param kwargs: Additional keyword arguments to use for validation.
+    """
     editor_cmd = os.getenv("EDITOR", "vi")
 
     while True:
@@ -220,11 +227,33 @@ def edit_validation_sets(
                     filepath=Path("validation-sets"),
                 )
             )
+            validate_assertion(edited_validation_sets, **kwargs)
             return edited_validation_sets
         except (yaml.YAMLError, CraftValidationError) as err:
             emit.message(f"{err!s}")
             if not utils.confirm_with_user("Do you wish to amend the validation set?"):
                 raise errors.SnapcraftError("operation aborted") from err
+
+
+def validate_assertion(
+    assertion: validation_sets.EditableBuildAssertion, **kwargs: dict[str, Any]
+) -> None:
+    """Additional validation to perform on the assertion.
+
+    :param assertion: The assertion to validate.
+    :param kwargs: Additional keyword arguments to use for validation.
+
+    :raises CraftValidationError: If the assertion is invalid.
+    """
+    new_sequence = assertion.sequence
+    old_sequence = kwargs.get("sequence")
+    emit.debug(f"Sequence updated from {old_sequence} to {new_sequence}")
+
+    if new_sequence == old_sequence:
+        raise CraftValidationError(
+            "Warning: The sequence number was not incremented. This prevents automatic reversions to a valid state in "
+            "the case of invalid changes or snap refresh failures."
+        )
 
 
 def _sign_assertion(assertion: dict[str, Any], *, key_name: str | None) -> bytes:

--- a/snapcraft/commands/validation_sets.py
+++ b/snapcraft/commands/validation_sets.py
@@ -24,7 +24,7 @@ import subprocess
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import craft_application.util
 import yaml
@@ -246,10 +246,10 @@ def validate_assertion(
     :raises CraftValidationError: If the assertion is invalid.
     """
     new_sequence = assertion.sequence
-    old_sequence = kwargs.get("sequence")
+    old_sequence = cast(int, kwargs.get("sequence", 0))
     emit.debug(f"Sequence updated from {old_sequence} to {new_sequence}")
 
-    if new_sequence == old_sequence:
+    if new_sequence <= old_sequence:
         raise CraftValidationError(
             "Warning: The sequence number was not incremented. This prevents automatic reversions to a valid state in "
             "the case of invalid changes or snap refresh failures."

--- a/snapcraft/services/assertions.py
+++ b/snapcraft/services/assertions.py
@@ -266,7 +266,12 @@ class Assertion(base.AppService):
         return signed_assertion
 
     def edit_assertion(
-        self, *, name: str, account_id: str, key_name: str | None = None
+        self,
+        *,
+        name: str,
+        account_id: str,
+        key_name: str | None = None,
+        **kwargs: dict[str, Any],
     ) -> None:
         """Edit, sign and upload an assertion.
 
@@ -275,6 +280,7 @@ class Assertion(base.AppService):
         :param name: The name of the assertion to edit.
         :param account_id: The account ID associated with the confdb schema.
         :param key_name: Name of the key to sign the assertion.
+        :param kwargs: Additional keyword arguments to use for validation.
         """
         yaml_data = self._get_yaml_data(name=name, account_id=account_id)
         yaml_file = self._write_to_file(yaml_data)
@@ -293,6 +299,7 @@ class Assertion(base.AppService):
                     craft_cli.emit.progress(f"Building {self._assertion_name}.")
                     built_assertion = self._build_assertion(edited_assertion)
                     craft_cli.emit.progress(f"Built {self._assertion_name}.")
+                    self._validate_assertion(built_assertion, **kwargs)
 
                     signed_assertion = self._sign_assertion(built_assertion, key_name)
                     published_assertion = self._post_assertion(signed_assertion)
@@ -313,3 +320,18 @@ class Assertion(base.AppService):
                         ) from assertion_error
         finally:
             self._remove_temp_file(yaml_file)
+
+    def _validate_assertion(
+        self, assertion: models.Assertion, **kwargs: dict[str, Any]
+    ) -> None:
+        """Additional validation to perform on the assertion after building.
+
+        Child classes should override this method if they need to perform
+        custom validation.
+
+        :param assertion: The assertion to validate.
+        :param kwargs: Additional keyword arguments to use for validation.
+
+        :raises SnapcraftAssertionError: If the assertion is invalid.
+        """
+        pass

--- a/tests/spread/store/validation-sets/editor.sh
+++ b/tests/spread/store/validation-sets/editor.sh
@@ -10,3 +10,7 @@ else
 fi
 
 sed -i "s/  presence:.*/  presence: $presence/g" "$validation_set_file"
+
+# increment the sequence
+# shellcheck disable=SC2002 # yq snap can't access /tmp
+cat "$validation_set_file" | yq '.sequence += 1' | tee "$validation_set_file"

--- a/tests/unit/commands/test_validation_sets.py
+++ b/tests/unit/commands/test_validation_sets.py
@@ -495,3 +495,61 @@ def test_edit_yaml_error_no_retry(mocker, tmp_path, monkeypatch):
 
     assert confirm_mock.mock_calls == [call("Do you wish to amend the validation set?")]
     assert subprocess_mock.mock_calls == [call(["faux-vi", tmp_file], check=True)]
+
+
+def test_edit_sequence_error_retry(mocker, tmp_path, monkeypatch, emitter):
+    """Don't increment the sequence number, then amend and increment the sequence number."""
+    monkeypatch.setenv("EDITOR", "faux-vi")
+    kwargs: dict[str, Any] = {"sequence": 9}
+    tmp_file = tmp_path / "validation_sets_template"
+    confirm_mock = mocker.patch("snapcraft.utils.confirm_with_user", return_value=True)
+    expected_edited_assertion = validation_sets.EditableBuildAssertion.unmarshal(
+        {
+            "account-id": "test",
+            "name": "test",
+            "sequence": 10,
+            "snaps": [{"name": "core22"}],
+        }
+    )
+    yaml_original_sequence = "{'account-id': 'test', 'name': 'test', 'sequence': 9, 'snaps': [{'name': 'core22'}]}"
+    yaml_new_sequence = "{'account-id': 'test', 'name': 'test', 'sequence': 10, 'snaps': [{'name': 'core22'}]}"
+    data_write = [yaml_new_sequence, yaml_original_sequence]
+
+    def side_effect(*args, **kwargs):
+        tmp_file.write_text(data_write.pop(), encoding="utf-8")
+
+    subprocess_mock = mocker.patch("subprocess.run", side_effect=side_effect)
+
+    assert edit_validation_sets(tmp_file, **kwargs) == expected_edited_assertion
+    assert confirm_mock.mock_calls == [call("Do you wish to amend the validation set?")]
+    assert subprocess_mock.mock_calls == [call(["faux-vi", tmp_file], check=True)] * 2
+    emitter.assert_message(
+        "Warning: The sequence number was not incremented. This prevents automatic reversions "
+        "to a valid state in the case of invalid changes or snap refresh failures."
+    )
+
+
+def test_edit_sequence_error_no_retry(mocker, tmp_path, monkeypatch, emitter):
+    """Don't increment the sequence number and don't amend."""
+    monkeypatch.setenv("EDITOR", "faux-vi")
+    kwargs: dict[str, Any] = {"sequence": 9}
+    tmp_file = tmp_path / "validation_sets_template"
+    confirm_mock = mocker.patch("snapcraft.utils.confirm_with_user", return_value=False)
+
+    def side_effect(*args, **kwargs):
+        tmp_file.write_text(
+            "{'account-id': 'test', 'name': 'test', 'sequence': 9, 'snaps': [{'name': 'core22'}]}",
+            encoding="utf-8",
+        )
+
+    subprocess_mock = mocker.patch("subprocess.run", side_effect=side_effect)
+
+    with pytest.raises(errors.SnapcraftError):
+        edit_validation_sets(tmp_file, **kwargs)
+
+    assert confirm_mock.mock_calls == [call("Do you wish to amend the validation set?")]
+    assert subprocess_mock.mock_calls == [call(["faux-vi", tmp_file], check=True)]
+    emitter.assert_message(
+        "Warning: The sequence number was not incremented. This prevents automatic reversions "
+        "to a valid state in the case of invalid changes or snap refresh failures."
+    )

--- a/tests/unit/commands/test_validation_sets.py
+++ b/tests/unit/commands/test_validation_sets.py
@@ -497,7 +497,13 @@ def test_edit_yaml_error_no_retry(mocker, tmp_path, monkeypatch):
     assert subprocess_mock.mock_calls == [call(["faux-vi", tmp_file], check=True)]
 
 
-def test_edit_sequence_error_retry(mocker, tmp_path, monkeypatch, emitter):
+@pytest.mark.parametrize(
+    "sequence_num",
+    [pytest.param(9, id="not incremented"), pytest.param(4, id="decremented")],
+)
+def test_edit_sequence_error_retry(
+    sequence_num, mocker, tmp_path, monkeypatch, emitter
+):
     """Don't increment the sequence number, then amend and increment the sequence number."""
     monkeypatch.setenv("EDITOR", "faux-vi")
     kwargs: dict[str, Any] = {"sequence": 9}
@@ -511,7 +517,7 @@ def test_edit_sequence_error_retry(mocker, tmp_path, monkeypatch, emitter):
             "snaps": [{"name": "core22"}],
         }
     )
-    yaml_original_sequence = "{'account-id': 'test', 'name': 'test', 'sequence': 9, 'snaps': [{'name': 'core22'}]}"
+    yaml_original_sequence = f"{{'account-id': 'test', 'name': 'test', 'sequence': {sequence_num}, 'snaps': [{{'name': 'core22'}}]}}"
     yaml_new_sequence = "{'account-id': 'test', 'name': 'test', 'sequence': 10, 'snaps': [{'name': 'core22'}]}"
     data_write = [yaml_new_sequence, yaml_original_sequence]
 
@@ -529,7 +535,13 @@ def test_edit_sequence_error_retry(mocker, tmp_path, monkeypatch, emitter):
     )
 
 
-def test_edit_sequence_error_no_retry(mocker, tmp_path, monkeypatch, emitter):
+@pytest.mark.parametrize(
+    "sequence_num",
+    [pytest.param(9, id="not incremented"), pytest.param(4, id="decremented")],
+)
+def test_edit_sequence_error_no_retry(
+    sequence_num, mocker, tmp_path, monkeypatch, emitter
+):
     """Don't increment the sequence number and don't amend."""
     monkeypatch.setenv("EDITOR", "faux-vi")
     kwargs: dict[str, Any] = {"sequence": 9}
@@ -538,7 +550,7 @@ def test_edit_sequence_error_no_retry(mocker, tmp_path, monkeypatch, emitter):
 
     def side_effect(*args, **kwargs):
         tmp_file.write_text(
-            "{'account-id': 'test', 'name': 'test', 'sequence': 9, 'snaps': [{'name': 'core22'}]}",
+            f"{{'account-id': 'test', 'name': 'test', 'sequence': {sequence_num}, 'snaps': [{{'name': 'core22'}}]}}",
             encoding="utf-8",
         )
 

--- a/tests/unit/services/test_assertions.py
+++ b/tests/unit/services/test_assertions.py
@@ -194,6 +194,16 @@ def fake_assertion_service(fake_services):
         ) -> str:
             return "Success."
 
+        @override
+        def _validate_assertion(  # type: ignore[override]
+            self,
+            assertion: FakeAssertion,
+            **kwargs: dict[str, Any],
+        ) -> None:
+            """Add an simple custom validator."""
+            if kwargs.get("test-arg") == assertion.test_field_2:
+                raise errors.SnapcraftAssertionError("Custom validation failed.")
+
     return FakeAssertionService(app=APP_METADATA, services=fake_services)
 
 
@@ -542,3 +552,86 @@ def test_edit_error_no_retry(
         mock.call("Do you wish to amend the fake assertion?")
     ]
     assert write_text.mock_calls == [mock.call(["faux-vi", tmp_file], check=True)]
+
+
+@pytest.mark.parametrize(
+    "write_text",
+    [
+        [
+            "test-field-1: test-value-1-edited\ntest-field-2: 1000",
+            "test-field-1: test-value-1-edited\ntest-field-2: 999",
+        ],
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mock_confirm_with_user", [True], indirect=True)
+@pytest.mark.usefixtures("fake_sign_assertion")
+def test_edit_assertions_validate_assertion_error_retry(
+    fake_assertion_service,
+    emitter,
+    mock_confirm_with_user,
+    write_text,
+    mocker,
+    tmp_path,
+):
+    """Receive an error when validating an assertion, the re-edit and post the assertion."""
+    # this will trigger an error in FakeAssertion.validate_assertion
+    kwargs: dict[str, Any] = {"test-arg": 999}
+    expected_assertion = (
+        b'{"test_field_1": "test-value-1-edited-built", "test_field_2": "1000"}-signed'
+    )
+    mock_post_assertion = mocker.spy(fake_assertion_service, "_post_assertion")
+
+    fake_assertion_service.setup()
+    fake_assertion_service.edit_assertion(
+        name="test-confb", account_id="test-account-id", key_name="test-key", **kwargs
+    )
+
+    assert mock_confirm_with_user.mock_calls == [
+        mock.call("Do you wish to amend the fake assertion?")
+    ]
+    assert mock_post_assertion.mock_calls == [mock.call(expected_assertion)]
+    emitter.assert_trace(f"Signed assertion: {expected_assertion.decode()}")
+    emitter.assert_message("Success.")
+    assert not (tmp_path / "assertion-file").exists()
+
+
+@pytest.mark.parametrize(
+    "write_text",
+    [
+        [
+            "test-field-1: test-value-1-edited\ntest-field-2: 999",
+        ],
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mock_confirm_with_user", [False], indirect=True)
+@pytest.mark.usefixtures("fake_sign_assertion")
+def test_edit_assertions_validate_assertion_error(
+    fake_assertion_service,
+    emitter,
+    mock_confirm_with_user,
+    write_text,
+    mocker,
+    tmp_path,
+):
+    """Receive an error when validating an assertion and don't retry."""
+    # this will trigger an error in FakeAssertion.validate_assertion
+    kwargs: dict[str, Any] = {"test-arg": 999}
+    mock_post_assertion = mocker.spy(fake_assertion_service, "_post_assertion")
+
+    fake_assertion_service.setup()
+
+    with pytest.raises(errors.SnapcraftError, match="operation aborted"):
+        fake_assertion_service.edit_assertion(
+            name="test-confb",
+            account_id="test-account-id",
+            key_name="test-key",
+            **kwargs,
+        )
+
+    assert mock_confirm_with_user.mock_calls == [
+        mock.call("Do you wish to amend the fake assertion?")
+    ]
+    assert mock_post_assertion.mock_calls == []
+    assert not (tmp_path / "assertion-file").exists()

--- a/tests/unit/store/test_legacy_account.py
+++ b/tests/unit/store/test_legacy_account.py
@@ -105,6 +105,14 @@ def test_store_credentials_not_configparser_based_fails(
         LegacyUbuntuOne.store_credentials("not config parser")
 
 
+def test_store_credentials_unicode_decode_error(
+    legacy_config_path, legacy_config_credentials
+):
+    """Catch UnicodeDecode errors."""
+    with pytest.raises(errors.LegacyCredentialsParseError):
+        LegacyUbuntuOne.store_credentials("\\\\nfoo")
+
+
 def test_legacy_credentials_in_env(monkeypatch, legacy_config_credentials):
     monkeypatch.setenv("SNAPCRAFT_STORE_CREDENTIALS", legacy_config_credentials)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

This PR adds a warning when a user doesn't increment the sequence in a validation set.

I recommend reviewing per-commit.

The first commit does this with a new function `_validate_assertion()` and passing kwargs to the new function.

The second commit adds the same infrastructure to the abstract `AssertionService`, which currently isn't used for validation sets.  There are no user-facing changes here, but I'm doing this now while it's fresh in my mind. This will make creating a `ValidationSetsService` easier when we complete https://github.com/canonical/snapcraft/issues/5337.

Fixes #5367
(SNAPCRAFT-811)