### PR TITLE
docs: fix typos in release notes

### DIFF
--- a/docs/release-notes/snapcraft-8-11.rst
+++ b/docs/release-notes/snapcraft-8-11.rst
@@ -86,6 +86,7 @@ For example, consider the following snippet:
   :caption: snapcraft.yaml
 
   name: hello-world
+  base: core24
   version: 1.0
   platforms:
     rpi:
@@ -152,7 +153,7 @@ this release.
 
 :literalref:`@ahkazak23<https://github.com/ahkazak23>`,
 :literalref:`@bepri<https://github.com/bepri>`,
-:literalref:`@steinbro<https://github.com/steinbro`,
+:literalref:`@steinbro<https://github.com/steinbro>`,
 :literalref:`@jahn-junior<https://github.com/jahn-junior>`,
 :literalref:`@lengau<https://github.com/lengau>`,
 :literalref:`@medubelko<https://github.com/medubelko>`,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---

Fixes 2 typos in the 8.11 release notes.