### PR TITLE
docs: fix version in Snapcraft 8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,13 +26,10 @@ import snapcraft
 
 project = "Snapcraft"
 author = "Canonical Group Ltd"
-# The full version, including alpha/beta/rc tags
-release = snapcraft.__version__
-if ".post" in release:
-    release = "dev"
-else:
-    major, minor, *_ = release.split(".")
-    release = f"{major}.{minor}"
+
+# Version string in sidebar
+major, minor, *_ = snapcraft.__version__.split(".")
+release = "dev" if os.environ.get("READTHEDOCS_VERSION") == "latest" else f"{major}.{minor}"
 
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)
 


### PR DESCRIPTION
With this change, all local, PR, and branch builds will show the major and minor version in the docs title. The only exception is the 'latest' branch build, which will show 'dev' as the version.

This change was brought about by the simplification of our RTD version slugs.

You can check the PR branch versioning at https://canonical-snapcraft--6387.com.readthedocs.build/6387/.

You can check branch versioning on [the private RTD branch I created](https://ubuntu.com/docs/snapcraft/test/).Describe your changes.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
