### PR TITLE
fix(desktop-file): verify theme icons before rewriting icon

### DIFF
--- a/snapcraft/parts/desktop_file.py
+++ b/snapcraft/parts/desktop_file.py
@@ -98,11 +98,11 @@ class DesktopFile:
             # If icon is just a name (no path separator), try to resolve it from the hicolor icon theme.
             if "/" not in icon:
                 if (
-                    icon_path := get_icon_from_theme(
+                    theme_icon_path := get_icon_from_theme(
                         os.fspath(self._prime_dir), "hicolor", icon
                     )
                 ) is not None:
-                    self._parser[section]["Icon"] = os.path.join("${SNAP}", icon_path)
+                    icon = theme_icon_path
 
             # With everything stripped, check to see if the icon is there.
             # if it is, add "${SNAP}" back and set the icon


### PR DESCRIPTION
Theme-resolved icon path was written to the desktop file without checking the file exists, and the subsequent existence check ran against the bare icon name stored in `icon` variable, emitting a spurious "not found" warning. Assign the resolved path to the local var first so the same check covers theme icons.

Fixes #6364 

IMO, this complete function should be refactored, including early return when icon is None, converting these 2 lines into a single one liner and remove any prefixed `$SNAP` as well

```diff
@@ -89,11 +89,8 @@ class DesktopFile:
             if icon_path is not None:
                 icon = icon_path
 
-            # Strip any leading slash.
-            icon = icon[1:] if icon.startswith("/") else icon
-
-            # Strip any leading ${SNAP}.
-            icon = icon[8:] if icon.startswith("${SNAP}") else icon
+            # Strip any leading slash, ${SNAP} and $SNAP variable
+            icon.removeprefix("/").removeprefix("${SNAP}").removeprefix("$SNAP")
 
             # If icon is just a name (no path separator), try to resolve it from the hicolor icon theme.
             if "/" not in icon:
```
---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
