### PR TITLE
feat(confdb-schemas): add filters and parameters

### DIFF
--- a/snapcraft/models/assertions.py
+++ b/snapcraft/models/assertions.py
@@ -74,6 +74,24 @@ class ConfdbSchema(models.CraftBaseModel):
     """Optional nested rules."""
 
 
+class Parameter(models.CraftBaseModel):
+    """A named constraint to filter results."""
+
+    summary: str | None = None
+    """Optional summary of the parameter."""
+
+    presence: Literal[
+        "required", "required-on-read", "required-on-write", "optional"
+    ] = "optional"
+    """The scenarios where a parameter must be assigned a value."""
+
+
+class Filter(models.CraftBaseModel):
+    """A constraint on whether a parameter is required for a filter to match."""
+
+    optional: bool
+
+
 class Rules(models.CraftBaseModel):
     """A list of confdb schemas for a particular view."""
 
@@ -81,6 +99,12 @@ class Rules(models.CraftBaseModel):
     """Optional summary for this view."""
 
     rules: list[ConfdbSchema]
+
+    parameters: dict[str, Parameter] | None = None
+    """Parameters used to create filters."""
+
+    filters: list[dict[str, Filter]] | None = None
+    """Combinations of parameters that filter which rules apply."""
 
 
 class EditableConfdbSchemaAssertion(models.CraftBaseModel):
@@ -98,6 +122,8 @@ class EditableConfdbSchemaAssertion(models.CraftBaseModel):
     views: dict[str, Rules]
     """A map of logical views of how the storage is accessed."""
 
+    # This is a string of json data, not the data itself. The json is awkward to edit in a yaml file.
+    # This could be changed to an 'Any' field and converted to a json string when marshaled.
     body: str | None = None
     """A JSON schema that defines the storage structure."""
 

--- a/tests/spread/store/confdbs/task.yaml
+++ b/tests/spread/store/confdbs/task.yaml
@@ -30,7 +30,7 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name test-staging-key-2
+  snapcraft edit-confdb-schema "$(snapcraft whoami | yq .id)" testset --key-name test-staging-key
 
   snapcraft confdb-schemas | MATCH testset
 

--- a/tests/spread/store/validation-sets/editor.sh
+++ b/tests/spread/store/validation-sets/editor.sh
@@ -11,6 +11,9 @@ fi
 
 sed -i "s/  presence:.*/  presence: $presence/g" "$validation_set_file"
 
-# increment the sequence
+# Increments the sequence.
+#
 # shellcheck disable=SC2002 # yq snap can't access /tmp
-cat "$validation_set_file" | yq '.sequence += 1' | tee "$validation_set_file"
+new_content="$(cat "$validation_set_file" | yq '.sequence += 1')"
+echo "$new_content" >"$validation_set_file"
+cat "$validation_set_file"

--- a/tests/spread/store/validation-sets/task.yaml
+++ b/tests/spread/store/validation-sets/task.yaml
@@ -27,7 +27,7 @@ execute: |
   # snapcraft will use a fake file editor
   export EDITOR="$PWD/editor.sh"
 
-  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name test-staging-key-2
+  snapcraft edit-validation-sets "$(snapcraft whoami | yq .id)" testset 1 --key-name test-staging-key
 
   snapcraft validation-sets | MATCH testset
 

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -27,6 +27,9 @@ from snapcraft.models import (
     ValidationSetAssertion,
 )
 from snapcraft.models.assertions import (
+    Filter,
+    Parameter,
+    Rules,
     Snap,
     ValidationAssertion,
     cast_dict_scalars_to_strings,
@@ -163,6 +166,72 @@ def test_confdb_schema_nested(check):
     )
 
 
+def test_parameter_defaults(check):
+    """Test default values of the Parameter model."""
+    parameter = Parameter.unmarshal({})
+
+    check.is_none(parameter.summary)
+    check.equal(parameter.presence, "optional")
+
+
+def test_parameter_all_fields(check):
+    """Test that all Parameter fields are set correctly when provided."""
+    parameter = Parameter.unmarshal(
+        {"summary": "test-parameter-summary", "presence": "required"}
+    )
+
+    check.equal(parameter.summary, "test-parameter-summary")
+    check.equal(parameter.presence, "required")
+
+
+def test_rules_defaults(check):
+    """Test default values of the Rules model."""
+    rules = Rules.unmarshal({"rules": [{"storage": "test-storage"}]})
+
+    check.is_none(rules.summary)
+    check.is_none(rules.parameters)
+    check.is_none(rules.filters)
+
+
+def test_rules_parameters(check):
+    """Test that parameters are unmarshalled correctly."""
+    rules = Rules.unmarshal(
+        {
+            "rules": [{"storage": "test-storage"}],
+            "parameters": {
+                "test-parameter": {
+                    "summary": "test-parameter-summary",
+                    "presence": "required-on-write",
+                }
+            },
+        }
+    )
+
+    check.equal(
+        rules.parameters,
+        {
+            "test-parameter": Parameter(
+                summary="test-parameter-summary", presence="required-on-write"
+            )
+        },
+    )
+
+
+def test_rules_filters(check):
+    """Test that filters are unmarshalled correctly."""
+    rules = Rules.unmarshal(
+        {
+            "rules": [{"storage": "test-storage"}],
+            "filters": [{"test-parameter": {"optional": True}}],
+        }
+    )
+
+    check.equal(
+        rules.filters,
+        [{"test-parameter": Filter(optional=True)}],
+    )
+
+
 def test_editable_confdb_schema_assertion_defaults(check):
     """Test default values of the EditableConfdbSchemaAssertion model."""
     assertion = EditableConfdbSchemaAssertion.unmarshal(
@@ -238,6 +307,7 @@ def test_confdb_schema_assertion_defaults(check):
     check.equal(assertion.revision, 0)
     check.is_none(assertion.summary)
     check.is_none(assertion.views["wifi-setup"].summary)
+    check.is_none(assertion.views["wifi-setup"].parameters)
 
 
 def test_confdb_schema_assertion_marshal_as_str():


### PR DESCRIPTION
Adds filters and parameters to confdb schemas.

This is getting exercised indirectly the spread test - the confdb-schema used by the spread test has a parameter and filter, proving that it can be marshalled, unmarshalled, and sent to and from the Snap store.

(SNAPCRAFT-1269)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
