### PR TITLE
docs: rename 'about this doc' → 'contribute to this doc'

### DIFF
--- a/docs/contribute-to-this-documentation.rst
+++ b/docs/contribute-to-this-documentation.rst
@@ -1,7 +1,7 @@
-.. _about-this-documentation:
+.. _contribute-to-this-documentation:
 
-About this documentation
-========================
+Contribute to this documentation
+================================
 
 The documentation is Snapcraft's first-person account of itself to the world. It
 provides knowledge and guidance to people who use, study, and develop the project.
@@ -34,7 +34,7 @@ author the documentation, there are a few paths you can take:
 * Discuss your ideas on the `Snapcraft forum <https://forum.snapcraft.io>`_.
 * Bring your experience and ideas to the `Snapcraft Matrix channel
   <https://matrix.to/#/#snapcraft:ubuntu.com>`_.
-* Volunteer for a task in the :ref:`about-this-documentation-coda`.
+* Volunteer for a task in the :ref:`contribute-to-this-documentation-coda`.
 
 Your contributions to the project are valuable. The team sees authorship as being on
 equal footing with development.
@@ -46,7 +46,7 @@ Canonical employees in a public and visible way. Lastly, all contributors receiv
 recognition in the Snapcraft release that they work on.
 
 
-.. _about-this-documentation-coda:
+.. _contribute-to-this-documentation-coda:
 
 Canonical Open Documentation Academy
 ------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,5 +53,5 @@ feedback.
     how-to/index
     reference/index
     explanation/index
-    about-this-documentation
+    contribute-to-this-documentation
     release-notes/index


### PR DESCRIPTION
The title is a stakeholder requirement. I didn't create a redirect, because the doc isn't public yet.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?
