### PR TITLE
fix(legacy-cli): restore --version flag and minimal version subcommand

### DIFF
--- a/snapcraft_legacy/cli/_runner.py
+++ b/snapcraft_legacy/cli/_runner.py
@@ -81,6 +81,10 @@ def configure_requests_ca() -> None:
     invoke_without_command=True,
     context_settings=dict(help_option_names=["-h", "--help"]),
 )
+@click.version_option(
+    message="snapcraft %(version)s",
+    version=snapcraft_legacy.__version__,
+)
 @click.pass_context
 @add_provider_options(hidden=True)
 def run(ctx, debug, catch_exceptions=False, **kwargs):
@@ -132,6 +136,12 @@ def run(ctx, debug, catch_exceptions=False, **kwargs):
             ctx.params["output"] = None
         snap_command.invoke(ctx)
 
+
+# Add minimal version subcommand for backward compatibility
+@run.command()
+def version():
+    """Show the snapcraft version."""
+    click.echo(f"snapcraft {snapcraft_legacy.__version__}")
 
 # This would be much easier if they were subcommands
 for command_group in command_groups:


### PR DESCRIPTION
   ## Summary
   Fixes integration test failures caused by removing the `--version` flag when legacy help/version commands were removed.

   ## Changes
   - ✅ Restored `@click.version_option` decorator to handle `snapcraft --version`
   - ✅ Added minimal `version` subcommand for backward compatibility  
   - ✅ Maintains removal of legacy help/version command implementations
   - ✅ Fixes failing integration test: `tests/spread/core24-suites/manifest/manifest-creation/task.yaml`

   ## Root Cause
   The original removal of help/version commands also removed the `--version` flag handling, which broke integration tests that rely on `snapcraft --version` working.

   ## Testing
   - Integration test `manifest-creation` should now pass
   - Both `snapcraft --version` and `snapcraft version` work correctly
   - No complex help functionality restored (only minimal version support)

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---
