### PR TITLE
fix typo in enable-classic-confinement.rst

### DIFF
--- a/docs/how-to/crafting/enable-classic-confinement.rst
+++ b/docs/how-to/crafting/enable-classic-confinement.rst
@@ -38,7 +38,7 @@ Request classic confinement on the Snap Store
 ---------------------------------------------
 
 A classically-confined snap requires approval from the Store team before you can
-distribute it on the Snap Store. Obtaining approval takes takes on average three to five
+distribute it on the Snap Store. Obtaining approval takes on average three to five
 business days.
 
 `Submit your snap for review


### PR DESCRIPTION
`takes takes` -> `takes`

Not bothering to do these since this is a simple typo fix:

- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
