### PR TITLE
fix: properly ignore source-code field in metadata linter

### DIFF
--- a/snapcraft/linters/metadata_linter.py
+++ b/snapcraft/linters/metadata_linter.py
@@ -16,16 +16,20 @@
 
 """Metadata linter implementation."""
 
-from collections.abc import Callable
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import craft_cli
 from overrides import overrides
 
-from snapcraft.meta.snap_yaml import SnapMetadata
-
 from .base import Linter, LinterIssue, LinterResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from snapcraft.meta.snap_yaml import SnapMetadata
 
 _HELP_URL = "https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/"
 
@@ -34,9 +38,9 @@ _HELP_URL = "https://documentation.ubuntu.com/snapcraft/stable/reference/project
 class MetadataField:
     name: str
     severity: LinterResult
-    extract: Callable[["SnapMetadata"], Any]
+    extract: Callable[[SnapMetadata], Any]
     help_url: str
-    skip: Callable[["SnapMetadata"], bool] = lambda _: False
+    skip: Callable[[SnapMetadata], bool] = lambda _: False
 
 
 def _get_links_attr(meta: SnapMetadata, key: str) -> list[str] | str | None:
@@ -85,9 +89,9 @@ _FIELDS: list[MetadataField] = [
         f"{_HELP_URL}#issues",
     ),
     MetadataField(
-        "source_code",
+        "source-code",
         LinterResult.INFO,
-        lambda meta: _get_links_attr(meta, "source_code"),
+        lambda meta: _get_links_attr(meta, "source-code"),
         f"{_HELP_URL}#source-code",
     ),
     MetadataField(

--- a/snapcraft/linters/metadata_linter.py
+++ b/snapcraft/linters/metadata_linter.py
@@ -91,7 +91,7 @@ _FIELDS: list[MetadataField] = [
     MetadataField(
         "source-code",
         LinterResult.INFO,
-        lambda meta: _get_links_attr(meta, "source-code"),
+        lambda meta: _get_links_attr(meta, "source_code"),
         f"{_HELP_URL}#source-code",
     ),
     MetadataField(

--- a/tests/unit/linters/test_metadata_linter.py
+++ b/tests/unit/linters/test_metadata_linter.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -140,6 +142,75 @@ def test_metadata_linter_ignore_some_issues(new_dir, snap_yaml_data):
             url="https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#website",
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    ("lint_source", "specify_source", "linter_issue"),
+    [
+        pytest.param(
+            True,
+            False,
+            LinterIssue(
+                name="metadata",
+                result=LinterResult.INFO,
+                text="Metadata field 'source-code' is missing or empty.",
+                url="https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#source-code",
+            ),
+            id="lint-missing",
+        ),
+        pytest.param(
+            True,
+            True,
+            None,
+            id="lint-happy",
+        ),
+        pytest.param(
+            False,
+            False,
+            LinterIssue(
+                name="metadata",
+                result=LinterResult.IGNORED,
+                text="Metadata field 'source-code' is ignored.",
+            ),
+            id="lint-ignored",
+        ),
+        pytest.param(
+            False,
+            True,
+            LinterIssue(
+                name="metadata",
+                result=LinterResult.IGNORED,
+                text="Metadata field 'source-code' is ignored.",
+            ),
+            id="skip-ignored",
+        ),
+    ],
+)
+def test_metadata_linter_source_code(
+    new_dir: Path,
+    snap_yaml_data: Callable[..., dict[str, Any]],
+    lint_source: bool,
+    specify_source: bool,
+    linter_issue: LinterIssue | None,
+) -> None:
+    """Make sure that the source-code field is handled properly.
+
+    https://github.com/canonical/snapcraft/issues/5794"""
+    yaml_data = snap_yaml_data()
+    if specify_source:
+        yaml_data["source-code"] = "https://github.com/torvalds/linux"
+    project = models.Project.unmarshal(yaml_data)
+    snap_yaml.write(project, prime_dir=Path(new_dir), arch="amd64")
+
+    issues = linters.run_linters(
+        new_dir,
+        lint=models.Lint(ignore=[] if lint_source else [{"metadata": ["source-code"]}]),
+    )
+
+    if linter_issue is None:
+        assert "source-code" not in str(issues)
+    else:
+        assert linter_issue in issues
 
 
 def test_metadata_linter_ignore_devel_grade(new_dir, snap_yaml_data):


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

Fixes #5794. Does a little fly-by typing work while I'm in this file, as well.