### PR TITLE
fix: remove python complain

### DIFF
--- a/snapcraft_legacy/plugins/v2/_plugin.py
+++ b/snapcraft_legacy/plugins/v2/_plugin.py
@@ -55,7 +55,7 @@ class PluginV2(abc.ABC):
         """
 
     @property
-    def out_of_source_build(self):
+    def out_of_source_build(self) -> bool:
         """Set to True if the plugin performs out-of-source-tree builds.
 
         In practice, this controls whether the PluginHandler code will

--- a/snapcraft_legacy/plugins/v2/meson.py
+++ b/snapcraft_legacy/plugins/v2/meson.py
@@ -73,7 +73,7 @@ class MesonPlugin(PluginV2):
         return dict()
 
     @property
-    def out_of_source_build(self):
+    def out_of_source_build(self) -> bool:
         return True
 
     def get_build_commands(self) -> List[str]:


### PR DESCRIPTION
The out_of_source_build() property, as defined, returns a Literal(false), but when overriden by the meson plugin, it returns a Literal(true), which strictly speaking is incompatible, as shown in the python module for Code.

<img width="1192" height="435" alt="image" src="https://github.com/user-attachments/assets/c069beb9-4972-4dd7-87e0-25006de6ef62" />

This patch fixes this by specifying that the property is a boolean.

- [x] Have you followed the [guidelines for contributing](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `make test`?

---
