### PR TITLE
docs: update LXD docs URL

### DIFF
--- a/docs/how-to/set-up-snapcraft.rst
+++ b/docs/how-to/set-up-snapcraft.rst
@@ -117,7 +117,7 @@ Finally, initialize LXD with a lightweight configuration:
     sudo lxd init --auto
 
 If you need help troubleshooting your LXD installation, see `How to install LXD
-<https://documentation.ubuntu.com/lxd/en/latest/installing/#installing>`_ in the LXD
+<https://canonical.com/lxd/docs/latest/installing/#installing>`_ in the LXD
 documentation.
 
 

--- a/docs/reference/build-environment-options.rst
+++ b/docs/reference/build-environment-options.rst
@@ -21,7 +21,7 @@ Snapcraft can optionally use the following arguments to modify the build environ
      - See :ref:`destructive mode <reference-build-environment-options-destructive>`.
 
    * - ``--use-lxd``
-     - Builds the snap using `LXD <https://linuxcontainers.org/lxd/introduction/>`_
+     - Builds the snap using `LXD <https://canonical.com/lxd/docs/>`_
        rather than Multipass. This can potentially reduce resource usage, especially
        from a VM.
      - Requires LXD. For more information, see :ref:`how-to-select-a-build-provider`.


### PR DESCRIPTION
LXD docs are now on https://canonical.com/lxd/docs/
