### PR TITLE
fix(test): enable test to run on platforms other than 24.04

### DIFF
--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pytest
 import pytest_subprocess
-from craft_platforms import DebianArchitecture
+from craft_platforms import DebianArchitecture, DistroBase
 
 import snapcraft.parts
 from snapcraft import __version__, models, os_release
@@ -42,6 +42,11 @@ def lifecycle_service(default_project, fake_services, setup_project):
 
 def test_lifecycle_installs_base(lifecycle_service, mocker):
     install_snaps = mocker.patch("craft_parts.packages.snaps.install_snaps")
+
+    mocker.patch(
+        "craft_platforms.DistroBase.from_linux_distribution",
+        return_value=DistroBase("ubuntu", "24.04"),
+    )
 
     lifecycle_service.run("pull")
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint`?
- [x] Have you successfully run `make test`?

---

One of our tests only passed if ran on 24.04, this fixes that