### PR TITLE
ci: fix zizmor warnings

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -13,10 +13,11 @@ jobs:
       contents: write
     steps:
       - name: Create a Prerelease
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          # Generate release notes on the new GH release
-          generate_release_notes: true
-          # Mark this new release as a pre-release, to be marked manually
-          # as the latest stable release later.
-          prerelease: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --generate-notes \
+            --prerelease

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -13,4 +13,5 @@ jobs:
     uses: canonical/starflow/.github/workflows/tics.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
     with:
       project: "snapcraft"
-    secrets: inherit
+    secrets:
+      TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}


### PR DESCRIPTION
Fixes zizmor warnings from https://github.com/canonical/snapcraft/pull/6391.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
