### PR TITLE
docs: fix version in Snapcraft 7

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,12 +26,7 @@ project = "Snapcraft"
 author = "Canonical Group Ltd"
 
 # Version string in sidebar
-if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
-    # Because of Autotools, we can safely assume the version starts with `n.n`
-    major, minor, *_ = snapcraft.__version__.split(".")
-    release = f"{major}.{minor}"
-else:  # Branch build
-    release = os.environ.get("READTHEDOCS_VERSION", "latest")
+release = "7.5"
 
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,12 +15,10 @@
 #
 
 import datetime
-import os
 import pathlib
 import sys
 
 import craft_parts_docs
-import snapcraft
 
 project = "Snapcraft"
 author = "Canonical Group Ltd"


### PR DESCRIPTION
Mimics the fix from https://github.com/canonical/snapcraft/pull/6387. Since the Snapcraft 7 docs are a docs-only branch and `snapcraft.__version__` doesn't match up, the `release` is hard-coded instead.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
