### PR TITLE
fix(docs): remove obsolete CLI reference pages after generation

### DIFF
--- a/tools/docs/gen_cli_docs.py
+++ b/tools/docs/gen_cli_docs.py
@@ -141,6 +141,17 @@ def main(docs_dir):
             # Add an entry in the table of contents.
             toc.append(cmd.name)
 
+    # Delete obsolete .rst files that are not in the new list of commands.
+    existing_files = {
+        f.stem for f in commands_ref_dir.glob("*.rst")
+        if f.name not  in ["toc.rst"] and not f.name.endswith("-commands.rst")
+    }
+    generated_files = set(toc)
+
+    obsolete_files = existing_files - generated_files
+    for name in obsolete_files:
+        (commands_ref_dir / (name + os.extsep + "rst")).unlink(missing_ok=True)
+
     toc_path = commands_ref_dir / "toc.rst"
     f = toc_path.open("w")
     f.write(".. toctree::\n   :hidden:\n\n")


### PR DESCRIPTION
- [x] I have followed the [contributing guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I have successfully run `make lint`.
- [ ] I have successfully run `make test`.

This PR fixes an issue where obsolete CLI documentation files (`.rst`) under `docs/reference/commands/` were not removed after regeneration.

Obsolete command pages could persist after a build, causing errors such as:

    document isn't included in any toctree

This change ensures old `.rst` files are deleted if their corresponding commands are no longer present.

Closes #5200

**Note**: I was unable to run `make lint` and `make test` due to missing `tox` configuration and test setup in my environment. Happy to revise the PR after feedback.
