### PR TITLE
fix(library-linter): add support for content source section for use by the library linter.

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -160,12 +160,19 @@ class ContentSlot(SnapcraftMetadata):
     content: str | None = None
     read: list[str] = []
     write: list[str] = []
+    source: dict[str, list[str]] = {}
 
     def get_content_dirs(self, installed_path: Path) -> set[Path]:
         """Obtain the slot's content directories."""
         content_dirs: set[Path] = set()
 
-        for path_ in self.read + self.write:
+        paths = [
+            *self.read,
+            *self.write,
+            *self.source.get("read", []),
+            *self.source.get("write", []),
+        ]
+        for path_ in paths:
             # Strip leading "$SNAP" and "/".
             path = re.sub(r"^\$SNAP", "", path_)
             path = re.sub(r"^/", "", path)


### PR DESCRIPTION
Describe your changes.

The content source section was added to snapd Jan 17, 2018, 05490a4, but apparently escaped notice by the library linter for 9 years. It came to light testing core26 support for the gnome extension, #6278, where it caused numerous erroneous missing dependency warnings related to the use of the source section in mesa-2604.

This resolves #6404

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
