### PR TITLE
feat: mediate creation of hooks and gui assets

### DIFF
--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -44,6 +44,7 @@ def setup_assets(
     project_dir: Path,
     prime_dirs: dict[str | None, Path],
     meta_directory_handler: Callable[[Path, Path], None] | None = None,
+    copy_hooks_and_gui: bool = True,
 ) -> None:
     """Copy assets to the appropriate locations in the snap filesystem.
 
@@ -54,22 +55,27 @@ def setup_assets(
         map to the default prime directory.
     :param meta_directory_handler: callback that overrides default behavior for
         handling hooks and gui. The arguments passed are assets_dir and prime_dir.
+    :param copy_hooks_and_gui: Whether to copy hooks and gui assets. When False, the
+        application is expected to handle hooks and gui assets through the mediated
+        packing flow.
     """
     prime_dir = prime_dirs[None]
     meta_dir = prime_dir / "meta"
     gui_dir = meta_dir / "gui"
     gui_dir.mkdir(parents=True, exist_ok=True)
 
-    copy_assets(assets_dir, prime_dir, meta_directory_handler)
+    if copy_hooks_and_gui:
+        copy_assets(assets_dir, prime_dir, meta_directory_handler)
     setup_hooks(project.hooks, prime_dir)
 
     if project.components:
         for component_name, component in project.components.items():
-            copy_assets(
-                assets_dir / "component" / component_name,
-                prime_dirs[component_name],
-                meta_directory_handler,
-            )
+            if copy_hooks_and_gui:
+                copy_assets(
+                    assets_dir / "component" / component_name,
+                    prime_dirs[component_name],
+                    meta_directory_handler,
+                )
             setup_hooks(component.hooks, prime_dirs[component_name])
 
     if _uses_legacy_system_metadata(project):
@@ -130,7 +136,7 @@ def copy_assets(
             assets_dir=assets_dir, prime_dir=prime_dir, meta_dir=prime_dir / "meta"
         )
         # create wrappers for hooks in the snap/hooks directory
-        _create_hook_wrappers(prime_dir)
+        create_hook_wrappers(prime_dir)
 
 
 def setup_hooks(hooks: dict[str, models.Hook] | None, prime_dir: Path) -> None:
@@ -294,7 +300,7 @@ def _ensure_hook_executable(hook_path: Path) -> None:
         hook_path.chmod(0o755)
 
 
-def _create_hook_wrappers(prime_dir: Path) -> None:
+def create_hook_wrappers(prime_dir: Path) -> None:
     """Create wrappers for hooks.
 
     Hooks in the snap/hooks/ directory are typically built by parts.
@@ -338,6 +344,8 @@ def _write_hook_wrapper(hook_name: str, wrapper_path: Path) -> None:
             f'exec "{Path("$SNAP", "snap", "hooks", hook_name)}" "$@"',
             file=wrapper_file,
         )
+
+    wrapper_path.chmod(0o755)
 
 
 def _copy_file(source: Path, destination: Path, **kwargs) -> None:

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -336,8 +336,7 @@ def _write_hook_wrapper(hook_name: str, wrapper_path: Path) -> None:
     :param hook_name: name of the hook
     :param wrapper_path: file path of hook wrapper
     """
-    if wrapper_path.exists():
-        return
+    wrapper_path.unlink(missing_ok=True)
 
     with open(wrapper_path, "w+", encoding="utf-8") as wrapper_file:
         print("#!/bin/sh", file=wrapper_file)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -300,7 +300,7 @@ def _ensure_hook_executable(hook_path: Path) -> None:
         hook_path.chmod(0o755)
 
 
-def create_hook_wrappers(prime_dir: Path) -> None:
+def create_hook_wrappers(prime_dir: Path, *, overwrite: bool = True) -> None:
     """Create wrappers for hooks.
 
     Hooks in the snap/hooks/ directory are typically built by parts.
@@ -309,6 +309,7 @@ def create_hook_wrappers(prime_dir: Path) -> None:
     execute the hook in $SNAP/snap/hooks/.
 
     :param prime_dir: The directory containing the content to be snapped.
+    :param overwrite: Whether wrappers should replace existing meta/hooks entries.
     """
     # collect hooks in snap/hooks directory
     hooks_snap_dir = Path(prime_dir, "snap", "hooks")
@@ -325,18 +326,22 @@ def create_hook_wrappers(prime_dir: Path) -> None:
     # create a wrapper for each hook
     for hook in hooks_in_snap_dir:
         _ensure_hook_executable(hook)
-        _write_hook_wrapper(hook.name, hooks_meta_dir / hook.name)
+        _write_hook_wrapper(hook.name, hooks_meta_dir / hook.name, overwrite=overwrite)
 
 
-def _write_hook_wrapper(hook_name: str, wrapper_path: Path) -> None:
+def _write_hook_wrapper(hook_name: str, wrapper_path: Path, *, overwrite: bool = True) -> None:
     """Write hook wrapper file.
 
     The wrapper is a minimal shell script that calls a hook in $SNAP/snap/hooks/
 
     :param hook_name: name of the hook
     :param wrapper_path: file path of hook wrapper
+    :param overwrite: Whether to replace an existing hook at wrapper_path.
     """
-    wrapper_path.unlink(missing_ok=True)
+    if wrapper_path.exists():
+        if not overwrite:
+            return
+        wrapper_path.unlink()
 
     with open(wrapper_path, "w+", encoding="utf-8") as wrapper_file:
         print("#!/bin/sh", file=wrapper_file)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -329,6 +329,38 @@ def create_hook_wrappers(prime_dir: Path, *, overwrite: bool = True) -> None:
         _write_hook_wrapper(hook.name, hooks_meta_dir / hook.name, overwrite=overwrite)
 
 
+def provision_hooks(prime_dir: Path, *, overwrite: bool = True) -> None:
+    """Provision built hooks directly into meta/hooks.
+
+    Hooks in snap/hooks/ are copied into meta/hooks/ so the primed tree contains
+    directly runnable hook payloads. Existing meta/hooks entries can be preserved
+    to let project hooks override generated ones. This matches the previous hook
+    installation strategy for core24.
+
+    :param prime_dir: The directory containing the content to be snapped.
+    :param overwrite: Whether to replace an existing hook in meta/hooks.
+    """
+    hooks_snap_dir = Path(prime_dir, "snap", "hooks")
+    hooks_in_snap_dir = hooks_snap_dir.iterdir() if hooks_snap_dir.is_dir() else []
+
+    if not hooks_in_snap_dir:
+        return
+
+    hooks_meta_dir = Path(prime_dir, "meta", "hooks")
+    hooks_meta_dir.mkdir(parents=True, exist_ok=True)
+
+    for hook in hooks_in_snap_dir:
+        _ensure_hook_executable(hook)
+
+        destination = hooks_meta_dir / hook.name
+        if destination.exists() and not overwrite:
+            continue
+
+        destination.unlink(missing_ok=True)
+        _copy_file(hook, destination, follow_symlinks=True)
+        _ensure_hook_executable(destination)
+
+
 def _write_hook_wrapper(hook_name: str, wrapper_path: Path, *, overwrite: bool = True) -> None:
     """Write hook wrapper file.
 

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -336,7 +336,8 @@ def _write_hook_wrapper(hook_name: str, wrapper_path: Path) -> None:
     :param hook_name: name of the hook
     :param wrapper_path: file path of hook wrapper
     """
-    wrapper_path.unlink(missing_ok=True)
+    if wrapper_path.exists():
+        return
 
     with open(wrapper_path, "w+", encoding="utf-8") as wrapper_file:
         print("#!/bin/sh", file=wrapper_file)

--- a/snapcraft/parts/setup_assets.py
+++ b/snapcraft/parts/setup_assets.py
@@ -361,7 +361,9 @@ def provision_hooks(prime_dir: Path, *, overwrite: bool = True) -> None:
         _ensure_hook_executable(destination)
 
 
-def _write_hook_wrapper(hook_name: str, wrapper_path: Path, *, overwrite: bool = True) -> None:
+def _write_hook_wrapper(
+    hook_name: str, wrapper_path: Path, *, overwrite: bool = True
+) -> None:
     """Write hook wrapper file.
 
     The wrapper is a minimal shell script that calls a hook in $SNAP/snap/hooks/

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -36,7 +36,7 @@ from snapcraft.meta import component_yaml, snap_yaml
 from snapcraft.models import ContentPlug
 from snapcraft.parts import extract_metadata as extract
 from snapcraft.parts import update_metadata as update
-from snapcraft.parts.setup_assets import create_hook_wrappers, setup_assets
+from snapcraft.parts.setup_assets import provision_hooks, setup_assets
 from snapcraft.services import Lifecycle
 from snapcraft.utils import get_component_name, process_version
 
@@ -538,9 +538,9 @@ class Package(PackageService):
 
     @override
     def _materialize_extra_assets(self, partition_name: str | None = None) -> None:
-        """Materialize mediated hook and GUI assets, including hook wrappers."""
+        """Materialize mediated hook and GUI assets, including hook provisioning."""
         super()._materialize_extra_assets(partition_name)
-        create_hook_wrappers(self._prime_dir_for(partition_name), overwrite=False)
+        provision_hooks(self._prime_dir_for(partition_name), overwrite=False)
 
     def _write_system_metadata(self, path: pathlib.Path) -> None:
         """Materialize mediated gadget/kernel metadata files for core24+ snaps."""

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -390,7 +390,7 @@ class Package(PackageService):
         if project_hooks_dir.is_dir():
             for hook in project_hooks_dir.iterdir():
                 if hook.is_file():
-                    assets.append((hook, prime_dir / "meta" / "hooks" / hook.name))
+                    assets.append((hook, prime_dir / "snap" / "hooks" / hook.name))
 
         if normalized_partition is None:
             gui_project_dir = assets_dir / "gui"

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -372,7 +372,9 @@ class Package(PackageService):
         if partition_name in (None, "default"):
             return self._services.lifecycle.prime_dir
 
-        return cast(Lifecycle, self._services.lifecycle).get_prime_dir(partition_name)
+        return cast(Lifecycle, self._services.lifecycle).get_prime_dir(
+            get_component_name(partition_name)
+        )
 
     @override
     def _gen_extra_assets(

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -390,7 +390,7 @@ class Package(PackageService):
         if project_hooks_dir.is_dir():
             for hook in project_hooks_dir.iterdir():
                 if hook.is_file():
-                    assets.append((hook, prime_dir / "snap" / "hooks" / hook.name))
+                    assets.append((hook, prime_dir / "meta" / "hooks" / hook.name))
 
         if normalized_partition is None:
             gui_project_dir = assets_dir / "gui"

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -36,9 +36,9 @@ from snapcraft.meta import component_yaml, snap_yaml
 from snapcraft.models import ContentPlug
 from snapcraft.parts import extract_metadata as extract
 from snapcraft.parts import update_metadata as update
-from snapcraft.parts.setup_assets import setup_assets
+from snapcraft.parts.setup_assets import create_hook_wrappers, setup_assets
 from snapcraft.services import Lifecycle
-from snapcraft.utils import process_version
+from snapcraft.utils import get_component_name, process_version
 
 
 class Package(PackageService):
@@ -60,12 +60,9 @@ class Package(PackageService):
     @package_file("meta/component.yaml", partition_re=r"(?!default$)[a-z0-9][a-z0-9-]*")
     def _get_component_yaml(self, partition: str | None = None) -> str:
         """Generate mediated component metadata files."""
-        if partition is None:
+        component_name = get_component_name(partition)
+        if component_name is None:
             raise ValueError("Component metadata requires a component partition.")
-
-        # Accept both the bare component name used by get_artifacts() and
-        # the fully qualified partition form for direct callers.
-        component_name = partition.removeprefix("component/")
         return component_yaml.get_str(self._project, component_name)
 
     @package_file("meta/gadget.yaml", partition_re="default")
@@ -357,6 +354,14 @@ class Package(PackageService):
             return None
         return self._package_output_dir
 
+    def _get_partition_assets_dir(self, component_name: str | None) -> pathlib.Path:
+        """Return the project assets directory for a mediated artifact."""
+        assets_dir = self._get_assets_dir()
+        if component_name is None:
+            return assets_dir
+
+        return assets_dir / "component" / component_name
+
     @override
     def _prime_dir_for(self, partition_name: str | None) -> pathlib.Path:
         """Return the prime directory for the requested artifact.
@@ -368,6 +373,32 @@ class Package(PackageService):
             return self._services.lifecycle.prime_dir
 
         return cast(Lifecycle, self._services.lifecycle).get_prime_dir(partition_name)
+
+    @override
+    def _gen_extra_assets(
+        self, partition_name: str | None = None
+    ) -> list[tuple[str | bytes | None | pathlib.Path, pathlib.Path]]:
+        """Generate mediated hook and GUI assets for the requested artifact."""
+        normalized_partition = get_component_name(partition_name)
+        prime_dir = self._prime_dir_for(normalized_partition)
+        assets_dir = self._get_partition_assets_dir(normalized_partition)
+
+        assets: list[tuple[str | bytes | None | pathlib.Path, pathlib.Path]] = []
+        project_hooks_dir = assets_dir / "hooks"
+        if project_hooks_dir.is_dir():
+            for hook in project_hooks_dir.iterdir():
+                if hook.is_file():
+                    assets.append((hook, prime_dir / "snap" / "hooks" / hook.name))
+
+        if normalized_partition is None:
+            gui_project_dir = assets_dir / "gui"
+            gui_meta_dir = prime_dir / "meta" / "gui"
+            if gui_project_dir.is_dir():
+                for gui_asset in gui_project_dir.iterdir():
+                    if gui_asset.is_file():
+                        assets.append((gui_asset, gui_meta_dir / gui_asset.name))
+
+        return assets
 
     def _pack_snap(
         self, prime_dir: pathlib.Path, output_path: pathlib.Path
@@ -486,6 +517,29 @@ class Package(PackageService):
 
         return None
 
+    @override
+    def _write_asset(
+        self, source: str | bytes | None | pathlib.Path, destination: pathlib.Path
+    ) -> None:
+        """Write a mediated asset while preserving hook executability."""
+        if isinstance(source, pathlib.Path):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(source, destination)
+        else:
+            super()._write_asset(source, destination)
+
+        if destination.parent.name == "hooks" and destination.parent.parent.name in {
+            "meta",
+            "snap",
+        }:
+            destination.chmod(0o755)
+
+    @override
+    def _materialize_extra_assets(self, partition_name: str | None = None) -> None:
+        """Materialize mediated hook and GUI assets, including hook wrappers."""
+        super()._materialize_extra_assets(partition_name)
+        create_hook_wrappers(self._prime_dir_for(partition_name))
+
     def _write_system_metadata(self, path: pathlib.Path) -> None:
         """Materialize mediated gadget/kernel metadata files for core24+ snaps."""
         meta_dir = path / "meta"
@@ -531,7 +585,7 @@ class Package(PackageService):
             assets_dir=assets_dir,
             project_dir=self._services.lifecycle.project_info.project_dir,
             prime_dirs=lifecycle_service.prime_dirs,
-            meta_directory_handler=meta_directory_handler,
+            copy_hooks_and_gui=False,
         )
         self._write_system_metadata(path)
 
@@ -550,64 +604,3 @@ class Package(PackageService):
             self._services.lifecycle.prime_dir,
             arch=self._build_for,
         )
-
-
-def _hardlink_or_copy(source: pathlib.Path, destination: pathlib.Path) -> bool:
-    """Try to hardlink and fallback to copy if it fails.
-
-    :param source: the source path.
-    :param destination: the destination path.
-    :returns: True if a hardlink was done or False for copy.
-    """
-    # Unlink the destination to avoid link failures
-    destination.unlink(missing_ok=True)
-
-    try:
-        destination.hardlink_to(source)
-    except OSError as os_error:
-        # Cross device link
-        if os_error.errno != 18:
-            raise
-        shutil.copy(source, destination)
-        return False
-
-    return True
-
-
-def meta_directory_handler(assets_dir: pathlib.Path, path: pathlib.Path):
-    """Handle hooks and gui assets from Snapcraft.
-
-    :param assets_dir: directory with project assets.
-    :param path: directory to write assets to.
-    """
-    meta_dir = path / "meta"
-    built_snap_hooks = path / "snap" / "hooks"
-    hooks_project_dir = assets_dir / "hooks"
-
-    hooks_meta_dir = meta_dir / "hooks"
-
-    if built_snap_hooks.is_dir():
-        hooks_meta_dir.mkdir(parents=True, exist_ok=True)
-        for hook in built_snap_hooks.iterdir():
-            meta_dir_hook = hooks_meta_dir / hook.name
-            # Remove to always refresh to the latest
-            meta_dir_hook.unlink(missing_ok=True)
-            meta_dir_hook.hardlink_to(hook)
-
-    # Overwrite any built hooks with project level ones
-    if hooks_project_dir.is_dir():
-        hooks_meta_dir.mkdir(parents=True, exist_ok=True)
-        for hook in hooks_project_dir.iterdir():
-            meta_dir_hook = hooks_meta_dir / hook.name
-
-            _hardlink_or_copy(hook, meta_dir_hook)
-
-    # Write any gui assets
-    gui_project_dir = assets_dir / "gui"
-    gui_meta_dir = meta_dir / "gui"
-    if gui_project_dir.is_dir():
-        gui_meta_dir.mkdir(parents=True, exist_ok=True)
-        for gui in gui_project_dir.iterdir():
-            meta_dir_gui = gui_meta_dir / gui.name
-
-            _hardlink_or_copy(gui, meta_dir_gui)

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -390,7 +390,7 @@ class Package(PackageService):
         if project_hooks_dir.is_dir():
             for hook in project_hooks_dir.iterdir():
                 if hook.is_file():
-                    assets.append((hook, prime_dir / "snap" / "hooks" / hook.name))
+                    assets.append((hook, prime_dir / "meta" / "hooks" / hook.name))
 
         if normalized_partition is None:
             gui_project_dir = assets_dir / "gui"
@@ -540,7 +540,7 @@ class Package(PackageService):
     def _materialize_extra_assets(self, partition_name: str | None = None) -> None:
         """Materialize mediated hook and GUI assets, including hook wrappers."""
         super()._materialize_extra_assets(partition_name)
-        create_hook_wrappers(self._prime_dir_for(partition_name))
+        create_hook_wrappers(self._prime_dir_for(partition_name), overwrite=False)
 
     def _write_system_metadata(self, path: pathlib.Path) -> None:
         """Materialize mediated gadget/kernel metadata files for core24+ snaps."""

--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -359,6 +359,21 @@ def is_snapcraft_running_from_snap() -> bool:
     return os.getenv("SNAP_NAME") == "snapcraft" and os.getenv("SNAP") is not None
 
 
+def get_component_name(partition_name: str | None) -> str | None:
+    """Normalize a partition name to a component name.
+
+    Partition names may come in as either bare component names
+    (e.g. "foo") or fully qualified names (e.g. "component/foo").
+    This function normalizes both to just the component name.
+
+    :param partition_name: The partition name to normalize.
+    :returns: The component name, or None if the input was None or "default".
+    """
+    if partition_name in (None, "default"):
+        return None
+    return partition_name.removeprefix("component/")
+
+
 def get_prime_dirs_from_project(project_info: ProjectInfo) -> dict[str | None, Path]:
     """Get a mapping of component names to prime directories from a ProjectInfo.
 
@@ -372,7 +387,7 @@ def get_prime_dirs_from_project(project_info: ProjectInfo) -> dict[str | None, P
     # strip 'component/' prefix so that the component name is the key
     for partition, prime_dir in partition_prime_dirs.items():
         if partition and partition.startswith("component/"):
-            component = partition.split("/", 1)[1]
+            component = get_component_name(partition)
             component_prime_dirs[component] = prime_dir
 
     return component_prime_dirs

--- a/tests/unit/parts/test_setup_assets.py
+++ b/tests/unit/parts/test_setup_assets.py
@@ -25,7 +25,7 @@ import pytest
 from snapcraft import errors, models
 from snapcraft.parts import setup_assets as parts_setup_assets
 from snapcraft.parts.setup_assets import (
-    _create_hook_wrappers,
+    create_hook_wrappers,
     _ensure_hook,
     _ensure_hook_executable,
     _validate_command_chain,
@@ -653,7 +653,7 @@ def test_create_hook_wrappers(new_dir):
         hook.write_text("#!/bin/true\n")
         hook.chmod(0o644)
 
-    _create_hook_wrappers(new_dir)
+    create_hook_wrappers(new_dir)
 
     # verify prime/meta/hooks directory was created
     hooks_meta_dir = new_dir / "meta" / "hooks"

--- a/tests/unit/parts/test_setup_assets.py
+++ b/tests/unit/parts/test_setup_assets.py
@@ -25,11 +25,11 @@ import pytest
 from snapcraft import errors, models
 from snapcraft.parts import setup_assets as parts_setup_assets
 from snapcraft.parts.setup_assets import (
-    create_hook_wrappers,
     _ensure_hook,
     _ensure_hook_executable,
     _validate_command_chain,
     _write_hook_wrapper,
+    create_hook_wrappers,
     setup_assets,
 )
 

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -124,8 +124,7 @@ def test_write_metadata(default_project, fake_services, setup_project, new_dir):
 
     package_service.write_metadata(prime_dir)
 
-    assert (meta_dir / "snap.yaml").read_text() == dedent(
-        """\
+    assert (meta_dir / "snap.yaml").read_text() == dedent("""\
         name: default
         version: '1.0'
         summary: default project
@@ -139,8 +138,7 @@ def test_write_metadata(default_project, fake_services, setup_project, new_dir):
         environment:
           LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
-    """
-    )
+    """)
 
     assert not (prime_dir / "snap" / "manifest.yaml").exists()
 
@@ -420,8 +418,7 @@ def test_write_metadata_with_project_hooks(
 
     package_service.write_metadata(prime_dir)
 
-    assert (meta_dir / "snap.yaml").read_text() == dedent(
-        """\
+    assert (meta_dir / "snap.yaml").read_text() == dedent("""\
         name: default
         version: '1.0'
         summary: default project
@@ -435,8 +432,7 @@ def test_write_metadata_with_project_hooks(
         environment:
           LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
-    """
-    )
+    """)
 
     # Hooks are mediated to snap/hooks by the packaging flow, not copied by
     # write_metadata.
@@ -458,8 +454,7 @@ def test_write_metadata_with_built_hooks(
     package_service.write_metadata(prime_dir)
 
     meta_dir = prime_dir / "meta"
-    assert (meta_dir / "snap.yaml").read_text() == dedent(
-        """\
+    assert (meta_dir / "snap.yaml").read_text() == dedent("""\
         name: default
         version: '1.0'
         summary: default project
@@ -473,8 +468,7 @@ def test_write_metadata_with_built_hooks(
         environment:
           LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
-    """
-    )
+    """)
 
     # Built hooks are not hardlinked into meta/hooks by write_metadata; the
     # mediated packaging flow creates the meta/hooks wrappers.
@@ -499,8 +493,7 @@ def test_write_metadata_with_project_gui(
 
     package_service.write_metadata(prime_dir)
 
-    assert (meta_dir / "snap.yaml").read_text() == dedent(
-        """\
+    assert (meta_dir / "snap.yaml").read_text() == dedent("""\
         name: default
         version: '1.0'
         summary: default project
@@ -514,8 +507,7 @@ def test_write_metadata_with_project_gui(
         environment:
           LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
-    """
-    )
+    """)
 
     # GUI assets are mediated to meta/gui by the packaging flow, not copied by
     # write_metadata. The directory itself is created unconditionally.
@@ -644,16 +636,18 @@ def test_materialize_extra_assets_project_hooks_override_built_hooks(
     package_service._materialize_extra_assets(None)
 
     # Project hook overrides the built hook in snap/hooks
-    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "project_configure_hook"
-    assert oct((prime_dir / "snap" / "hooks" / "configure").stat().st_mode)[-3:] == "755"
+    assert (
+        prime_dir / "snap" / "hooks" / "configure"
+    ).read_text() == "project_configure_hook"
+    assert (
+        oct((prime_dir / "snap" / "hooks" / "configure").stat().st_mode)[-3:] == "755"
+    )
     # Wrapper points to the final hook in snap/hooks
     destination = prime_dir / "meta" / "hooks" / "configure"
-    assert destination.read_text() == dedent(
-        """\
+    assert destination.read_text() == dedent("""\
         #!/bin/sh
         exec "$SNAP/snap/hooks/configure" "$@"
-    """
-    )
+    """)
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
@@ -681,12 +675,10 @@ def test_materialize_extra_assets_creates_meta_hook_wrappers(
     assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "configure_hook"
     # Wrapper points to the final hook in snap/hooks
     wrapper = prime_dir / "meta" / "hooks" / "configure"
-    assert wrapper.read_text() == dedent(
-        """\
+    assert wrapper.read_text() == dedent("""\
         #!/bin/sh
         exec "$SNAP/snap/hooks/configure" "$@"
-    """
-    )
+    """)
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -538,11 +538,11 @@ def test_gen_extra_assets_with_project_hooks(
         [
             (
                 project_hooks_dir / "configure",
-                fake_services.lifecycle.prime_dir / "meta/hooks/configure",
+                fake_services.lifecycle.prime_dir / "snap/hooks/configure",
             ),
             (
                 project_hooks_dir / "install",
-                fake_services.lifecycle.prime_dir / "meta/hooks/install",
+                fake_services.lifecycle.prime_dir / "snap/hooks/install",
             ),
         ]
     )
@@ -576,7 +576,7 @@ def test_gen_extra_assets_project_hooks_override_built_hooks(
     assert package_service._gen_extra_assets() == [
         (
             project_hooks_dir / "configure",
-            fake_services.lifecycle.prime_dir / "meta/hooks/configure",
+            fake_services.lifecycle.prime_dir / "snap/hooks/configure",
         ),
     ]
 
@@ -643,14 +643,18 @@ def test_materialize_extra_assets_project_hooks_override_built_hooks(
 
     package_service._materialize_extra_assets(None)
 
-    # Built hook remains untouched in snap/hooks
-    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "built_configure_hook"
-    # Project hook placed in meta/hooks, overriding the built hook
+    # Project hook overrides the built hook in snap/hooks
+    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "project_configure_hook"
+    assert oct((prime_dir / "snap" / "hooks" / "configure").stat().st_mode)[-3:] == "755"
+    # Wrapper points to the final hook in snap/hooks
     destination = prime_dir / "meta" / "hooks" / "configure"
-    assert destination.read_text() == "project_configure_hook"
+    assert destination.read_text() == dedent(
+        """\
+        #!/bin/sh
+        exec "$SNAP/snap/hooks/configure" "$@"
+    """
+    )
     assert oct(destination.stat().st_mode)[-3:] == "755"
-    # No wrapper created since project hook exists
-    assert not destination.read_text().startswith("#!/bin/sh")
 
 
 def test_materialize_extra_assets_creates_meta_hook_wrappers(
@@ -673,11 +677,16 @@ def test_materialize_extra_assets_creates_meta_hook_wrappers(
 
     package_service._materialize_extra_assets(None)
 
-    # Built hook remains in snap/hooks
-    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "built_hook"
-    # Project hook placed in meta/hooks, taking priority
+    # Project hook overrides the built hook in snap/hooks
+    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "configure_hook"
+    # Wrapper points to the final hook in snap/hooks
     wrapper = prime_dir / "meta" / "hooks" / "configure"
-    assert wrapper.read_text() == "configure_hook"
+    assert wrapper.read_text() == dedent(
+        """\
+        #!/bin/sh
+        exec "$SNAP/snap/hooks/configure" "$@"
+    """
+    )
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -692,6 +692,7 @@ def test_needs_packing_project_hooks(
     # Bump the source mtime past the primed copy to account for coarse
     # filesystem timestamp granularity.
     for src, dest in package_service._gen_extra_assets(None):
+        assert isinstance(src, Path)
         os.utime(src, (dest.stat().st_mtime + 10, dest.stat().st_mtime + 10))
     assert package_service.needs_packing() is True
 
@@ -721,6 +722,7 @@ def test_needs_packing_project_gui(
     # Bump the source mtime past the primed copy to account for coarse
     # filesystem timestamp granularity.
     for src, dest in package_service._gen_extra_assets(None):
+        assert isinstance(src, Path)
         os.utime(src, (dest.stat().st_mtime + 10, dest.stat().st_mtime + 10))
     assert package_service.needs_packing() is True
 

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -538,11 +538,11 @@ def test_gen_extra_assets_with_project_hooks(
         [
             (
                 project_hooks_dir / "configure",
-                fake_services.lifecycle.prime_dir / "snap/hooks/configure",
+                fake_services.lifecycle.prime_dir / "meta/hooks/configure",
             ),
             (
                 project_hooks_dir / "install",
-                fake_services.lifecycle.prime_dir / "snap/hooks/install",
+                fake_services.lifecycle.prime_dir / "meta/hooks/install",
             ),
         ]
     )
@@ -576,7 +576,7 @@ def test_gen_extra_assets_project_hooks_override_built_hooks(
     assert package_service._gen_extra_assets() == [
         (
             project_hooks_dir / "configure",
-            fake_services.lifecycle.prime_dir / "snap/hooks/configure",
+            fake_services.lifecycle.prime_dir / "meta/hooks/configure",
         ),
     ]
 
@@ -643,9 +643,14 @@ def test_materialize_extra_assets_project_hooks_override_built_hooks(
 
     package_service._materialize_extra_assets(None)
 
-    destination = prime_dir / "snap" / "hooks" / "configure"
+    # Built hook remains untouched in snap/hooks
+    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "built_configure_hook"
+    # Project hook placed in meta/hooks, overriding the built hook
+    destination = prime_dir / "meta" / "hooks" / "configure"
     assert destination.read_text() == "project_configure_hook"
     assert oct(destination.stat().st_mode)[-3:] == "755"
+    # No wrapper created since project hook exists
+    assert not destination.read_text().startswith("#!/bin/sh")
 
 
 def test_materialize_extra_assets_creates_meta_hook_wrappers(
@@ -655,6 +660,12 @@ def test_materialize_extra_assets_creates_meta_hook_wrappers(
     package_service = cast(Package, fake_services.get("package"))
     prime_dir = fake_services.lifecycle.prime_dir
 
+    # Code-generated hook from part lifecycle
+    built_hooks_dir = prime_dir / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "configure").write_text("built_hook")
+
+    # Project hook that should take priority
     project_hooks_dir = package_service._get_assets_dir() / "hooks"
     project_hooks_dir.mkdir(parents=True)
     source = project_hooks_dir / "configure"
@@ -662,10 +673,11 @@ def test_materialize_extra_assets_creates_meta_hook_wrappers(
 
     package_service._materialize_extra_assets(None)
 
-    real_hook = prime_dir / "snap" / "hooks" / "configure"
+    # Built hook remains in snap/hooks
+    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "built_hook"
+    # Project hook placed in meta/hooks, taking priority
     wrapper = prime_dir / "meta" / "hooks" / "configure"
-    assert real_hook.read_text() == "configure_hook"
-    assert wrapper.read_text() == '#!/bin/sh\nexec "$SNAP/snap/hooks/configure" "$@"\n'
+    assert wrapper.read_text() == "configure_hook"
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -17,6 +17,7 @@
 """Tests for the Snapcraft Package service."""
 
 import datetime
+import os
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
@@ -437,13 +438,9 @@ def test_write_metadata_with_project_hooks(
     """
     )
 
-    assert (meta_dir / "hooks").exists()
-    # Ensure the hook is the one we provided in the project
-    # and not a wrapped hook.
-    assert (meta_dir / "hooks" / "configure").exists()
-    assert (meta_dir / "hooks" / "configure").read_text() == "configure_hook"
-    assert (meta_dir / "hooks" / "install").exists()
-    assert (meta_dir / "hooks" / "install").read_text() == "install_hook"
+    # Hooks are mediated to snap/hooks by the packaging flow, not copied by
+    # write_metadata.
+    assert not (meta_dir / "hooks").exists()
 
 
 def test_write_metadata_with_built_hooks(
@@ -479,13 +476,11 @@ def test_write_metadata_with_built_hooks(
     """
     )
 
-    assert (meta_dir / "hooks").exists()
-    # Ensure the hook is the one we provided in the project
-    # and not a wrapped hook.
-    assert (meta_dir / "hooks" / "configure").exists()
-    assert (meta_dir / "hooks" / "configure").read_text() == "configure_hook"
-    assert (meta_dir / "hooks" / "install").exists()
-    assert (meta_dir / "hooks" / "install").read_text() == "install_hook"
+    # Built hooks are not hardlinked into meta/hooks by write_metadata; the
+    # mediated packaging flow creates the meta/hooks wrappers.
+    assert not (meta_dir / "hooks").exists()
+    assert (built_hooks_dir / "configure").read_text() == "configure_hook"
+    assert (built_hooks_dir / "install").read_text() == "install_hook"
 
 
 def test_write_metadata_with_project_gui(
@@ -522,13 +517,214 @@ def test_write_metadata_with_project_gui(
     """
     )
 
-    assert (meta_dir / "gui").exists()
-    # Ensure the hook is the one we provided in the project
-    # and not a wrapped hook.
-    assert (meta_dir / "gui" / "default.default.desktop").exists()
-    assert (meta_dir / "gui" / "default.default.desktop").read_text() == "desktop_file"
-    assert (meta_dir / "gui" / "icon.png").exists()
-    assert (meta_dir / "gui" / "icon.png").read_text() == "package_png_icon"
+    # GUI assets are mediated to meta/gui by the packaging flow, not copied by
+    # write_metadata. The directory itself is created unconditionally.
+    assert (meta_dir / "gui").is_dir()
+    assert not (meta_dir / "gui" / "default.default.desktop").exists()
+    assert not (meta_dir / "gui" / "icon.png").exists()
+
+
+def test_gen_extra_assets_with_project_hooks(
+    default_project, fake_services, setup_project
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    project_hooks_dir = package_service._get_assets_dir() / "hooks"
+    project_hooks_dir.mkdir(parents=True)
+    (project_hooks_dir / "configure").write_text("configure_hook")
+    (project_hooks_dir / "install").write_text("install_hook")
+
+    assert sorted(package_service._gen_extra_assets()) == sorted(
+        [
+            (
+                project_hooks_dir / "configure",
+                fake_services.lifecycle.prime_dir / "snap/hooks/configure",
+            ),
+            (
+                project_hooks_dir / "install",
+                fake_services.lifecycle.prime_dir / "snap/hooks/install",
+            ),
+        ]
+    )
+
+
+def test_gen_extra_assets_with_built_hooks(
+    default_project, fake_services, setup_project, tmp_path
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    built_hooks_dir = tmp_path / "prime" / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "configure").write_text("configure_hook")
+    (built_hooks_dir / "install").write_text("install_hook")
+
+    assert package_service._gen_extra_assets() == []
+
+
+def test_gen_extra_assets_project_hooks_override_built_hooks(
+    default_project, fake_services, setup_project, tmp_path
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    project_hooks_dir = package_service._get_assets_dir() / "hooks"
+    project_hooks_dir.mkdir(parents=True)
+    built_hooks_dir = tmp_path / "prime" / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "configure").write_text("built_configure_hook")
+    (project_hooks_dir / "configure").write_text("project_configure_hook")
+
+    assert package_service._gen_extra_assets() == [
+        (
+            project_hooks_dir / "configure",
+            fake_services.lifecycle.prime_dir / "snap/hooks/configure",
+        ),
+    ]
+
+
+def test_gen_extra_assets_with_project_gui(
+    default_project, fake_services, setup_project
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    project_gui_dir = package_service._get_assets_dir() / "gui"
+    project_gui_dir.mkdir(parents=True)
+    (project_gui_dir / "default.default.desktop").write_text("desktop_file")
+    (project_gui_dir / "icon.png").write_text("package_png_icon")
+
+    assert sorted(package_service._gen_extra_assets()) == sorted(
+        [
+            (
+                project_gui_dir / "default.default.desktop",
+                fake_services.lifecycle.prime_dir / "meta/gui/default.default.desktop",
+            ),
+            (
+                project_gui_dir / "icon.png",
+                fake_services.lifecycle.prime_dir / "meta/gui/icon.png",
+            ),
+        ]
+    )
+
+
+def test_write_asset_preserves_hook_executable(
+    default_project, fake_services, setup_project
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    project_hooks_dir = package_service._get_assets_dir() / "hooks"
+    project_hooks_dir.mkdir(parents=True)
+    source = project_hooks_dir / "configure"
+    source.write_text("configure_hook")
+    source.chmod(0o644)
+    destination = fake_services.lifecycle.prime_dir / "snap" / "hooks" / "configure"
+
+    package_service._write_asset(source, destination)
+
+    assert destination.read_text() == "configure_hook"
+    assert oct(destination.stat().st_mode)[-3:] == "755"
+    assert oct(source.stat().st_mode)[-3:] == "644"
+
+
+def test_materialize_extra_assets_project_hooks_override_built_hooks(
+    default_project, fake_services, setup_project
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    prime_dir = fake_services.lifecycle.prime_dir
+
+    built_hooks_dir = prime_dir / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "configure").write_text("built_configure_hook")
+
+    project_hooks_dir = package_service._get_assets_dir() / "hooks"
+    project_hooks_dir.mkdir(parents=True)
+    source = project_hooks_dir / "configure"
+    source.write_text("project_configure_hook")
+    source.chmod(0o644)
+
+    package_service._materialize_extra_assets(None)
+
+    destination = prime_dir / "snap" / "hooks" / "configure"
+    assert destination.read_text() == "project_configure_hook"
+    assert oct(destination.stat().st_mode)[-3:] == "755"
+
+
+def test_materialize_extra_assets_creates_meta_hook_wrappers(
+    default_project, fake_services, setup_project
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    prime_dir = fake_services.lifecycle.prime_dir
+
+    project_hooks_dir = package_service._get_assets_dir() / "hooks"
+    project_hooks_dir.mkdir(parents=True)
+    source = project_hooks_dir / "configure"
+    source.write_text("configure_hook")
+
+    package_service._materialize_extra_assets(None)
+
+    real_hook = prime_dir / "snap" / "hooks" / "configure"
+    wrapper = prime_dir / "meta" / "hooks" / "configure"
+    assert real_hook.read_text() == "configure_hook"
+    assert wrapper.read_text() == '#!/bin/sh\nexec "$SNAP/snap/hooks/configure" "$@"\n'
+    assert oct(wrapper.stat().st_mode)[-3:] == "755"
+
+
+def test_needs_packing_project_hooks(
+    default_project, fake_services, setup_project, new_dir, mocker
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    # Force the asset checks to be the deciding factor in needs_packing.
+    mocker.patch.dict(package_service._app.__dict__, {"always_repack": False})
+    package_service._project_was_updated = False
+
+    project_hooks_dir = package_service._get_assets_dir() / "hooks"
+    project_hooks_dir.mkdir(parents=True)
+    source = project_hooks_dir / "configure"
+    source.write_text("configure_hook")
+
+    package_service._materialize_package_files(None)
+    package_service._materialize_extra_assets(None)
+    package_service.get_artifacts()[None].touch()
+
+    assert package_service.needs_packing() is False
+
+    # Modifying the project hook makes the primed hook stale.
+    source.write_text("modified_hook")
+    # Bump the source mtime past the primed copy to account for coarse
+    # filesystem timestamp granularity.
+    for src, dest in package_service._gen_extra_assets(None):
+        os.utime(src, (dest.stat().st_mtime + 10, dest.stat().st_mtime + 10))
+    assert package_service.needs_packing() is True
+
+
+def test_needs_packing_project_gui(
+    default_project, fake_services, setup_project, new_dir, mocker
+):
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast(Package, fake_services.get("package"))
+    # Force the asset checks to be the deciding factor in needs_packing.
+    mocker.patch.dict(package_service._app.__dict__, {"always_repack": False})
+    package_service._project_was_updated = False
+
+    project_gui_dir = package_service._get_assets_dir() / "gui"
+    project_gui_dir.mkdir(parents=True)
+    source = project_gui_dir / "icon.png"
+    source.write_text("icon_data")
+
+    package_service._materialize_package_files(None)
+    package_service._materialize_extra_assets(None)
+    package_service.get_artifacts()[None].touch()
+
+    assert package_service.needs_packing() is False
+
+    # Modifying the project icon makes the primed icon stale.
+    source.write_text("modified_icon_data")
+    # Bump the source mtime past the primed copy to account for coarse
+    # filesystem timestamp granularity.
+    for src, dest in package_service._gen_extra_assets(None):
+        os.utime(src, (dest.stat().st_mtime + 10, dest.stat().st_mtime + 10))
+    assert package_service.needs_packing() is True
 
 
 def test_update_project_parse_info(

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -470,8 +470,8 @@ def test_write_metadata_with_built_hooks(
           PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
     """)
 
-    # Built hooks are not hardlinked into meta/hooks by write_metadata; the
-    # mediated packaging flow creates the meta/hooks wrappers.
+    # Built hooks are not copied into meta/hooks by write_metadata; the
+    # mediated packaging flow provisions meta/hooks during asset materialization.
     assert not (meta_dir / "hooks").exists()
     assert (built_hooks_dir / "configure").read_text() == "configure_hook"
     assert (built_hooks_dir / "install").read_text() == "install_hook"
@@ -639,13 +639,13 @@ def test_materialize_extra_assets_project_hooks_override_built_hooks(
     assert (
         prime_dir / "snap" / "hooks" / "configure"
     ).read_text() == "built_configure_hook"
-    # Project hook in meta/hooks overrides the built hook wrapper
+    # Project hook in meta/hooks overrides the built hook provision
     destination = prime_dir / "meta" / "hooks" / "configure"
     assert destination.read_text() == "project_configure_hook"
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
-def test_materialize_extra_assets_creates_meta_hook_wrappers(
+def test_materialize_extra_assets_provisions_meta_hooks(
     default_project, fake_services, setup_project
 ):
     setup_project(fake_services, default_project.marshal(), write_project=True)
@@ -657,20 +657,14 @@ def test_materialize_extra_assets_creates_meta_hook_wrappers(
     built_hooks_dir.mkdir(parents=True)
     (built_hooks_dir / "configure").write_text("built_hook")
 
-    # Project hook that should take priority
-    project_hooks_dir = package_service._get_assets_dir() / "hooks"
-    project_hooks_dir.mkdir(parents=True)
-    source = project_hooks_dir / "configure"
-    source.write_text("configure_hook")
-
     package_service._materialize_extra_assets(None)
 
     # Built hook remains in snap/hooks
     assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "built_hook"
-    # Project hook placed in meta/hooks, taking priority
-    wrapper = prime_dir / "meta" / "hooks" / "configure"
-    assert wrapper.read_text() == "configure_hook"
-    assert oct(wrapper.stat().st_mode)[-3:] == "755"
+    # Built hook is provisioned directly into meta/hooks
+    provisioned_hook = prime_dir / "meta" / "hooks" / "configure"
+    assert provisioned_hook.read_text() == "built_hook"
+    assert oct(provisioned_hook.stat().st_mode)[-3:] == "755"
 
 
 def test_needs_packing_project_hooks(

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -530,11 +530,11 @@ def test_gen_extra_assets_with_project_hooks(
         [
             (
                 project_hooks_dir / "configure",
-                fake_services.lifecycle.prime_dir / "snap/hooks/configure",
+                fake_services.lifecycle.prime_dir / "meta/hooks/configure",
             ),
             (
                 project_hooks_dir / "install",
-                fake_services.lifecycle.prime_dir / "snap/hooks/install",
+                fake_services.lifecycle.prime_dir / "meta/hooks/install",
             ),
         ]
     )
@@ -568,7 +568,7 @@ def test_gen_extra_assets_project_hooks_override_built_hooks(
     assert package_service._gen_extra_assets() == [
         (
             project_hooks_dir / "configure",
-            fake_services.lifecycle.prime_dir / "snap/hooks/configure",
+            fake_services.lifecycle.prime_dir / "meta/hooks/configure",
         ),
     ]
 
@@ -635,19 +635,13 @@ def test_materialize_extra_assets_project_hooks_override_built_hooks(
 
     package_service._materialize_extra_assets(None)
 
-    # Project hook overrides the built hook in snap/hooks
+    # Built hook remains untouched in snap/hooks
     assert (
         prime_dir / "snap" / "hooks" / "configure"
-    ).read_text() == "project_configure_hook"
-    assert (
-        oct((prime_dir / "snap" / "hooks" / "configure").stat().st_mode)[-3:] == "755"
-    )
-    # Wrapper points to the final hook in snap/hooks
+    ).read_text() == "built_configure_hook"
+    # Project hook in meta/hooks overrides the built hook wrapper
     destination = prime_dir / "meta" / "hooks" / "configure"
-    assert destination.read_text() == dedent("""\
-        #!/bin/sh
-        exec "$SNAP/snap/hooks/configure" "$@"
-    """)
+    assert destination.read_text() == "project_configure_hook"
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
@@ -671,14 +665,11 @@ def test_materialize_extra_assets_creates_meta_hook_wrappers(
 
     package_service._materialize_extra_assets(None)
 
-    # Project hook overrides the built hook in snap/hooks
-    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "configure_hook"
-    # Wrapper points to the final hook in snap/hooks
+    # Built hook remains in snap/hooks
+    assert (prime_dir / "snap" / "hooks" / "configure").read_text() == "built_hook"
+    # Project hook placed in meta/hooks, taking priority
     wrapper = prime_dir / "meta" / "hooks" / "configure"
-    assert wrapper.read_text() == dedent("""\
-        #!/bin/sh
-        exec "$SNAP/snap/hooks/configure" "$@"
-    """)
+    assert wrapper.read_text() == "configure_hook"
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -371,7 +371,7 @@ def test_gen_extra_assets_for_component_hooks(
         (
             component_assets_dir / "install",
             fake_services.get("lifecycle").get_prime_dir("firstcomponent")
-            / "snap/hooks/install",
+            / "meta/hooks/install",
         ),
     ]
 
@@ -401,20 +401,13 @@ def test_materialize_extra_assets_component_hooks_override_built_hooks(
 
     package_service._materialize_extra_assets("firstcomponent")
 
-    # Project hook overrides the built hook in snap/hooks
+    # Built hook remains untouched in snap/hooks
     assert (
         component_prime_dir / "snap" / "hooks" / "install"
-    ).read_text() == "project_install_hook"
-    assert (
-        oct((component_prime_dir / "snap" / "hooks" / "install").stat().st_mode)[-3:]
-        == "755"
-    )
-    # Wrapper points to the final hook in snap/hooks
+    ).read_text() == "built_install_hook"
+    # Project hook in meta/hooks overrides the built hook wrapper
     destination = component_prime_dir / "meta" / "hooks" / "install"
-    assert destination.read_text() == dedent("""\
-        #!/bin/sh
-        exec "$SNAP/snap/hooks/install" "$@"
-    """)
+    assert destination.read_text() == "project_install_hook"
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
@@ -443,16 +436,13 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
 
     package_service._materialize_extra_assets("firstcomponent")
 
-    # Project hook overrides the built hook in snap/hooks
+    # Built hook remains in snap/hooks
     assert (
         component_prime_dir / "snap" / "hooks" / "install"
-    ).read_text() == "install_hook"
-    # Wrapper points to the final hook in snap/hooks
+    ).read_text() == "built_hook"
+    # Project hook placed in meta/hooks, taking priority
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == dedent("""\
-        #!/bin/sh
-        exec "$SNAP/snap/hooks/install" "$@"
-    """)
+    assert wrapper.read_text() == "install_hook"
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 
@@ -481,16 +471,13 @@ def test_materialize_extra_assets_component_accepts_qualified_partition_name(
 
     package_service._materialize_extra_assets("component/firstcomponent")
 
-    # Project hook overrides the built hook in snap/hooks
+    # Built hook remains in snap/hooks
     assert (
         component_prime_dir / "snap" / "hooks" / "install"
-    ).read_text() == "install_hook"
-    # Wrapper points to the final hook in snap/hooks
+    ).read_text() == "built_hook"
+    # Project hook placed in meta/hooks, taking priority
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == dedent("""\
-        #!/bin/sh
-        exec "$SNAP/snap/hooks/install" "$@"
-    """)
+    assert wrapper.read_text() == "install_hook"
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
@@ -517,6 +504,6 @@ def test_gen_extra_assets_component_hooks_override_built_hooks(
     assert package_service._gen_extra_assets("firstcomponent") == [
         (
             component_assets_dir / "install",
-            lifecycle_service.get_prime_dir("firstcomponent") / "snap/hooks/install",
+            lifecycle_service.get_prime_dir("firstcomponent") / "meta/hooks/install",
         ),
     ]

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -355,3 +355,111 @@ def test_write_metadata(
         description: lorem ipsum
     """
     )
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_gen_extra_assets_for_component_hooks(
+    default_project,
+    fake_services,
+    setup_project,
+):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    component_assets_dir = (
+        package_service._get_assets_dir() / "component/firstcomponent/hooks"
+    )
+    component_assets_dir.mkdir(parents=True)
+    (component_assets_dir / "install").write_text("install_hook")
+
+    assert package_service._gen_extra_assets("firstcomponent") == [
+        (
+            component_assets_dir / "install",
+            fake_services.get("lifecycle").get_prime_dir("firstcomponent")
+            / "snap/hooks/install",
+        ),
+    ]
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_materialize_extra_assets_component_hooks_override_built_hooks(
+    default_project,
+    fake_services,
+    setup_project,
+):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    lifecycle_service = fake_services.get("lifecycle")
+    component_prime_dir = lifecycle_service.get_prime_dir("firstcomponent")
+
+    built_hooks_dir = component_prime_dir / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "install").write_text("built_install_hook")
+
+    component_assets_dir = (
+        package_service._get_assets_dir() / "component/firstcomponent/hooks"
+    )
+    component_assets_dir.mkdir(parents=True)
+    source = component_assets_dir / "install"
+    source.write_text("project_install_hook")
+    source.chmod(0o644)
+
+    package_service._materialize_extra_assets("firstcomponent")
+
+    destination = component_prime_dir / "snap" / "hooks" / "install"
+    assert destination.read_text() == "project_install_hook"
+    assert oct(destination.stat().st_mode)[-3:] == "755"
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
+    default_project,
+    fake_services,
+    setup_project,
+):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    lifecycle_service = fake_services.get("lifecycle")
+    component_prime_dir = lifecycle_service.get_prime_dir("firstcomponent")
+
+    component_assets_dir = (
+        package_service._get_assets_dir() / "component/firstcomponent/hooks"
+    )
+    component_assets_dir.mkdir(parents=True)
+    (component_assets_dir / "install").write_text("install_hook")
+
+    package_service._materialize_extra_assets("firstcomponent")
+
+    real_hook = component_prime_dir / "snap" / "hooks" / "install"
+    wrapper = component_prime_dir / "meta" / "hooks" / "install"
+    assert real_hook.read_text() == "install_hook"
+    assert wrapper.read_text() == '#!/bin/sh\nexec "$SNAP/snap/hooks/install" "$@"\n'
+    assert oct(wrapper.stat().st_mode)[-3:] == "755"
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_gen_extra_assets_component_hooks_override_built_hooks(
+    default_project,
+    fake_services,
+    setup_project,
+):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    lifecycle_service = fake_services.get("lifecycle")
+    built_hooks_dir = (
+        lifecycle_service.get_prime_dir("firstcomponent") / "snap" / "hooks"
+    )
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "install").write_text("built_install_hook")
+
+    component_assets_dir = (
+        package_service._get_assets_dir() / "component/firstcomponent/hooks"
+    )
+    component_assets_dir.mkdir(parents=True)
+    (component_assets_dir / "install").write_text("project_install_hook")
+
+    assert package_service._gen_extra_assets("firstcomponent") == [
+        (
+            component_assets_dir / "install",
+            lifecycle_service.get_prime_dir("firstcomponent") / "snap/hooks/install",
+        ),
+    ]

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -204,15 +204,13 @@ def test_get_component_yaml(default_project, fake_services, setup_project):
     setup_project(fake_services, default_project.marshal())
     package_service = fake_services.get("package")
 
-    expected = dedent(
-        """\
+    expected = dedent("""\
         component: default+firstcomponent
         type: test
         version: '1.0'
         summary: first component
         description: lorem ipsum
-        """
-    )
+        """)
 
     # Bare component name is the artifact key from get_artifacts() and the form
     # passed through the mediation pipeline.
@@ -290,8 +288,7 @@ def test_write_metadata(
 
     package_service.write_metadata(prime_dir)
 
-    assert (meta_dir / "snap.yaml").read_text() == dedent(
-        """\
+    assert (meta_dir / "snap.yaml").read_text() == dedent("""\
         name: default
         version: '1.0'
         summary: default project
@@ -329,8 +326,7 @@ def test_write_metadata(
             summary: second component
             description: lorem ipsum
             type: test
-    """
-    )
+    """)
 
     assert (
         lifecycle_service.get_prime_dir("firstcomponent") / "meta" / "component.yaml"
@@ -406,16 +402,19 @@ def test_materialize_extra_assets_component_hooks_override_built_hooks(
     package_service._materialize_extra_assets("firstcomponent")
 
     # Project hook overrides the built hook in snap/hooks
-    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "project_install_hook"
-    assert oct((component_prime_dir / "snap" / "hooks" / "install").stat().st_mode)[-3:] == "755"
+    assert (
+        component_prime_dir / "snap" / "hooks" / "install"
+    ).read_text() == "project_install_hook"
+    assert (
+        oct((component_prime_dir / "snap" / "hooks" / "install").stat().st_mode)[-3:]
+        == "755"
+    )
     # Wrapper points to the final hook in snap/hooks
     destination = component_prime_dir / "meta" / "hooks" / "install"
-    assert destination.read_text() == dedent(
-        """\
+    assert destination.read_text() == dedent("""\
         #!/bin/sh
         exec "$SNAP/snap/hooks/install" "$@"
-    """
-    )
+    """)
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
@@ -445,15 +444,15 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
     package_service._materialize_extra_assets("firstcomponent")
 
     # Project hook overrides the built hook in snap/hooks
-    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "install_hook"
+    assert (
+        component_prime_dir / "snap" / "hooks" / "install"
+    ).read_text() == "install_hook"
     # Wrapper points to the final hook in snap/hooks
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == dedent(
-        """\
+    assert wrapper.read_text() == dedent("""\
         #!/bin/sh
         exec "$SNAP/snap/hooks/install" "$@"
-    """
-    )
+    """)
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 
@@ -483,15 +482,15 @@ def test_materialize_extra_assets_component_accepts_qualified_partition_name(
     package_service._materialize_extra_assets("component/firstcomponent")
 
     # Project hook overrides the built hook in snap/hooks
-    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "install_hook"
+    assert (
+        component_prime_dir / "snap" / "hooks" / "install"
+    ).read_text() == "install_hook"
     # Wrapper points to the final hook in snap/hooks
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == dedent(
-        """\
+    assert wrapper.read_text() == dedent("""\
         #!/bin/sh
         exec "$SNAP/snap/hooks/install" "$@"
-    """
-    )
+    """)
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -405,14 +405,14 @@ def test_materialize_extra_assets_component_hooks_override_built_hooks(
     assert (
         component_prime_dir / "snap" / "hooks" / "install"
     ).read_text() == "built_install_hook"
-    # Project hook in meta/hooks overrides the built hook wrapper
+    # Project hook in meta/hooks overrides the built hook provision
     destination = component_prime_dir / "meta" / "hooks" / "install"
     assert destination.read_text() == "project_install_hook"
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
-def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
+def test_materialize_extra_assets_component_provisions_meta_hooks(
     default_project,
     fake_services,
     setup_project,
@@ -427,23 +427,16 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
     built_hooks_dir.mkdir(parents=True)
     (built_hooks_dir / "install").write_text("built_hook")
 
-    # Project hook that should take priority
-    component_assets_dir = (
-        package_service._get_assets_dir() / "component/firstcomponent/hooks"
-    )
-    component_assets_dir.mkdir(parents=True)
-    (component_assets_dir / "install").write_text("install_hook")
-
     package_service._materialize_extra_assets("firstcomponent")
 
     # Built hook remains in snap/hooks
     assert (
         component_prime_dir / "snap" / "hooks" / "install"
     ).read_text() == "built_hook"
-    # Project hook placed in meta/hooks, taking priority
-    wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == "install_hook"
-    assert oct(wrapper.stat().st_mode)[-3:] == "755"
+    # Built hook is provisioned directly into meta/hooks
+    provisioned_hook = component_prime_dir / "meta" / "hooks" / "install"
+    assert provisioned_hook.read_text() == "built_hook"
+    assert oct(provisioned_hook.stat().st_mode)[-3:] == "755"
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
@@ -462,22 +455,15 @@ def test_materialize_extra_assets_component_accepts_qualified_partition_name(
     built_hooks_dir.mkdir(parents=True)
     (built_hooks_dir / "install").write_text("built_hook")
 
-    # Project hook that should take priority
-    component_assets_dir = (
-        package_service._get_assets_dir() / "component/firstcomponent/hooks"
-    )
-    component_assets_dir.mkdir(parents=True)
-    (component_assets_dir / "install").write_text("install_hook")
-
     package_service._materialize_extra_assets("component/firstcomponent")
 
     # Built hook remains in snap/hooks
     assert (
         component_prime_dir / "snap" / "hooks" / "install"
     ).read_text() == "built_hook"
-    # Project hook placed in meta/hooks, taking priority
-    wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == "install_hook"
+    # Built hook is provisioned directly into meta/hooks
+    provisioned_hook = component_prime_dir / "meta" / "hooks" / "install"
+    assert provisioned_hook.read_text() == "built_hook"
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -437,6 +437,31 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
+def test_materialize_extra_assets_component_accepts_qualified_partition_name(
+    default_project,
+    fake_services,
+    setup_project,
+):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    lifecycle_service = fake_services.get("lifecycle")
+    component_prime_dir = lifecycle_service.get_prime_dir("firstcomponent")
+
+    component_assets_dir = (
+        package_service._get_assets_dir() / "component/firstcomponent/hooks"
+    )
+    component_assets_dir.mkdir(parents=True)
+    (component_assets_dir / "install").write_text("install_hook")
+
+    package_service._materialize_extra_assets("component/firstcomponent")
+
+    real_hook = component_prime_dir / "snap" / "hooks" / "install"
+    wrapper = component_prime_dir / "meta" / "hooks" / "install"
+    assert real_hook.read_text() == "install_hook"
+    assert wrapper.read_text() == '#!/bin/sh\nexec "$SNAP/snap/hooks/install" "$@"\n'
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
 def test_gen_extra_assets_component_hooks_override_built_hooks(
     default_project,
     fake_services,

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -375,7 +375,7 @@ def test_gen_extra_assets_for_component_hooks(
         (
             component_assets_dir / "install",
             fake_services.get("lifecycle").get_prime_dir("firstcomponent")
-            / "snap/hooks/install",
+            / "meta/hooks/install",
         ),
     ]
 
@@ -405,7 +405,10 @@ def test_materialize_extra_assets_component_hooks_override_built_hooks(
 
     package_service._materialize_extra_assets("firstcomponent")
 
-    destination = component_prime_dir / "snap" / "hooks" / "install"
+    # Built hook remains untouched in snap/hooks
+    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "built_install_hook"
+    # Project hook placed in meta/hooks, overriding the built hook
+    destination = component_prime_dir / "meta" / "hooks" / "install"
     assert destination.read_text() == "project_install_hook"
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
@@ -421,6 +424,12 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
     lifecycle_service = fake_services.get("lifecycle")
     component_prime_dir = lifecycle_service.get_prime_dir("firstcomponent")
 
+    # Code-generated hook from part lifecycle
+    built_hooks_dir = component_prime_dir / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "install").write_text("built_hook")
+
+    # Project hook that should take priority
     component_assets_dir = (
         package_service._get_assets_dir() / "component/firstcomponent/hooks"
     )
@@ -429,10 +438,11 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
 
     package_service._materialize_extra_assets("firstcomponent")
 
-    real_hook = component_prime_dir / "snap" / "hooks" / "install"
+    # Built hook remains in snap/hooks
+    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "built_hook"
+    # Project hook placed in meta/hooks, taking priority
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert real_hook.read_text() == "install_hook"
-    assert wrapper.read_text() == '#!/bin/sh\nexec "$SNAP/snap/hooks/install" "$@"\n'
+    assert wrapper.read_text() == "install_hook"
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 
@@ -447,6 +457,12 @@ def test_materialize_extra_assets_component_accepts_qualified_partition_name(
     lifecycle_service = fake_services.get("lifecycle")
     component_prime_dir = lifecycle_service.get_prime_dir("firstcomponent")
 
+    # Code-generated hook from part lifecycle
+    built_hooks_dir = component_prime_dir / "snap" / "hooks"
+    built_hooks_dir.mkdir(parents=True)
+    (built_hooks_dir / "install").write_text("built_hook")
+
+    # Project hook that should take priority
     component_assets_dir = (
         package_service._get_assets_dir() / "component/firstcomponent/hooks"
     )
@@ -455,10 +471,11 @@ def test_materialize_extra_assets_component_accepts_qualified_partition_name(
 
     package_service._materialize_extra_assets("component/firstcomponent")
 
-    real_hook = component_prime_dir / "snap" / "hooks" / "install"
+    # Built hook remains in snap/hooks
+    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "built_hook"
+    # Project hook placed in meta/hooks, taking priority
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert real_hook.read_text() == "install_hook"
-    assert wrapper.read_text() == '#!/bin/sh\nexec "$SNAP/snap/hooks/install" "$@"\n'
+    assert wrapper.read_text() == "install_hook"
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
@@ -485,6 +502,6 @@ def test_gen_extra_assets_component_hooks_override_built_hooks(
     assert package_service._gen_extra_assets("firstcomponent") == [
         (
             component_assets_dir / "install",
-            lifecycle_service.get_prime_dir("firstcomponent") / "snap/hooks/install",
+            lifecycle_service.get_prime_dir("firstcomponent") / "meta/hooks/install",
         ),
     ]

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -375,7 +375,7 @@ def test_gen_extra_assets_for_component_hooks(
         (
             component_assets_dir / "install",
             fake_services.get("lifecycle").get_prime_dir("firstcomponent")
-            / "meta/hooks/install",
+            / "snap/hooks/install",
         ),
     ]
 
@@ -405,11 +405,17 @@ def test_materialize_extra_assets_component_hooks_override_built_hooks(
 
     package_service._materialize_extra_assets("firstcomponent")
 
-    # Built hook remains untouched in snap/hooks
-    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "built_install_hook"
-    # Project hook placed in meta/hooks, overriding the built hook
+    # Project hook overrides the built hook in snap/hooks
+    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "project_install_hook"
+    assert oct((component_prime_dir / "snap" / "hooks" / "install").stat().st_mode)[-3:] == "755"
+    # Wrapper points to the final hook in snap/hooks
     destination = component_prime_dir / "meta" / "hooks" / "install"
-    assert destination.read_text() == "project_install_hook"
+    assert destination.read_text() == dedent(
+        """\
+        #!/bin/sh
+        exec "$SNAP/snap/hooks/install" "$@"
+    """
+    )
     assert oct(destination.stat().st_mode)[-3:] == "755"
 
 
@@ -438,11 +444,16 @@ def test_materialize_extra_assets_component_creates_meta_hook_wrappers(
 
     package_service._materialize_extra_assets("firstcomponent")
 
-    # Built hook remains in snap/hooks
-    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "built_hook"
-    # Project hook placed in meta/hooks, taking priority
+    # Project hook overrides the built hook in snap/hooks
+    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "install_hook"
+    # Wrapper points to the final hook in snap/hooks
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == "install_hook"
+    assert wrapper.read_text() == dedent(
+        """\
+        #!/bin/sh
+        exec "$SNAP/snap/hooks/install" "$@"
+    """
+    )
     assert oct(wrapper.stat().st_mode)[-3:] == "755"
 
 
@@ -471,11 +482,16 @@ def test_materialize_extra_assets_component_accepts_qualified_partition_name(
 
     package_service._materialize_extra_assets("component/firstcomponent")
 
-    # Built hook remains in snap/hooks
-    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "built_hook"
-    # Project hook placed in meta/hooks, taking priority
+    # Project hook overrides the built hook in snap/hooks
+    assert (component_prime_dir / "snap" / "hooks" / "install").read_text() == "install_hook"
+    # Wrapper points to the final hook in snap/hooks
     wrapper = component_prime_dir / "meta" / "hooks" / "install"
-    assert wrapper.read_text() == "install_hook"
+    assert wrapper.read_text() == dedent(
+        """\
+        #!/bin/sh
+        exec "$SNAP/snap/hooks/install" "$@"
+    """
+    )
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
@@ -502,6 +518,6 @@ def test_gen_extra_assets_component_hooks_override_built_hooks(
     assert package_service._gen_extra_assets("firstcomponent") == [
         (
             component_assets_dir / "install",
-            lifecycle_service.get_prime_dir("firstcomponent") / "meta/hooks/install",
+            lifecycle_service.get_prime_dir("firstcomponent") / "snap/hooks/install",
         ),
     ]


### PR DESCRIPTION
Implement the Craft Application metadata mediation API when copying
hooks and GUI assets to the snap artifact.

---
CRAFT-1374

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
