### PR TITLE
docs: ignore deprecated command pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,15 @@ exclude_patterns = [
     # Staged files for Discourse migration
     "how-to/crafting/add-a-part.rst",
     "how-to/publishing/build-snaps-remotely.rst",
+    # Deprecated commands
+    "reference/commands/extensions.rst",
+    "reference/commands/list-registered.rst",
+    "reference/commands/list.rst",
+    "reference/commands/push.rst",
+    "reference/commands/plugins.rst",
+    "reference/commands/revisions.rst",
+    "reference/commands/snap.rst",
+    "reference/commands/tracks.rst",
 ]
 
 # region Options for extensions


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `make test`?

---
* Adds deprecated command pages to `exclude_patterns`