### PR TITLE
docs: add docs for setting component versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,7 @@ exclude_patterns = [
     "how-to/crafting/add-a-part.rst",
     "how-to/publishing/build-snaps-remotely.rst",
     "release-notes/snapcraft-8-12.rst",
+    "release-notes/snapcraft-8-13.rst",
 ]
 
 # region Options for extensions

--- a/docs/how-to/crafting/create-a-component.rst
+++ b/docs/how-to/crafting/create-a-component.rst
@@ -88,6 +88,6 @@ and the component file for the ``translations`` component.
    snapcraft upload hello-components_1.0_amd64.snap \
      --component translations=hello-components+translations_1.0.comp
 
-The store expects a snap and its components to be uploaded together.
-
-The component has to be uploaded alongside the snap.
+The store expects a snap and its components to be uploaded together. However, the component
+may have a different version than the snap. To dynamically set the component version,
+see :ref:`how-to-access-project-variables-across-parts-and-components`.

--- a/docs/how-to/crafting/customize-lifecycle-steps-and-part-variables.rst
+++ b/docs/how-to/crafting/customize-lifecycle-steps-and-part-variables.rst
@@ -26,6 +26,7 @@ Example solutions
     :start-after: craftctl get <key>
     :end-before: Expose part variables in apps
 
+.. _how-to-access-project-variables-across-parts-and-components:
 
 Access project variables across parts and components
 ----------------------------------------------------

--- a/docs/release-notes/snapcraft-8-13.rst
+++ b/docs/release-notes/snapcraft-8-13.rst
@@ -1,0 +1,35 @@
+.. _release-8.13:
+
+Snapcraft 8.13 release notes
+============================
+
+.. add date here, once scheduled
+
+Learn about the new features, changes, and fixes introduced in Snapcraft 8.13.
+
+
+Requirements and compatibility
+------------------------------
+See :ref:`reference-system-requirements` for information on the minimum hardware and
+installed software.
+
+
+What's new
+----------
+
+Snapcraft 8.13 brings the following features, integrations, and improvements.
+
+
+Set component versions dynamically
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /reuse/bases-intro.rst
+
+Similar to setting the top-level version, a component's version can now be set
+dynamically with ``craftctl``.
+
+Additionally, the version for each component can be set by a different part. This is
+controlled with a new ``adopt-info`` key for each component.
+
+For more information, see
+:ref:`how-to-access-project-variables-across-parts-and-components`.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

* Adds an 8.13 release note entry for the setting component versions.
* Links the component how-to to the `craftctl` how-to

(SNAPCRAFT-1165)