### PR TITLE
fix(kernel): improve package version parsing

### DIFF
--- a/snapcraft/parts/plugins/kernel_build.sh
+++ b/snapcraft/parts/plugins/kernel_build.sh
@@ -406,6 +406,14 @@ pack_kernel() {
   unlink "${CRAFT_PART_INSTALL}/lib/modules/${_kver}/source" || true
 }
 
+# normalize_kernel_version converts the version reported by apt into the version
+# used in kernel binary package names.
+normalize_kernel_version() (
+  version="${1%~*}"
+  printf '%s\n' "$version" | sed -E \
+    's/^([0-9]+\.[0-9]+\.[0-9]+)[.-]([0-9]+)[.-].*$/\1-\2/'
+)
+
 # build_bin_pkg is the most strict case of building a kernel snap. It allows you
 # to choose any kernel in the archives available to you at build-time by ABI
 # number and flavour. Not much in the way of customization can occur in this
@@ -416,16 +424,7 @@ build_bin_pkg() {
   if [ -z "$kernel_ubuntu_abinumber" ]; then
     # kver is the total version string but cuts the upload number
     kver="$(apt info "linux-image-${kconfigflavour}" | grep '^Version: ' | cut -d' ' -f2)"
-    # Trim ~<LTS> as kernels like partner, HWE, or riscv64 append ~<LTS>
-    kver="${kver%~*}"
-    # Trim the kernel release from the string
-    kver="${kver%.*}"
-    # linux-image-${kconfigflavour} has version of the form x.y.z.a-b, but ver
-    # in linux-modules-<ver>-${kconfigflavour} is of the form x.y.z-a-b on Jammy
-    # so swap .a for -a
-    if [ "${UBUNTU_SERIES}" = "jammy" ]; then
-      kver="$(echo "$kver" | sed -E 's/(.*)\./\1-/')"
-    fi
+    kver="$(normalize_kernel_version "$kver")"
   else
     kver="${kernel_ubuntu_abinumber}"
   fi
@@ -821,4 +820,6 @@ main() {
   run
 }
 
-main "$@"
+if [ "${SNAPCRAFT_TESTING:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/snapcraft/parts/plugins/kernel_build.sh
+++ b/snapcraft/parts/plugins/kernel_build.sh
@@ -722,7 +722,6 @@ main() {
   # /etc/os-release is guaranteed as build host is Ubuntu
   # shellcheck disable=SC1091
   . /etc/os-release
-  UBUNTU_SERIES="${UBUNTU_CODENAME}"
 
   # required_boot are Kconfigs required for booting Ubuntu Core
   required_boot="SQUASHFS"

--- a/tests/unit/parts/plugins/test_kernel_build.py
+++ b/tests/unit/parts/plugins/test_kernel_build.py
@@ -1,0 +1,57 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+KERNEL_BUILD_SCRIPT = (
+    Path(__file__).parents[4] / "snapcraft/parts/plugins/kernel_build.sh"
+)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.2.3.4-5", "1.2.3-4"),
+        ("1.2.3-4-5", "1.2.3-4"),
+        ("1.2.3.4.5", "1.2.3-4"),
+        ("1.2.3.4-arbitrary-suffix", "1.2.3-4"),
+        ("1.2.3.4-5~24.04.1", "1.2.3-4"),
+    ],
+)
+def test_normalize_kernel_version(version, expected):
+    env = os.environ.copy()
+    env["SNAPCRAFT_TESTING"] = "1"
+
+    process = subprocess.run(
+        [
+            "sh",
+            "-c",
+            '. "$1"; normalize_kernel_version "$2"',
+            "sh",
+            str(KERNEL_BUILD_SCRIPT),
+            version,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert process.stdout == f"{expected}\n"


### PR DESCRIPTION
Some kernels use different version strings independent of the Ubuntu series. Modify the version string parsing function to normalise the version string regardless of which Ubuntu series is being used.

This supports all version string formats:

 - `x.y.z.a-b`
 - `x.y.z-a-b`
 - `x.y.z.a.b`

And converts them to the normalised format `x.y.z-a` which is used for package names.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [X] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
