### PR TITLE
fix(store): raise error when upload processing status is 'error'

### DIFF
--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -282,11 +282,11 @@ is invoked by the consuming application.
 
 .. _Apt: https://wiki.debian.org/AptCLI
 .. _Bazaar: https://launchpad.net/bzr
-.. _Craft Application cryptography: https://canonical-craft-application.readthedocs-hosted.com/en/latest/explanation/cryptography/
-.. _Craft Archives cryptography: https://canonical-craft-archives.readthedocs-hosted.com/en/latest/explanation/cryptography/
-.. _Craft Parts cryptography: https://canonical-craft-parts.readthedocs-hosted.com/en/latest/explanation/cryptography/
-.. _Craft Providers cryptography: https://canonical-craft-providers.readthedocs-hosted.com/en/latest/explanation/cryptography/
-.. _Craft Store cryptography: https://canonical-craft-store.readthedocs-hosted.com/en/latest/explanation/cryptography/
+.. _Craft Application cryptography: https://documentation.ubuntu.com/craft-application/latest/explanation/cryptography/
+.. _Craft Archives cryptography: https://documentation.ubuntu.com/craft-archives/latest/explanation/cryptography/
+.. _Craft Parts cryptography: https://documentation.ubuntu.com/craft-parts/latest/explanation/cryptography/
+.. _Craft Providers cryptography: https://documentation.ubuntu.com/craft-providers/latest/explanation/cryptography/
+.. _Craft Store cryptography: https://documentation.ubuntu.com/craft-store/latest/explanation/cryptography/
 .. _Crystal snap: https://snapcraft.io/crystal
 .. _curl: https://curl.se/
 .. _dirmngr: https://manpages.ubuntu.com/manpages/noble/man8/dirmngr.8.html

--- a/docs/reference/package-repositories.rst
+++ b/docs/reference/package-repositories.rst
@@ -19,4 +19,4 @@ packages.
 For more information on how to configure package repositories, see the `Craft Archives
 documentation`_.
 
-.. _Craft Archives documentation: https://canonical-craft-archives.readthedocs-hosted.com/en/latest/reference/repo_properties/
+.. _Craft Archives documentation: https://documentation.ubuntu.com/craft-archives/latest/

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -576,6 +576,11 @@ class LegacyStoreClientCLI:
                     raise errors.SnapcraftError(
                         f"Issues while processing snap:\n{error_string}"
                     )
+                if status.get("code") == "error":
+                    raise errors.SnapcraftError(
+                        f"Store processing failed with status: {human_status!r}. "
+                        "Please check the automated review on the Snap Store."
+                    )
                 break
 
             time.sleep(_POLL_DELAY)

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -2277,3 +2277,38 @@ def test_on_prem_list_releases(
             headers={"Content-Type": "application/json", "Accept": "application/json"},
         )
     ]
+
+
+def test_notify_upload_error_status_raises_error(mocker):
+    """Test that notify_upload raises SnapcraftError if store processing returns code 'error'."""
+    status_url = "https://dashboard.snapcraft.io/dev/api/snap-push/123/status/"
+
+    # Use the exact class we found from grep
+    test_client = client.StoreClientCLI()
+
+    post_response = mocker.Mock()
+    post_response.json.return_value = {"status_details_url": status_url}
+
+    get_response = mocker.Mock()
+    get_response.json.return_value = {
+        "processed": True,
+        "code": "error",
+        "errors": [],
+        "revision": 1,
+    }
+
+    mocker.patch.object(
+        test_client, "request", side_effect=[post_response, get_response]
+    )
+
+    with pytest.raises(
+        errors.SnapcraftError, match="Store processing failed with status"
+    ):
+        test_client.notify_upload(
+            snap_name="test-snap",
+            upload_id="upload-123",
+            snap_file_size=1024,
+            built_at=None,
+            channels=None,
+            components=None,
+        )


### PR DESCRIPTION
**Context:**
Currently, when running `snapcraft upload --release`, the CLI polls the store API for the upload processing status. If the store's automated review fails, the API sometimes returns a status with `code: "error"` but an empty `errors` list. Because the existing logic only raised an exception if the `errors` list was populated, the CLI silently bypassed the error, broke out of the polling loop, and returned a revision number—falsely reporting a successful release to the user when it was actually rejected.

**Changes in this PR:**
- Updated the `notify_upload` method in `snapcraft/store/client.py` to explicitly check if `status.get("code") == "error"`. If this condition is met, the CLI now properly aborts the process and raises a `SnapcraftError`.
- Added a corresponding unit test `test_notify_upload_error_status_raises_error` in `tests/unit/store/test_client.py` to ensure regressions are prevented.

Fixes #6299

---

- [x] I've followed the contribution guidelines.
- [x] I've signed the CLA.
- [x] I've successfully run `make lint && make test`.