### PR TITLE
chore: resolve deprecation warnings

### DIFF
--- a/snapcraft_legacy/internal/states/_global_state.py
+++ b/snapcraft_legacy/internal/states/_global_state.py
@@ -15,9 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from typing import List, Optional, Type
-
-from mypy_extensions import TypedDict
+from typing import List, Optional, Type, TypedDict
 
 from snapcraft_legacy import yaml_utils
 from snapcraft_legacy.internal.states._state import State

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -189,7 +189,7 @@ def test_application_extra_yaml_transforms(
     app = application.create_app()
     app.run()
 
-    project = app.get_project()
+    project = app.services.get("project").get()
     assert "fake-extension/fake-part" in project.parts
     assert project.parts["snapcraft/core"]["build-packages"] == ["test-package"]
     assert project.parts["snapcraft/core"]["build-snaps"] == ["test-snap"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Fixes some deprecation warnings before they become deprecation errors. Two of the fixes were very simple, but the one involving the context manager was a little bit messier.

In short, the test mocking setup was setting the return value of a context manager to a simple `Path`, when it needed to be a generator object that supported the `__enter__()` method. This wasn't an issue previously since `Path` just did a no-op as a context manager, but now it needs to be correct.

Closes #5539.
SNAPCRAFT-1159