### PR TITLE
docs: place 'about docs' above 'release notes' in toc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,5 +53,5 @@ feedback.
     how-to/index
     reference/index
     explanation/index
-    release-notes/index
     about-this-documentation
+    release-notes/index


### PR DESCRIPTION
We had a change of heart about the position of the page in the TOC. We want release notes to always be the final item.


---
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
