### PR TITLE
docs: clean up 'snapcraft.yaml'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,13 +147,6 @@ else:
 project_dir = pathlib.Path(__file__).parents[1].resolve()
 sys.path.insert(0, str(project_dir.absolute()))
 
-# Add directories to sys path to simplify kitbash arguments
-model_dir = (project_dir / "snapcraft/models").resolve()
-sys.path.append(str(model_dir.absolute()))
-
-library_dir = (project_dir / ".venv/lib/python3.12/site-packages").resolve()
-sys.path.append(str(library_dir.absolute()))
-
 def generate_cli_docs(nil):
     gen_cli_docs_path = (project_dir / "tools/docs/gen_cli_docs.py").resolve()
     os.system("%s %s" % (gen_cli_docs_path, project_dir / "docs"))

--- a/docs/reference/project-file/snapcraft-yaml.rst
+++ b/docs/reference/project-file/snapcraft-yaml.rst
@@ -21,86 +21,104 @@ how it builds.
 Top-level details include a snap's name, version and description, alongside operational
 values such as its confinement level and supported architectures.
 
-.. kitbash-field:: project.Project name
+.. py:currentmodule:: snapcraft.models.project
 
-.. kitbash-field:: craft_application.models.project.Project title
+.. kitbash-field:: Project name
 
-.. kitbash-field:: project.Project version
+.. py:currentmodule:: craft_application.models.project
 
-.. kitbash-field:: craft_application.models.project.Project license
+.. kitbash-field:: Project title
 
-.. kitbash-field:: craft_application.models.project.Project summary
+.. py:currentmodule:: snapcraft.models.project
 
-.. kitbash-field:: craft_application.models.project.Project description
+.. kitbash-field:: Project version
 
-.. kitbash-field:: project.Project adopt_info
+.. py:currentmodule:: craft_application.models.project
 
-.. kitbash-field:: project.Project type
+.. kitbash-field:: Project license
 
-.. kitbash-field:: craft_application.models.project.Project base
+.. kitbash-field:: Project summary
 
-.. kitbash-field:: project.Project build_base
+.. kitbash-field:: Project description
 
-.. kitbash-field:: project.Project grade
+.. py:currentmodule:: snapcraft.models.project
 
-.. kitbash-field:: project.Project confinement
+.. kitbash-field:: Project adopt_info
 
-.. kitbash-field:: project.Project source_code
+.. kitbash-field:: Project type
 
-.. kitbash-field:: project.Project contact
+.. py:currentmodule:: craft_application.models.project
 
-.. kitbash-field:: project.Project website
+.. kitbash-field:: Project base
 
-.. kitbash-field:: project.Project issues
+.. py:currentmodule:: snapcraft.models.project
 
-.. kitbash-field:: project.Project donation
+.. kitbash-field:: Project build_base
 
-.. kitbash-field:: project.Project compression
+.. kitbash-field:: Project grade
 
-.. kitbash-field:: project.Project icon
+.. kitbash-field:: Project confinement
 
-.. kitbash-field:: project.Project layout
+.. kitbash-field:: Project source_code
 
-.. kitbash-field:: project.Project passthrough
+.. kitbash-field:: Project contact
 
-.. kitbash-field:: project.Project assumes
+.. kitbash-field:: Project website
 
-.. kitbash-field:: project.Project slots
+.. kitbash-field:: Project issues
 
-.. kitbash-field:: project.Project lint
+.. kitbash-field:: Project donation
 
-.. kitbash-field:: project.Project epoch
+.. kitbash-field:: Project compression
 
-.. kitbash-field:: project.Project system_usernames
+.. kitbash-field:: Project icon
 
-.. kitbash-field:: project.Project environment
+.. kitbash-field:: Project layout
 
-.. kitbash-field:: project.Project build_packages
+.. kitbash-field:: Project passthrough
 
-.. kitbash-field:: project.Project build_snaps
+.. kitbash-field:: Project assumes
 
-.. kitbash-field:: project.Project ua_services
+.. kitbash-field:: Project slots
 
-.. kitbash-field:: project.Project provenance
+.. kitbash-field:: Project lint
 
-.. kitbash-field:: project.Project platforms
+.. kitbash-field:: Project epoch
 
-.. kitbash-field:: project.Project architectures
+.. kitbash-field:: Project system_usernames
 
-.. kitbash-field:: project.Project apps
+.. kitbash-field:: Project environment
 
-.. kitbash-field:: craft_application.models.project.Project parts
+.. kitbash-field:: Project build_packages
+
+.. kitbash-field:: Project build_snaps
+
+.. kitbash-field:: Project ua_services
+
+.. kitbash-field:: Project provenance
+
+.. kitbash-field:: Project platforms
+
+.. kitbash-field:: Project architectures
+
+.. kitbash-field:: Project apps
+
+.. py:currentmodule:: craft_application.models.project
+
+.. kitbash-field:: Project parts
     :override-type: dict[str, Part]
 
-.. kitbash-field:: craft_application.models.project.Project package_repositories
+.. kitbash-field:: Project package_repositories
     :override-type: list[dict[str, Any]]
 
-.. kitbash-field:: project.Project hooks
+.. py:currentmodule:: snapcraft.models.project
 
-.. kitbash-field:: project.Project components
+.. kitbash-field:: Project hooks
+
+.. kitbash-field:: Project components
     :override-type: dict[str, Component]
 
-.. kitbash-field:: project.Project plugs
+.. kitbash-field:: Project plugs
 
 
 .. _reference-snapcraft-yaml-app-keys:
@@ -111,7 +129,7 @@ App keys
 The ``apps`` key declares the programs and services that a snap operates on the host,
 and details how they're executed and which resources they can access.
 
-.. kitbash-model:: project.App
+.. kitbash-model:: App
     :prepend-name: apps.<app-name>
 
 
@@ -123,57 +141,59 @@ Part keys
 The ``parts`` key and its values declare the snap's :ref:`parts <explanation-parts>` and
 detail how they're built.
 
+.. py:currentmodule:: craft_parts.parts
+
 .. Main keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec plugin
+.. kitbash-field:: PartSpec plugin
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec after
+.. kitbash-field:: PartSpec after
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec disable_parallel
+.. kitbash-field:: PartSpec disable_parallel
     :prepend-name: parts.<part-name>
 
 .. Source keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec source
+.. kitbash-field:: PartSpec source
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_type
+.. kitbash-field:: PartSpec source_type
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_checksum
+.. kitbash-field:: PartSpec source_checksum
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_branch
+.. kitbash-field:: PartSpec source_branch
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_tag
+.. kitbash-field:: PartSpec source_tag
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_commit
+.. kitbash-field:: PartSpec source_commit
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_depth
+.. kitbash-field:: PartSpec source_depth
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_submodules
+.. kitbash-field:: PartSpec source_submodules
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec source_subdir
+.. kitbash-field:: PartSpec source_subdir
     :prepend-name: parts.<part-name>
 
 .. Pull step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_pull
+.. kitbash-field:: PartSpec override_pull
     :prepend-name: parts.<part-name>
 
 .. Build step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_environment
+.. kitbash-field:: PartSpec build_environment
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_attributes
+.. kitbash-field:: PartSpec build_attributes
     :prepend-name: parts.<part-name>
 
 **Description**
@@ -209,16 +229,16 @@ For more details on part processing for core22 and newer, see `Processing order 
 dependencies
 <https://documentation.ubuntu.com/snapcraft/stable/explanation/parts-lifecycle/#processing-order-and-dependencies>`_.
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_build
+.. kitbash-field:: PartSpec override_build
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_packages
+.. kitbash-field:: PartSpec build_packages
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec build_snaps
+.. kitbash-field:: PartSpec build_snaps
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec organize_files
+.. kitbash-field:: PartSpec organize_files
     :prepend-name: parts.<part-name>
 
 Files from the build environment can be organized into specific components. The
@@ -228,69 +248,73 @@ included. Source paths always reference the default build environment.
 
 .. Stage step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec stage_files
+.. kitbash-field:: PartSpec stage_files
     :prepend-name: parts.<part-name>
     :override-type: list[str]
 
-.. kitbash-field:: craft_parts.parts.PartSpec stage_packages
+.. kitbash-field:: PartSpec stage_packages
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec stage_snaps
+.. kitbash-field:: PartSpec stage_snaps
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_stage
+.. kitbash-field:: PartSpec override_stage
     :prepend-name: parts.<part-name>
 
 .. Prime step keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec prime_files
+.. kitbash-field:: PartSpec prime_files
     :prepend-name: parts.<part-name>
     :override-type: list[str]
 
-.. kitbash-field:: craft_parts.parts.PartSpec override_prime
+.. kitbash-field:: PartSpec override_prime
     :prepend-name: parts.<part-name>
 
 .. Permission keys
 
-.. kitbash-field:: craft_parts.parts.PartSpec permissions
+.. kitbash-field:: PartSpec permissions
     :prepend-name: parts.<part-name>
 
-.. kitbash-field:: craft_parts.permissions.Permissions path
+.. py:currentmodule:: craft_parts.permissions
+
+.. kitbash-field:: Permissions path
     :prepend-name: parts.<part-name>.permissions.<permission>
 
-.. kitbash-field:: craft_parts.permissions.Permissions owner
+.. kitbash-field:: Permissions owner
     :prepend-name: parts.<part-name>.permissions.<permission>
 
-.. kitbash-field:: craft_parts.permissions.Permissions group
+.. kitbash-field:: Permissions group
     :prepend-name: parts.<part-name>.permissions.<permission>
 
-.. kitbash-field:: craft_parts.permissions.Permissions mode
+.. kitbash-field:: Permissions mode
     :prepend-name: parts.<part-name>.permissions.<permission>
 
 
 Socket keys
 -----------
 
-.. kitbash-model:: project.Socket
+.. py:currentmodule:: snapcraft.models.project
+
+.. kitbash-model:: Socket
     :prepend-name: sockets.<socket-name>
 
 
 Hook keys
 ---------
 
-.. kitbash-model:: project.Hook
+.. kitbash-model:: Hook
     :prepend-name: hooks.<hook-type>
 
 
 Component keys
 --------------
 
-.. kitbash-model:: project.Component
+.. kitbash-model:: Component
     :prepend-name: components.<component-name>
 
 
 Content plug keys
 -----------------
 
-.. kitbash-model:: project.ContentPlug
+.. kitbash-model:: ContentPlug
     :prepend-name: plugs.<plug-name>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ docs = [
     "sphinxcontrib-details-directive",
     "sphinxext-rediraffe==0.2.7",
     "docutils>=0.21",
-    "pydantic-kitbash==0.0.6",
+    "pydantic-kitbash==0.0.7",
     "pyspelling",
 ]
 lint = [

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-kitbash"
-version = "0.0.6"
+version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -1799,9 +1799,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/48066291bb9db968d42d6419fa666be077c893d17cdca0eac44cedb2e3d1/pydantic_kitbash-0.0.6.tar.gz", hash = "sha256:60b18ce727f06b6c5a3f8db5675bb6c423449bb59832c3e04cfef4b1568a84e9", size = 124406, upload-time = "2025-07-03T19:24:33.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/b9/630281fa690b2449e70d59ce221c91d9633571c4a7c2dcd8469a59a8c7cc/pydantic_kitbash-0.0.7.tar.gz", hash = "sha256:14eda8a87401b09d746e1ad4157248d8c0d1841803bf609600143e567a687551", size = 131893, upload-time = "2025-08-01T16:26:32.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/4e/4f492ee0d832eb9d8ebd9915e35bff6fd09d658bc6fdb1f31d70495492cf/pydantic_kitbash-0.0.6-py3-none-any.whl", hash = "sha256:e16fa65ebfebe7d295e9b476641e253e02b18686e52bedc2ec65c46421d9875d", size = 13156, upload-time = "2025-07-03T19:24:32.342Z" },
+    { url = "https://files.pythonhosted.org/packages/56/05/4a05fbb8f72ae86060430e55349e1d504ee73973e9a767aeb9ecaf85a447/pydantic_kitbash-0.0.7-py3-none-any.whl", hash = "sha256:4ab60369cb8b3cbf289724df295a514bb309d2cb669d1d0c6d1eafaacf530ec5", size = 13645, upload-time = "2025-08-01T16:26:29.879Z" },
 ]
 
 [[package]]
@@ -2802,7 +2802,7 @@ dev-questing = [{ name = "python-apt", marker = "sys_platform == 'linux'", speci
 docs = [
     { name = "canonical-sphinx", extras = ["full"], specifier = "~=0.4.0" },
     { name = "docutils", specifier = ">=0.21" },
-    { name = "pydantic-kitbash", specifier = "==0.0.6" },
+    { name = "pydantic-kitbash", specifier = "==0.0.7" },
     { name = "pyspelling" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-typehints" },


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint`?
- [X] Have you successfully run `make test`?

---

* Update `pydantic-kitbash` to v0.0.7
* Remove library modules from `sys.path`
* Clean up 'Part Properties' by declaring ..py:currentmodule::

Once Snapcraft is updated to the next Craft Parts release, this will get rid of the Kitbash warnings in docs builds.