### PR TITLE
feat(snapcraft_legacy): support verbosity args in non-lifecycle commands

### DIFF
--- a/docs/release-notes/snapcraft-8-11.rst
+++ b/docs/release-notes/snapcraft-8-11.rst
@@ -144,6 +144,13 @@ Snapcraft 8.11.0
 - Multi-line details in error messages now start on a new line.
 - If the project file is empty, Snapcraft now emits an error instead of a traceback.
 
+.. _release-notes-fixes-8.11.1:
+
+Snapcraft 8.11.1
+~~~~~~~~~~~~~~~~
+
+- `#5298`_ Verbosity arguments are parsed for all non-lifecycle commands.
+
 
 Contributors
 ------------
@@ -159,3 +166,5 @@ this release.
 :literalref:`@medubelko<https://github.com/medubelko>`,
 :literalref:`@mr-cal<https://github.com/mr-cal>`, and
 :literalref:`@upils<https://github.com/upils>`.
+
+.. _#5298: https://github.com/canonical/snapcraft/issues/5298

--- a/docs/release-notes/snapcraft-8-11.rst
+++ b/docs/release-notes/snapcraft-8-11.rst
@@ -149,7 +149,7 @@ Snapcraft 8.11.0
 Snapcraft 8.11.1
 ~~~~~~~~~~~~~~~~
 
-- `#5298`_ Verbosity arguments are parsed for all non-lifecycle commands.
+- `#5298`_ Verbosity arguments are now parsed for all non-lifecycle commands.
 
 
 Contributors

--- a/snapcraft_legacy/cli/_options.py
+++ b/snapcraft_legacy/cli/_options.py
@@ -225,6 +225,8 @@ _PROVIDER_OPTIONS: List[Dict[str, Any]] = [
         envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_UA_SERVICES",
         supported_providers=_ALL_PROVIDERS,
     ),
+]
+_VERBOSITY_OPTIONS = [
     dict(
         param_decls=["--verbose", "-v"],
         is_flag=True,
@@ -265,9 +267,16 @@ def _add_options(options, func, hidden):
 
 def add_provider_options(hidden=False):
     def _add_provider_options(func):
-        return _add_options(_PROVIDER_OPTIONS, func, hidden)
+        return _add_options([*_PROVIDER_OPTIONS, *_VERBOSITY_OPTIONS], func, hidden)
 
     return _add_provider_options
+
+
+def add_verbosity_options(hidden=False):
+    def _add_verbosity_options(func):
+        return _add_options(_VERBOSITY_OPTIONS, func, hidden)
+
+    return _add_verbosity_options
 
 
 def _sanity_check_build_provider_flags(build_provider: str, **kwargs) -> None:

--- a/snapcraft_legacy/cli/assertions.py
+++ b/snapcraft_legacy/cli/assertions.py
@@ -23,6 +23,7 @@ from snapcraft_legacy import storeapi
 from snapcraft_legacy._store import StoreClientCLI
 
 from . import echo
+from ._options import add_verbosity_options
 
 
 @click.group()
@@ -31,7 +32,8 @@ def assertionscli():
 
 
 @assertionscli.command("list-keys")
-def list_keys():
+@add_verbosity_options()
+def list_keys(**kwargs):
     """List the keys available to sign assertions.
 
     This command has an alias of `keys`.
@@ -41,7 +43,8 @@ def list_keys():
 
 @assertionscli.command("create-key")
 @click.argument("key-name", metavar="<key-name>", required=False)
-def create_key(key_name: str) -> None:
+@add_verbosity_options()
+def create_key(key_name: str, **kwargs) -> None:
     """Create a key to sign assertions."""
     snapcraft_legacy.create_key(key_name)
 
@@ -54,7 +57,8 @@ def create_key(key_name: str) -> None:
     help="*EXPERIMENTAL* Enables login through candid.",
     envvar="SNAPCRAFT_LOGIN",
 )
-def register_key(key_name: str, experimental_login: bool) -> None:
+@add_verbosity_options()
+def register_key(key_name: str, experimental_login: bool, **kwargs) -> None:
     """Register a key with the store to sign assertions."""
     if experimental_login:
         raise click.BadArgumentUsage(
@@ -73,7 +77,8 @@ def register_key(key_name: str, experimental_login: bool) -> None:
 @click.option(
     "--local", is_flag=True, help="Do not upload the generated assertion to the store"
 )
-def sign_build(snap_file: str, key_name: str, local: bool) -> None:
+@add_verbosity_options()
+def sign_build(snap_file: str, key_name: str, local: bool, **kwargs) -> None:
     """Sign a built snap file and assert it using the developer's key."""
     snapcraft_legacy.sign_build(snap_file, key_name=key_name, local=local)
 
@@ -83,7 +88,10 @@ def sign_build(snap_file: str, key_name: str, local: bool) -> None:
 @click.argument("validations", metavar="<validation>...", nargs=-1, required=True)
 @click.option("--key-name", metavar="<key-name>")
 @click.option("--revoke/--no-revoke", default=False)
-def validate(snap_name: str, validations: list, key_name: str, revoke: bool) -> None:
+@add_verbosity_options()
+def validate(
+    snap_name: str, validations: list, key_name: str, revoke: bool, **kwargs
+) -> None:
     """Validate a gated snap.
 
     Each validation can be presented with either syntax:
@@ -96,7 +104,8 @@ def validate(snap_name: str, validations: list, key_name: str, revoke: bool) -> 
 
 @assertionscli.command()
 @click.argument("snap-name", metavar="<snap-name>")
-def gated(snap_name: str) -> None:
+@add_verbosity_options()
+def gated(snap_name: str, **kwargs) -> None:
     """Get the list of snaps and revisions gating a snap."""
     snapcraft_legacy.gated(snap_name)
 
@@ -108,7 +117,8 @@ def gated(snap_name: str) -> None:
     help="Only show results for a given Validation Set name.",
 )
 @click.option("--sequence", metavar="<sequence>", help="Sequences to show.")
-def list_validation_sets(name, sequence):
+@add_verbosity_options()
+def list_validation_sets(name, sequence, **kwargs):
     """Get the list of validation sets.
 
     The sequence option can be a sequence number or a keyword.

--- a/snapcraft_legacy/cli/discovery.py
+++ b/snapcraft_legacy/cli/discovery.py
@@ -27,7 +27,7 @@ from snapcraft_legacy.internal.common import (
 )
 from snapcraft_legacy.project import errors as project_errors
 
-from ._options import get_project
+from ._options import add_verbosity_options, get_project
 
 
 @click.group()
@@ -58,7 +58,8 @@ def _get_modules_iter(base: str) -> Iterable:
     help="Show plugins for specific base",
     type=click.Choice(["core20"]),
 )
-def list_plugins(base):
+@add_verbosity_options()
+def list_plugins(base, **kwargs):
     """List the available plugins that handle different types of part.
 
     This command has an alias of `plugins`.

--- a/snapcraft_legacy/cli/extensions.py
+++ b/snapcraft_legacy/cli/extensions.py
@@ -25,7 +25,7 @@ import tabulate
 from snapcraft_legacy import yaml_utils
 from snapcraft_legacy.internal import project_loader
 
-from ._options import get_project
+from ._options import add_verbosity_options, get_project
 
 
 @click.group()
@@ -34,6 +34,7 @@ def extensioncli(**kwargs):
 
 
 @extensioncli.command("list-extensions")
+@add_verbosity_options()
 def list_extensions(**kwargs):
     """List available extensions.
 
@@ -62,6 +63,7 @@ def list_extensions(**kwargs):
 @extensioncli.command()
 @click.pass_context
 @click.argument("name")
+@add_verbosity_options()
 def extension(ctx, name, **kwargs):
     """Show contents of extension."""
 
@@ -83,6 +85,7 @@ def extension(ctx, name, **kwargs):
     is_flag=True,
     envvar="SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS",
 )
+@add_verbosity_options()
 def expand_extensions(**kwargs):
     """Display snapcraft.yaml with all extensions applied."""
     if kwargs.get("enable_experimental_extensions"):

--- a/snapcraft_legacy/cli/help.py
+++ b/snapcraft_legacy/cli/help.py
@@ -24,7 +24,7 @@ from snapcraft_legacy.internal import errors, sources
 from snapcraft_legacy.project import errors as project_errors
 
 from . import echo
-from ._options import get_project
+from ._options import add_verbosity_options, get_project
 
 _TOPICS = {"sources": sources, "plugins": snapcraft_legacy}
 
@@ -45,8 +45,9 @@ def helpcli():
     help="Show help for specific base",
     type=click.Choice(["core18", "core20"]),
 )
+@add_verbosity_options()
 @click.pass_context
-def help_command(ctx, topic, devel, base):
+def help_command(ctx, topic, devel, base, **kwargs):
     """Obtain help for a certain topic, plugin or command.
 
     The <topic> can either be a plugin name or one of:

--- a/snapcraft_legacy/cli/remote.py
+++ b/snapcraft_legacy/cli/remote.py
@@ -25,7 +25,7 @@ from snapcraft_legacy.internal.remote_build import LaunchpadClient, WorkTree, er
 from snapcraft_legacy.project import Project
 
 from . import echo
-from ._options import PromptOption, get_project
+from ._options import PromptOption, add_verbosity_options, get_project
 
 _SUPPORTED_ARCHS = ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"]
 
@@ -85,6 +85,7 @@ def remotecli():
     is_flag=True,
     help="Package all sources to send to remote builder, not just local sources.",
 )
+@add_verbosity_options()
 def remote_build(
     recover: bool,
     status: bool,
@@ -94,6 +95,7 @@ def remote_build(
     launchpad_accept_public_upload: bool,
     launchpad_timeout: int,
     package_all_sources: bool,
+    **kwargs,
 ) -> None:
     """Dispatch a snap for remote build.
 

--- a/snapcraft_legacy/cli/store.py
+++ b/snapcraft_legacy/cli/store.py
@@ -31,6 +31,7 @@ from snapcraft_legacy.storeapi import metrics as metrics_module
 
 from . import echo
 from ._metrics import convert_metrics_to_table
+from ._options import add_verbosity_options
 
 
 @click.group()
@@ -83,7 +84,8 @@ def _human_readable_acls(store_client: storeapi.StoreClient) -> str:
     metavar="<snap-file>",
     type=click.Path(exists=True, readable=True, resolve_path=True, dir_okay=False),
 )
-def upload_metadata(snap_file, force):
+@add_verbosity_options()
+def upload_metadata(snap_file, force, **kwargs):
     """Upload metadata from <snap-file> to the store.
 
     The following information will be retrieved from <snap-file> and used
@@ -121,7 +123,8 @@ def upload_metadata(snap_file, force):
     help="The channel to promote to.",
 )
 @click.option("--yes", is_flag=True, help="Do not prompt for confirmation.")
-def promote(snap_name, from_channel, to_channel, yes):
+@add_verbosity_options()
+def promote(snap_name, from_channel, to_channel, yes, **kwargs):
     """Promote a build set from to a channel.
 
     A build set is a set of commonly tagged revisions, the most simple
@@ -206,7 +209,8 @@ def promote(snap_name, from_channel, to_channel, yes):
 @storecli.command()
 @click.argument("snap-name", metavar="<snap-name>")
 @click.argument("track_name", metavar="<track>")
-def set_default_track(snap_name: str, track_name: str):
+@add_verbosity_options()
+def set_default_track(snap_name: str, track_name: str, **kwargs):
     """Set the default track for <snap-name> to <track>.
 
     The track must be a valid active track for this operation to be successful.
@@ -252,7 +256,8 @@ _YESTERDAY = str(date.today() - timedelta(days=1))
     type=click.Choice(["table", "json"]),
     required=True,
 )
-def metrics(snap_name: str, name: str, start: str, end: str, format: str):
+@add_verbosity_options()
+def metrics(snap_name: str, name: str, start: str, end: str, format: str, **kwargs):
     """Get metrics for <snap-name>."""
     store = storeapi.StoreClient()
     account_info = store.get_account_information()

--- a/snapcraft_legacy/cli/version.py
+++ b/snapcraft_legacy/cli/version.py
@@ -18,6 +18,8 @@ import click
 
 import snapcraft_legacy
 
+from ._options import add_verbosity_options
+
 SNAPCRAFT_VERSION_TEMPLATE = "snapcraft %(version)s"
 
 
@@ -28,7 +30,8 @@ def versioncli():
 
 
 @versioncli.command("version")
-def version():
+@add_verbosity_options()
+def version(**kwargs):
     """Obtain snapcraft's version number.
 
     Examples:

--- a/tests/legacy/unit/commands/test_create_key.py
+++ b/tests/legacy/unit/commands/test_create_key.py
@@ -36,6 +36,13 @@ class CreateKeyTestCase(FakeStoreCommandsBaseTestCase):
 
         self.assertThat(str(raised), Equals("The key 'default' already exists"))
 
+    def test_create_key_already_exists_verbose(self):
+        raised = self.assertRaises(
+            storeapi.errors.KeyAlreadyExistsError, self.run_command, ["create-key", "--verbosity", "trace"]
+        )
+
+        self.assertThat(str(raised), Equals("The key 'default' already exists"))
+
     def test_create_key_already_registered(self):
         self.fake_store_account_info.mock.side_effect = [
             {

--- a/tests/legacy/unit/commands/test_gated.py
+++ b/tests/legacy/unit/commands/test_gated.py
@@ -37,6 +37,15 @@ class GatedCommandTestCase(StoreCommandsBaseTestCase):
 
         self.assertThat(str(raised), Equals("Snap 'notfound' was not found."))
 
+    def test_gated_unknown_snap_verbose(self):
+        raised = self.assertRaises(
+            snapcraft_legacy.storeapi.errors.SnapNotFoundError,
+            self.run_command,
+            ["gated", "notfound", "--verbosity", "trace"],
+        )
+
+        self.assertThat(str(raised), Equals("Snap 'notfound' was not found."))
+
     def test_gated_success(self):
         result = self.run_command(["gated", "core"])
 

--- a/tests/legacy/unit/commands/test_help.py
+++ b/tests/legacy/unit/commands/test_help.py
@@ -50,6 +50,17 @@ class HelpCommandTestCase(HelpCommandBaseTestCase):
             result.output, Contains("There is no help topic, plugin or command")
         )
 
+    def test_topic_and_plugin_not_found_exits_with_tip_verbose(self):
+        fake_logger = fixtures.FakeLogger(level=logging.ERROR)
+        self.useFixture(fake_logger)
+
+        result = self.run_command(["help", "does-not-exist", "--verbosity", "trace"])
+
+        self.assertThat(result.exit_code, Equals(1))
+        self.assertThat(
+            result.output, Contains("There is no help topic, plugin or command")
+        )
+
     def test_topic_and_plugin_adds_ellipsis_for_long_arg(self):
         fake_logger = fixtures.FakeLogger(level=logging.ERROR)
         self.useFixture(fake_logger)

--- a/tests/legacy/unit/commands/test_list_keys.py
+++ b/tests/legacy/unit/commands/test_list_keys.py
@@ -41,6 +41,22 @@ class ListKeysCommandTestCase(FakeStoreCommandsBaseTestCase):
             result.output, Contains("You are required to login before continuing.")
         )
 
+    def test_command_without_login_must_ask_verbose(self):
+        # TODO: look into why this many calls are done inside snapcraft_legacy.storeapi
+        self.fake_store_account_info.mock.side_effect = [
+            FAKE_UNAUTHORIZED_ERROR,
+            {"account_id": "abcd", "account_keys": list()},
+            {"account_id": "abcd", "account_keys": list()},
+            {"account_id": "abcd", "account_keys": list()},
+        ]
+
+        result = self.run_command(
+            [self.command_name, "--verbosity", "trace"], input="user@example.com\nsecret\n"
+        )
+        self.assertThat(
+            result.output, Contains("You are required to login before continuing.")
+        )
+
     def test_list_keys_successfully(self):
         self.fake_store_account_info.mock.return_value = {
             "account_id": "abcd",

--- a/tests/legacy/unit/commands/test_list_keys.py
+++ b/tests/legacy/unit/commands/test_list_keys.py
@@ -26,7 +26,6 @@ class ListKeysCommandTestCase(FakeStoreCommandsBaseTestCase):
     command_name = "list-keys"
 
     def test_command_without_login_must_ask(self):
-        # TODO: look into why this many calls are done inside snapcraft_legacy.storeapi
         self.fake_store_account_info.mock.side_effect = [
             FAKE_UNAUTHORIZED_ERROR,
             {"account_id": "abcd", "account_keys": list()},
@@ -42,7 +41,6 @@ class ListKeysCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
 
     def test_command_without_login_must_ask_verbose(self):
-        # TODO: look into why this many calls are done inside snapcraft_legacy.storeapi
         self.fake_store_account_info.mock.side_effect = [
             FAKE_UNAUTHORIZED_ERROR,
             {"account_id": "abcd", "account_keys": list()},

--- a/tests/legacy/unit/commands/test_list_plugins.py
+++ b/tests/legacy/unit/commands/test_list_plugins.py
@@ -91,6 +91,25 @@ class ListPluginsCommandTestCase(CommandBaseTestCase):
             snapcraft_legacy.plugins.v2.__path__
         )
 
+    def test_default_from_snapcraft_yaml_verbose(self):
+        self.useFixture(
+            fixture_setup.SnapcraftYaml(
+                self.path,
+                base="core20",
+                parts={"part1": {"source": ".", "plugin": "nil"}},
+            )
+        )
+
+        result = self.run_command([self.command_name, "--verbosity", "trace"])
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output, Contains("Displaying plugins available for 'core20")
+        )
+        self.fake_iter_modules.mock.assert_called_once_with(
+            snapcraft_legacy.plugins.v2.__path__
+        )
+
     def test_alias(self):
         self.command_name = "plugins"
         self.useFixture(
@@ -102,6 +121,20 @@ class ListPluginsCommandTestCase(CommandBaseTestCase):
         )
 
         result = self.run_command([self.command_name])
+
+        self.assertThat(result.exit_code, Equals(0))
+
+    def test_alias_verbose(self):
+        self.command_name = "plugins"
+        self.useFixture(
+            fixture_setup.SnapcraftYaml(
+                self.path,
+                base="core20",
+                parts={"part1": {"source": ".", "plugin": "nil"}},
+            )
+        )
+
+        result = self.run_command([self.command_name, "--verbosity", "trace"])
 
         self.assertThat(result.exit_code, Equals(0))
 

--- a/tests/legacy/unit/commands/test_list_validation_sets.py
+++ b/tests/legacy/unit/commands/test_list_validation_sets.py
@@ -60,8 +60,9 @@ combinations = [
 
 @pytest.mark.usefixtures("memory_keyring")
 @pytest.mark.parametrize("combo,", combinations)
-def test_no_sets(click_run, fake_dashboard_get_validation_sets, combo):
-    cmd = ["list-validation-sets"]
+@pytest.mark.parametrize("verbosity", [[], ["--verbosity", "trace"]])
+def test_no_sets(click_run, fake_dashboard_get_validation_sets, combo, verbosity):
+    cmd = ["list-validation-sets", *verbosity]
     if combo["name"] is not None:
         cmd.extend(["--name", combo["name"]])
     if combo["sequence"] is not None:

--- a/tests/legacy/unit/commands/test_metrics.py
+++ b/tests/legacy/unit/commands/test_metrics.py
@@ -86,6 +86,30 @@ class MetricsCommandTestCase(FakeStoreCommandsBaseTestCase):
         )
         assert result.exit_code == 0
 
+    def test_status_table_format_verbose(self):
+        result = self.run_command(
+            [
+                "metrics",
+                "snap-test",
+                "--name",
+                "daily_device_change",
+                "--format",
+                "table",
+                "--verbosity",
+                "trace"
+            ]
+        )
+
+        assert result.output == dedent(
+            """\
+               Devices    2021-01-01  2021-01-02  2021-01-03
+               Continued  10          11          12
+               Lost       1           2           3
+               New        2           3           4
+            """
+        )
+        assert result.exit_code == 0
+
     def test_status_table_json(self):
         result = self.run_command(
             [

--- a/tests/legacy/unit/commands/test_promote.py
+++ b/tests/legacy/unit/commands/test_promote.py
@@ -117,6 +117,26 @@ class PromoteCommandTestCase(FakeStoreCommandsBaseTestCase):
             snap_name="snap-test", revision="2", channels=["candidate"]
         )
 
+    def test_promote_confirm_yes_verbose(self):
+        result = self.run_command(
+            [
+                "promote",
+                "snap-test",
+                "--from-channel",
+                "beta",
+                "--to-channel",
+                "candidate",
+                "--verbosity",
+                "trace"
+            ],
+            input="y\n",
+        )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.fake_store_release.mock.assert_called_once_with(
+            snap_name="snap-test", revision="2", channels=["candidate"]
+        )
+
     def test_promote_yes_option(self):
         result = self.run_command(
             [

--- a/tests/legacy/unit/commands/test_remote.py
+++ b/tests/legacy/unit/commands/test_remote.py
@@ -64,6 +64,18 @@ class RemoteBuildTests(CommandBaseTestCase):
         mock_confirm.assert_not_called()
 
     @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
+    def test_remote_build_with_accept_option_doesnt_prompt_verbose(self, mock_confirm):
+        result = self.run_command(
+              ["remote-build", "--launchpad-accept-public-upload", "--verbosity", "trace"],
+          )
+
+        self.mock_lc.start_build.assert_called_once()
+        self.mock_lc.cleanup.assert_called_once()
+        self.assertThat(result.output, Contains("Building snap package for i386."))
+        self.assertThat(result.exit_code, Equals(0))
+        mock_confirm.assert_not_called()
+
+    @mock.patch("snapcraft_legacy.cli.remote.echo.confirm")
     def test_remote_build_core20_no_deprecation_warning(self, mock_confirm):
         snapcraft_yaml = fixture_setup.SnapcraftYaml(
             self.path,

--- a/tests/legacy/unit/commands/test_set_default_track.py
+++ b/tests/legacy/unit/commands/test_set_default_track.py
@@ -58,3 +58,13 @@ class SetDefaultTrackCommandTestCase(FakeStoreCommandsBaseTestCase):
         self.fake_metadata.mock.assert_called_once_with(
             snap_name="snap-test", metadata=dict(default_track="2.0"), force=True
         )
+
+    def test_set_default_track_verbose(self):
+        result = self.run_command(
+            ["set-default-track", "snap-test", "2.0", "--verbosity", "trace"]
+        )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.fake_metadata.mock.assert_called_once_with(
+            snap_name="snap-test", metadata=dict(default_track="2.0"), force=True
+        )

--- a/tests/legacy/unit/commands/test_upload_metadata.py
+++ b/tests/legacy/unit/commands/test_upload_metadata.py
@@ -100,6 +100,21 @@ class UploadMetadataCommandTestCase(CommandBaseTestCase):
         self.assertThat(result.output, Contains("The metadata has been uploaded"))
         self.assert_expected_metadata_calls(force=False)
 
+    def test_simple_verbose(self):
+        # upload metadata
+        with mock.patch("snapcraft_legacy.storeapi._status_tracker.StatusTracker"):
+            result = self.run_command(
+                ["upload-metadata", self.snap_file, "--verbosity", "trace"]
+            )
+        self.assertThat(result.exit_code, Equals(0))
+
+        self.assertThat(
+            result.output,
+            Not(Contains("Uploading metadata to the Store (force=False)")),
+        )
+        self.assertThat(result.output, Contains("The metadata has been uploaded"))
+        self.assert_expected_metadata_calls(force=False)
+
     def test_with_license_and_title(self):
         self.snap_file = os.path.join(
             os.path.dirname(tests.legacy.__file__),

--- a/tests/legacy/unit/commands/test_validate.py
+++ b/tests/legacy/unit/commands/test_validate.py
@@ -48,6 +48,19 @@ class ValidateCommandTestCase(StoreCommandsBaseTestCase):
             result.output, Contains("Signing validations assertion for test-snap=4")
         )
 
+    def test_validate_success_verbose(self):
+        result = self.run_command(
+            ["validate", "core", "core=3", "test-snap=4", "--verbosity", "trace"]
+        )
+
+        self.assertThat(result.exit_code, Equals(0))
+        self.assertThat(
+            result.output, Contains("Signing validations assertion for core=3")
+        )
+        self.assertThat(
+            result.output, Contains("Signing validations assertion for test-snap=4")
+        )
+
     def test_validate_with_key(self):
         result = self.run_command(
             ["validate", "core", "core=3", "test-snap=4", "--key-name=keyname"]

--- a/tests/legacy/unit/commands/test_version.py
+++ b/tests/legacy/unit/commands/test_version.py
@@ -23,8 +23,16 @@ class VersionCommandTestCase(CommandBaseTestCase):
         result = self.run_command(["--version"])
         self.assertThat(result.exit_code, Equals(0))
 
+    def test_has_version_verbose(self):
+        result = self.run_command(["--version", "--verbosity", "trace"])
+        self.assertThat(result.exit_code, Equals(0))
+
     def test_has_version_without_hyphens(self):
         result = self.run_command(["version"])
+        self.assertThat(result.exit_code, Equals(0))
+
+    def test_has_version_without_hyphens_version(self):
+        result = self.run_command(["version", "--verbosity", "trace"])
         self.assertThat(result.exit_code, Equals(0))
 
     def test_method_return_same_value(self):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Adds support for verbosity args in non-lifecycle commands in snapcraft legacy.

Verbosity gets parsed by modern snapcraft, so this PR allows legacy commands to accept and ignore verbosity args.

Fixes https://github.com/canonical/snapcraft/issues/5298