### PR TITLE
docs: switch from UK to US spellings

### DIFF
--- a/docs/explanation/components.rst
+++ b/docs/explanation/components.rst
@@ -22,7 +22,7 @@ debug symbols can download and install them as a component.
 Components and Partitions
 -------------------------
 
-Components utilise a `Craft Parts`_ feature called ``partitions``. This feature
+Components utilize a `Craft Parts`_ feature called ``partitions``. This feature
 is enabled only when the ``component`` key is defined in the project file.
 
 Each component has a namespaced partition ``component/<component-name>`` where

--- a/docs/how-to/code/integrations/example-python-recipe.yaml
+++ b/docs/how-to/code/integrations/example-python-recipe.yaml
@@ -5,7 +5,7 @@ summary: a status and control utility to for power, cooling and LED components
 version: "1.0"
 description: |
   liquidctl is a command-line tool to monitor and control the fan speed,
-  LED colour and pump volumes of specific power supplies, motherboards,
+  LED color and pump volumes of specific power supplies, motherboards,
   graphics cards and cooling solutions. The liquidctl snap unofficial and
   is not endorsed by the upstream project.
 base: core22

--- a/docs/how-to/code/integrations/example-rust-recipe.yaml
+++ b/docs/how-to/code/integrations/example-rust-recipe.yaml
@@ -4,7 +4,7 @@ name: xsv
 version: git
 summary: A fast CSV command line toolkit written in Rust
 description: |
-  xsv is a command line program for indexing, slicing, analysing,
+  xsv is a command line program for indexing, slicing, analyzing,
   splitting and joining CSV files. Commands should be simple, fast and
   composable.
 base: core18

--- a/docs/how-to/crafting/select-architectures.rst
+++ b/docs/how-to/crafting/select-architectures.rst
@@ -4,7 +4,7 @@ Select architectures
 ====================
 
 By default, Snapcraft builds a snap to run on the same architecture as the build
-environment. This behaviour can be modified with the top-level keys
+environment. This behavior can be modified with the top-level keys
 ``architectures`` and ``platforms`` in the snap's project file.
 
 The ``architectures`` and ``platforms`` keys are used to create a build

--- a/docs/how-to/debugging/debug-a-snap.rst
+++ b/docs/how-to/debugging/debug-a-snap.rst
@@ -51,7 +51,7 @@ your base snap when searching.
 
 Don't include glibc or libc6 in your list of staged packages. Doing so is unnecessary as
 the base snap contains those libraries already, and bundling them into your snap can
-cause unexpected behaviour.
+cause unexpected behavior.
 
 
 Individual libraries

--- a/docs/how-to/integrations/craft-a-cross-compiled-app.rst
+++ b/docs/how-to/integrations/craft-a-cross-compiled-app.rst
@@ -51,7 +51,7 @@ targets:
 Adjust the Autotools configuration
 ----------------------------------
 
-When building for a particular architecture, Snapcraft will initialise the
+When building for a particular architecture, Snapcraft will initialize the
 ``CRAFT_ARCH_TRIPLET_BUILD_FOR`` environment variable in the build environment. This
 variable describes the platform and architecture that Autotools uses to configure
 cross-compilation. For more information on environment variables, see
@@ -99,7 +99,7 @@ To select the correct library for the target platform, include these packages in
 
 The ``build-packages`` and ``stage-packages`` keys additionally support the
 :ref:`advanced grammar <reference-advanced-grammar>` keys, which allow further
-customisation of packages installed per-platform.
+customization of packages installed per-platform.
 
 Build the snap
 --------------

--- a/docs/how-to/integrations/craft-a-gtk2-app.rst
+++ b/docs/how-to/integrations/craft-a-gtk2-app.rst
@@ -34,7 +34,7 @@ Add an app that uses GNOME
 
 Apps that use GTK2 and GNOME as runtime libraries require a special script. It
 brings in the runtime environment and dependencies so that all desktop
-functionality is correctly initialised.
+functionality is correctly initialized.
 
 To add a GTK2 app:
 

--- a/docs/how-to/integrations/craft-a-gtk3-app.rst
+++ b/docs/how-to/integrations/craft-a-gtk3-app.rst
@@ -34,7 +34,7 @@ Add an app that uses GNOME
 
 Apps that use GTK3 and GNOME as runtime libraries require the
 :ref:`reference-gnome-extension`. The extension configures the runtime environment of
-the app so that all desktop functionality is correctly initialised. As desktop
+the app so that all desktop functionality is correctly initialized. As desktop
 environment apps, they also need special configuration for AppStream and ``.desktop``
 file compatibility.
 

--- a/docs/how-to/integrations/craft-a-gtk4-app.rst
+++ b/docs/how-to/integrations/craft-a-gtk4-app.rst
@@ -35,7 +35,7 @@ Add an app that uses GNOME
 
 Apps that use GTK4 and GNOME as runtime libraries require the
 :ref:`reference-gnome-extension`. The extension configures the runtime environment of
-the app so that all desktop functionality is correctly initialised. As desktop
+the app so that all desktop functionality is correctly initialized. As desktop
 environment apps, they also need special configuration for AppStream and ``.desktop``
 file compatibility.
 

--- a/docs/how-to/integrations/craft-a-qt5-kde-app.rst
+++ b/docs/how-to/integrations/craft-a-qt5-kde-app.rst
@@ -33,7 +33,7 @@ Add an app that uses KDE
 
 Apps that use KDE runtime libraries require the :ref:`KDE neon extension
 <reference-kde-neon-extensions>`. The extension configures the runtime environment of
-the app so that all desktop functionality is correctly initialised. As desktop
+the app so that all desktop functionality is correctly initialized. As desktop
 environment apps, they also need special configuration for AppStream and ``.desktop``
 file compatibility.
 

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -149,7 +149,7 @@ Example project file for ROS 2 Talker/Listener
 Add an ROS 2 app
 ----------------
 
-ROS 2 apps depend on special extensions that initialise the build- and run-time
+ROS 2 apps depend on special extensions that initialize the build- and run-time
 environments.
 
 To add an ROS 2 app:

--- a/docs/reference/extensions/env-injector-extension.rst
+++ b/docs/reference/extensions/env-injector-extension.rst
@@ -8,7 +8,7 @@ interface for altering snap behavior with user-defined environment variables.
 
 When you add the extension to individual apps inside a snap, you open the way for the
 user to `configure the snap <https://snapcraft.io/docs/configuration-in-snaps>`_ or
-affect its behaviour with environment variables.
+affect its behavior with environment variables.
 
 
 How it works

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -326,14 +326,14 @@ Command line
 Init
 ====
 
-* Add a ``<project-dir>`` argument to initialise the project in a particular
+* Add a ``<project-dir>`` argument to initialize the project in a particular
   directory.
 
-* Add a ``--name <name>`` argument to set the ``name`` key in the initialised
+* Add a ``--name <name>`` argument to set the ``name`` key in the initialized
   ``snapcraft.yaml``. If ``--name`` isn't provided, the name of the project
   directory or current working directory is used.
 
-* Add a ``--profile <profile>`` argument to initialise a project for a specific
+* Add a ``--profile <profile>`` argument to initialize a project for a specific
   purpose. Currently, only the ``simple`` profile is supported.
 
 Store

--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -273,7 +273,7 @@ For a complete list of commits, check out the `8.5.1`_ release on GitHub.
 Core
 ====
 
-* Remove the Snapcraft Dockerfile in favour of the `snapcraft-rocks`_ registry.
+* Remove the Snapcraft Dockerfile in favor of the `snapcraft-rocks`_ registry.
   For more information, see the ``docker/README.md`` file.
 
 Bases

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -135,13 +135,13 @@ development keeps pace with the OS's new releases and support lifecycle.
   | Other important update                 | <Describe update>            | Mitigation for Heartbleed vulnerability |
   +----------------------------------------+------------------------------+-----------------------------------------+
 
-  <Paragraph 1, optional: Briefly cover the previous behaviour or the change in
+  <Paragraph 1, optional: Briefly cover the previous behavior or the change in
   circumstances. For example, "With Ubuntu 24.04 LTS, the Snap Store and App
   Center now collect public reviews for snaps and assign an averaged score to
   them to provide users and authors an avenue for discoverability and
   feedback.">
 
-  <Paragraph 2: Present the new behaviour or feature. In words, *show* what the feature
+  <Paragraph 2: Present the new behavior or feature. In words, *show* what the feature
   is and make a case for how the reader could benefit from it. Centre the user whenever
   possible ("you"), and speak on behalf of Canonical ("we"). Prefer general, simple
   usage over complex applications. Use past tense, or the form "is now [x]" or "now

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -142,7 +142,7 @@ development keeps pace with the OS's new releases and support lifecycle.
   feedback.">
 
   <Paragraph 2: Present the new behavior or feature. In words, *show* what the feature
-  is and make a case for how the reader could benefit from it. Centre the user whenever
+  is and make a case for how the reader could benefit from it. Center the user whenever
   possible ("you"), and speak on behalf of Canonical ("we"). Prefer general, simple
   usage over complex applications. Use past tense, or the form "is now [x]" or "now
   [does x]". For example, "We understand that some authors may not want to have their

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -3,7 +3,7 @@
 Release notes
 =============
 
-This page lists the notes for past releases of Snapcraft, which summarise new features,
+This page lists the notes for past releases of Snapcraft, which summarize new features,
 bug fixes and backwards-incompatible changes in each version. It also contains the
 release and support policies for Snapcraft.
 


### PR DESCRIPTION
Fixing issue from task 244, from Open Documentation Academy
Replacing words for standardization
https://github.com/canonical/open-documentation-academy/issues/244




- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
