### PR TITLE
Ros plugin: handle stderr separated from stdout, fixes #5600

### DIFF
--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -378,11 +378,11 @@ def stage_runtime_dependencies(  # noqa: PLR0913 (too many arguments)
                     cmd,
                     check=True,
                     stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+                    stderr=subprocess.PIPE,
                     env={"PATH": os.environ["PATH"]},
                 )
             except subprocess.CalledProcessError as error:
-                click.echo(f"failed to run {cmd!r}: {error.output}")
+                click.echo(f"failed to run {cmd!r}: {error.stdout}, {error.stderr}")
                 raise RosdepError("rosdep encountered an error") from error
 
             parsed = _parse_rosdep_resolve_dependencies(
@@ -390,7 +390,7 @@ def stage_runtime_dependencies(  # noqa: PLR0913 (too many arguments)
             )
             apt_packages |= parsed.pop("apt", set())
 
-            if parsed:
+            if parsed:  # still non-empty after removing apt packages
                 click.echo(f"unhandled dependencies: {parsed!r}")
 
     build_snap_packages = get_installed_dependencies(

--- a/snapcraft_legacy/plugins/v2/_ros.py
+++ b/snapcraft_legacy/plugins/v2/_ros.py
@@ -325,18 +325,18 @@ def stage_runtime_dependencies(
                     cmd,
                     check=True,
                     stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+                    stderr=subprocess.PIPE,
                     env=dict(PATH=os.environ["PATH"]),
                 )
             except subprocess.CalledProcessError as error:
-                click.echo(f"failed to run {cmd!r}: {error.output}")
+                click.echo(f"failed to run {cmd!r}: {error.stdout}, {error.stderr}")
 
             parsed = _parse_rosdep_resolve_dependencies(
                 dep, proc.stdout.decode().strip()
             )
             apt_packages |= parsed.pop("apt", set())
 
-            if parsed:
+            if parsed:  # still non-empty after removing apt packages
                 click.echo(f"unhandled dependencies: {parsed!r}")
 
     build_snap_packages = get_installed_dependencies(


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
