### PR TITLE
fix(commands/promote): exit non-zero when promotion is cancelled

### DIFF
--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -313,9 +313,9 @@ Removed ``SNAPCRAFT_HAS_TTY``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously, the :ref:`ref_commands_promote` command didn't support the ``--yes`` flag
-for non-interactive promotions from the edge channel. As a workaround, CI workflows
-could pipe ``yes`` into Snapcraft and set ``SNAPCRAFT_HAS_TTY=1`` to bypass the
-interactive prompt.
+for non-interactive promotions from the edge channel. Some users bypassed the
+interactive prompt in their CI workflows by piping the ``yes`` command into the
+environment when prompted, and setting ``SNAPCRAFT_HAS_TTY=1``.
 
 Snapcraft 9 no longer supports the ``SNAPCRAFT_HAS_TTY`` environment variable. Use the
 ``--yes`` flag for non-interactive promotions instead.
@@ -347,9 +347,8 @@ Snapcraft 9.0.0
 Snapcraft 9.0.1
 ~~~~~~~~~~~~~~~~
 
-- `#6294 <https://github.com/canonical/snapcraft/issues/6294>`__ The
-  :ref:`ref_commands_promote` command now returns a non-zero exit code when the
-  promotion prompt is declined.
+- `#6294 <https://github.com/canonical/snapcraft/issues/6294>`__ Snapcraft 9 fails
+  silently with pre-9 CI promotion syntax.
 
 
 Contributors

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -101,6 +101,10 @@ Promote edge channels with ``--yes``
 The :ref:`ref_commands_promote` command now supports promoting releases from the edge
 channel non-interactively with the ``--yes`` flag.
 
+CI workflows that worked around this limitation using the ``SNAPCRAFT_HAS_TTY``
+environment variable must be updated. See :ref:`release-notes-9.0-snapcraft-has-tty`
+for instructions on removing the workaround.
+
 ``--format`` option for ``validation-sets``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -303,6 +307,19 @@ continue developing:
     git submodule deinit -f docs/sphinx-docs-starter-pack
     rm -r docs/sphinx-docs-starter-pack
 
+.. _release-notes-9.0-snapcraft-has-tty:
+
+Removed ``SNAPCRAFT_HAS_TTY``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, the :ref:`ref_commands_promote` command didn't support the ``--yes`` flag
+for non-interactive promotions from the edge channel. As a workaround, CI workflows
+could pipe ``yes`` into Snapcraft and set ``SNAPCRAFT_HAS_TTY=1`` to bypass the
+interactive prompt.
+
+Snapcraft 9 no longer supports the ``SNAPCRAFT_HAS_TTY`` environment variable. Use the
+``--yes`` flag for non-interactive promotions instead.
+
 
 Fixed bugs and issues
 ---------------------
@@ -324,6 +341,15 @@ Snapcraft 9.0.0
   build packages with versioned dependencies couldn't be resolved.
 - `craft-parts#1492 <https://github.com/canonical/craft-parts/issues/1492>`__ The
   :ref:`craft_parts_poetry_plugin` didn't work for core26 snaps.
+
+.. _release-notes-fixes-9.0.1:
+
+Snapcraft 9.0.1
+~~~~~~~~~~~~~~~~
+
+- `#6294 <https://github.com/canonical/snapcraft/issues/6294>`__ The
+  :ref:`ref_commands_promote` command now returns a non-zero exit code when the
+  promotion prompt is declined.
 
 
 Contributors

--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import operator
+import os
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -168,7 +169,11 @@ class StorePromoteCommand(AppCommand):
         )
 
     @override
-    def run(self, parsed_args: argparse.Namespace):
+    def run(self, parsed_args: argparse.Namespace) -> int | None:
+        """Promote a build set from a channel in the Snap Store.
+
+        Returns non-zero if the promotion fails or is declined by the user.
+        """
         emit.warning(
             "snapcraft promote does not have a stable CLI interface. Use with caution in scripts."
         )
@@ -208,8 +213,20 @@ class StorePromoteCommand(AppCommand):
                     channels=[str(to_channel)],
                 )
             emit.message(f"Promotion from {from_channel} to {to_channel} complete")
-        else:
-            emit.message("Channel promotion cancelled")
+            return os.EX_OK
+
+        # Prior to Snapcraft 9, the promote command didn't allow using '--yes' for non-interactive
+        # promotions from edge, so users had to do: 'yes | SNAPCRAFT_HAS_TTY=1 snapcraft promote'.
+        # This env var isn't supported anymore, so we provide helpful guidance.
+        if os.getenv("SNAPCRAFT_HAS_TTY"):
+            emit.warning(
+                "The 'SNAPCRAFT_HAS_TTY' environment variable is no longer used. "
+                "Use '--yes' for non-interactive promotions."
+            )
+
+        emit.message("Channel promotion cancelled")
+        # Return 1 because there isn't a good sysexits code for a user denying a prompt.
+        return 1
 
 
 class StoreCloseCommand(AppCommand):

--- a/tests/unit/commands/test_manage.py
+++ b/tests/unit/commands/test_manage.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import os
 from unittest.mock import ANY, call
 
 import pytest
@@ -286,7 +287,7 @@ def test_promote_with_yes(
     emitter, fake_store_get_snap_status, fake_store_release, fake_app_config
 ):
     cmd = commands.StorePromoteCommand(fake_app_config)
-    cmd.run(
+    result = cmd.run(
         argparse.Namespace(
             snap_name="test-snap",
             from_channel="candidate",
@@ -302,6 +303,7 @@ def test_promote_with_yes(
         ANY, snap_name="test-snap", revision=11, channels=["stable"]
     )
     emitter.assert_message("Promotion from candidate to stable complete")
+    assert result == os.EX_OK
 
 
 @pytest.mark.usefixtures("memory_keyring")
@@ -310,7 +312,7 @@ def test_promote_user_confirms(
 ):
     mocker.patch("craft_cli.emit.confirm", return_value=True)
     cmd = commands.StorePromoteCommand(fake_app_config)
-    cmd.run(
+    result = cmd.run(
         argparse.Namespace(
             snap_name="test-snap",
             from_channel="candidate",
@@ -321,6 +323,7 @@ def test_promote_user_confirms(
 
     assert fake_store_release.called
     emitter.assert_message("Promotion from candidate to stable complete")
+    assert result == os.EX_OK
 
 
 @pytest.mark.usefixtures("memory_keyring")
@@ -329,7 +332,7 @@ def test_promote_user_cancels(
 ):
     mocker.patch("craft_cli.emit.confirm", return_value=False)
     cmd = commands.StorePromoteCommand(fake_app_config)
-    cmd.run(
+    result = cmd.run(
         argparse.Namespace(
             snap_name="test-snap",
             from_channel="candidate",
@@ -340,6 +343,7 @@ def test_promote_user_cancels(
 
     fake_store_release.assert_not_called()
     emitter.assert_message("Channel promotion cancelled")
+    assert result == 1
 
 
 @pytest.mark.usefixtures("memory_keyring")
@@ -387,3 +391,31 @@ def test_promote_no_releases_error(fake_store_get_snap_status, fake_app_config):
                 yes=True,
             )
         )
+
+
+@pytest.mark.usefixtures("memory_keyring")
+def test_promote_warn_snapcraft_has_tty(
+    emitter,
+    fake_store_get_snap_status,
+    fake_store_release,
+    fake_app_config,
+    mocker,
+    monkeypatch,
+):
+    monkeypatch.setenv("SNAPCRAFT_HAS_TTY", "1")
+    mocker.patch("craft_cli.emit.confirm", return_value=False)
+    cmd = commands.StorePromoteCommand(fake_app_config)
+
+    cmd.run(
+        argparse.Namespace(
+            snap_name="test-snap",
+            from_channel="candidate",
+            to_channel="stable",
+            yes=False,
+        )
+    )
+
+    emitter.assert_warning(
+        "The 'SNAPCRAFT_HAS_TTY' environment variable is no longer used. "
+        "Use '--yes' for non-interactive promotions."
+    )


### PR DESCRIPTION
- Exit non-zero when promotion is cancelled by the user.
- Provide guidance for fixing CI workflows that relied on `SNAPCRAFT_HAS_TTY` to workaround #5958.

Fixes #6294
(SNAPCRAFT-1359)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
