### PR TITLE
fix: snapcraft init crash when snapcraft.yaml exists but is empty

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -118,7 +118,7 @@ class Snapcraft(Application):
             return False
 
         # When snapcraft.yaml exists but is empty
-        if type(_snapcraft_yaml_data) is not dict:
+        if not isinstance(_snapcraft_yaml_data, dict):
             return False
 
         base = _snapcraft_yaml_data.get("base")

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -117,6 +117,10 @@ class Snapcraft(Application):
         ):
             return False
 
+        # When snapcraft.yaml exists but is empty
+        if _snapcraft_yaml_data is None:
+            return False
+
         base = _snapcraft_yaml_data.get("base")
         build_base = _snapcraft_yaml_data.get("build-base")
 

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -118,7 +118,7 @@ class Snapcraft(Application):
             return False
 
         # When snapcraft.yaml exists but is empty
-        if _snapcraft_yaml_data is None:
+        if type(_snapcraft_yaml_data) is not dict:
             return False
 
         base = _snapcraft_yaml_data.get("base")

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -110,9 +110,8 @@ def test_init_existing_yaml_invalid(yaml_content, emitter, valid_new_dir, mocker
     mocker.patch.object(sys, "argv", cmd)
 
     # Write snapcraft.yaml content
-    snapcraft_yaml.parent.mkdir()
-    with open(snapcraft_yaml, "w") as f:
-        f.write(yaml_content)
+    snapcraft_yaml.parent.mkdir(exist_ok=True)
+    snapcraft_yaml.write_text(yaml_content)
 
     app = application.create_app()
     app.run()

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -100,3 +100,22 @@ def test_init_default(profile, name, project_dir, emitter, valid_new_dir, mocker
         "for reference information about the snapcraft.yaml format."
     )
     emitter.assert_message("Successfully initialised project.")
+
+
+@pytest.mark.parametrize("yaml_content", ["", "just a string"])
+def test_init_existing_yaml_invalid(yaml_content, emitter, valid_new_dir, mocker):
+    """Test the 'snapcraft init' command with existing empty/invalid snapcraft.yaml."""
+    snapcraft_yaml = pathlib.Path(valid_new_dir) / "snap/snapcraft.yaml"
+    cmd = _create_command(profile=None, project_dir=None, name=None)
+    mocker.patch.object(sys, "argv", cmd)
+
+    # Write snapcraft.yaml content
+    snapcraft_yaml.parent.mkdir()
+    with open(snapcraft_yaml, "w") as f:
+        f.write(yaml_content)
+
+    app = application.create_app()
+    app.run()
+
+    emitter.assert_progress("Checking for an existing 'snapcraft.yaml'.")
+    emitter.assert_debug("Loading project file 'snap/snapcraft.yaml")


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
Fixes the crash when running `snapcraft init` in a directory with an empty `snapcraft.yaml`:
```
$ cd `mktemp -d`
$ touch snapcraft.yaml
$ snapcraft init
Traceback (most recent call last):
  File "/snap/snapcraft/15369/bin/snapcraft", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/snap/snapcraft/15369/lib/python3.12/site-packages/snapcraft/application.py", line 464, in main
    app = create_app()
          ^^^^^^^^^^^^
  File "/snap/snapcraft/15369/lib/python3.12/site-packages/snapcraft/application.py", line 432, in create_app
    app = Snapcraft(
          ^^^^^^^^^^
  File "/snap/snapcraft/15369/lib/python3.12/site-packages/snapcraft/application.py", line 99, in __init__
    self._known_core24 = self._get_known_core24()
                         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/snapcraft/15369/lib/python3.12/site-packages/snapcraft/application.py", line 118, in _get_known_core24
    base = _snapcraft_yaml_data.get("base")
           ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```