### PR TITLE
fix(initrd): fix behavior quirk in module adding behavior

### DIFF
--- a/snapcraft/parts/plugins/initrd_build.sh
+++ b/snapcraft/parts/plugins/initrd_build.sh
@@ -230,13 +230,11 @@ add_modules() {
 
   # A bug in releases pre-24.04; ensure modules are properly added
   if [ "${UBUNTU_SERIES}" = "jammy" ]; then
-    modules=""
-    while read -r m; do
-      modules="${modules} ${m}"
-    done <"${initrd_modules_conf}"
+    mkdir -p "${initrd_modules_conf%/*}"
+    for m in ${modules}; do
+      echo "${m}" >>"${initrd_modules_conf}"
+    done
   fi
-
-  rm -f "${initrd_modules_conf}"
 
   # Shorten initrd_modules_conf
   initrd_modules_conf="${initrd_modules_conf%/*}/modules/main/extra-modules.conf"

--- a/tests/spread/plugins/craft-parts/kernel-deb/snapcraft.yaml
+++ b/tests/spread/plugins/craft-parts/kernel-deb/snapcraft.yaml
@@ -23,8 +23,8 @@ parts:
     kernel-kdefconfig: [test_defconfig]
     kernel-tools: [bpftool, cpupower, perf]
     kernel-ubuntu-debian-dkms:
-      - nvidia-dkms-535
-      - nvidia-kernel-source-535
+      - nvidia-dkms-580
+      - nvidia-kernel-source-580
     build-packages:
       - dwarves
     stage-packages:


### PR DESCRIPTION
Two small fixes:

- The first resolves an issue in the kernel-deb spread test. There was a shift in the nVidia driver version that we need to account for. The reason for why this happened is a Whole Thing, but I wouldn't expect this to be a requirement going forward.
- The second is a very old patch I had that resolves a behavior quirk I experienced when building core22 snaps; `while` loops are tricky and we were losing the `initrd-modules` list from the `snapcraft.yaml` when adding them to the initrd. This should be resolved now.

 
---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
