### PR TITLE
feat: support armv8l

### DIFF
--- a/snapcraft/elf/elf_utils.py
+++ b/snapcraft/elf/elf_utils.py
@@ -106,6 +106,8 @@ _ARCH_CONFIG = {
     "x86_64": _ArchConfig("x86_64-linux-gnu", "lib64/ld-linux-x86-64.so.2"),
     "i686": _ArchConfig("i386-linux-gnu", "lib/ld-linux.so.2"),
 }
+# armv8l indicates a 64-bit armv8 system running a 32-bit compatible armhf environment.
+_ARCH_CONFIG["armv8l"] = _ARCH_CONFIG["armv7l"]
 
 
 def get_dynamic_linker(*, root_path: Path, snap_path: Path) -> str:
@@ -151,4 +153,9 @@ def get_arch_triplet(arch: str | None = None) -> str:
 
 def get_all_arch_triplets() -> list[str]:
     """Get a list of all architecture triplets."""
-    return [architecture.arch_triplet for architecture in _ARCH_CONFIG.values()]
+    # Deduplicate because multiple architectures may map to the same arch triplet.
+    return list(
+        dict.fromkeys(
+            architecture.arch_triplet for architecture in _ARCH_CONFIG.values()
+        )
+    )

--- a/snapcraft/parts/plugins/conda_plugin.py
+++ b/snapcraft/parts/plugins/conda_plugin.py
@@ -32,7 +32,11 @@ _MINICONDA_ARCH_FROM_SNAP_ARCH = {
     "armhf": "armv7l",
     "ppc64el": "ppc64le",
 }
-_MINICONDA_ARCH_FROM_PLATFORM = {"x86_64": {"32bit": "x86", "64bit": "x86_64"}}
+_MINICONDA_ARCH_FROM_PLATFORM = {
+    "x86_64": {"32bit": "x86", "64bit": "x86_64"},
+    # armv8l indicates a 64-bit armv8 system running a 32-bit compatible armhf environment.
+    "armv8l": {"32bit": "armv7l"},
+}
 
 
 def _get_architecture() -> str:
@@ -49,7 +53,12 @@ def _get_architecture() -> str:
     else:
         machine = platform.machine()
         architecture = platform.architecture()[0]
-        miniconda_arch = _MINICONDA_ARCH_FROM_PLATFORM[machine][architecture]
+        try:
+            miniconda_arch = _MINICONDA_ARCH_FROM_PLATFORM[machine][architecture]
+        except KeyError as key_error:
+            raise errors.SnapcraftError(
+                f"Architecture not supported for conda plugin: {machine!r} {architecture!r}"
+            ) from key_error
 
     return miniconda_arch
 

--- a/tests/unit/elf/test_elf_utils.py
+++ b/tests/unit/elf/test_elf_utils.py
@@ -110,6 +110,9 @@ class TestGetDynamicLinker:
             pytest.param("x86_64", "lib64/ld-linux-x86-64.so.2", id="amd64"),
             pytest.param("aarch64", "lib/ld-linux-aarch64.so.1", id="arm64"),
             pytest.param("armv7l", "lib/ld-linux-armhf.so.3", id="armhf"),
+            pytest.param(
+                "armv8l", "lib/ld-linux-armhf.so.3", id="armhf on arm64 kernel"
+            ),
             pytest.param("riscv64", "lib/ld-linux-riscv64-lp64d.so.1", id="riscv64"),
             pytest.param("ppc64le", "lib64/ld64.so.2", id="ppc64el"),
             pytest.param("s390x", "lib/ld64.so.1", id="s390x"),
@@ -171,6 +174,7 @@ class TestArchConfig:
         [
             ("aarch64", "aarch64-linux-gnu"),
             ("armv7l", "arm-linux-gnueabihf"),
+            ("armv8l", "arm-linux-gnueabihf"),
             ("ppc64le", "powerpc64le-linux-gnu"),
             ("riscv64", "riscv64-linux-gnu"),
             ("s390x", "s390x-linux-gnu"),
@@ -190,6 +194,7 @@ class TestArchConfig:
         [
             ("aarch64", "aarch64-linux-gnu"),
             ("armv7l", "arm-linux-gnueabihf"),
+            ("armv8l", "arm-linux-gnueabihf"),
             ("ppc64le", "powerpc64le-linux-gnu"),
             ("riscv64", "riscv64-linux-gnu"),
             ("s390x", "s390x-linux-gnu"),

--- a/tests/unit/parts/plugins/test_conda_plugin.py
+++ b/tests/unit/parts/plugins/test_conda_plugin.py
@@ -22,7 +22,10 @@ from pydantic import ValidationError
 
 from snapcraft import errors
 from snapcraft.parts.plugins import CondaPlugin
-from snapcraft.parts.plugins.conda_plugin import _get_miniconda_source
+from snapcraft.parts.plugins.conda_plugin import (
+    _get_architecture,
+    _get_miniconda_source,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -212,4 +215,44 @@ def test_get_miniconda_unsupported_arch(
 
     assert str(raised.value) == (
         f"Architecture not supported for conda plugin: {snap_arch!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("machine", "architecture", "expected"),
+    [
+        ("x86_64", "64bit", "x86_64"),
+        ("x86_64", "32bit", "x86"),
+        # armv8l indicates a 64-bit armv8 system running a 32-bit compatible armhf environment.
+        ("armv8l", "32bit", "armv7l"),
+    ],
+)
+def test_get_architecture_from_platform(monkeypatch, machine, architecture, expected):
+    if os.getenv("SNAP_ARCH"):
+        monkeypatch.delenv("SNAP_ARCH")
+    monkeypatch.setattr("platform.machine", lambda: machine)
+    monkeypatch.setattr("platform.architecture", lambda: (architecture, "ELF"))
+
+    assert _get_architecture() == expected
+
+
+@pytest.mark.parametrize(
+    ("machine", "architecture"),
+    [
+        ("x86_64", "16bit"),
+        ("armv8l", "64bit"),
+        ("s390x", "64bit"),
+    ],
+)
+def test_get_architecture_from_platform_unsupported(monkeypatch, machine, architecture):
+    if os.getenv("SNAP_ARCH"):
+        monkeypatch.delenv("SNAP_ARCH")
+    monkeypatch.setattr("platform.machine", lambda: machine)
+    monkeypatch.setattr("platform.architecture", lambda: (architecture, "ELF"))
+
+    with pytest.raises(errors.SnapcraftError) as raised:
+        _get_architecture()
+
+    assert str(raised.value) == (
+        f"Architecture not supported for conda plugin: {machine!r} {architecture!r}"
     )


### PR DESCRIPTION
Maps `armv8l` to `armv7l`.

Follows the precedence in https://github.com/canonical/craft-parts/pull/697 and https://github.com/canonical/craft-platforms/pull/244.

This should be the last bit of work to enable armv8l in snapcraft.

Fixes #5638

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
