### PR TITLE
ci: update Pro token

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run spread
         env:
-          UA_TOKEN: ${{ secrets.UA_TOKEN }}
+          UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
           RUN_UA_TESTS: ${{ ! github.event.pull_request.head.repo.fork }}
         run: spread ${{ matrix.spread-jobs }}
 

--- a/tests/spread/general/ua_token/task.yaml
+++ b/tests/spread/general/ua_token/task.yaml
@@ -2,7 +2,7 @@ summary: Verify --ua-token functionality
 
 environment:
   SNAP_DIR: snaps/ua-token-test
-  SNAPCRAFT_UA_TOKEN: "$(HOST: echo ${UA_TOKEN})"
+  SNAPCRAFT_UA_TOKEN: "$(HOST: echo ${UBUNTU_PRO_TOKEN})"
   SNAPCRAFT_BUILD_ENVIRONMENT: ""
   RUN_UA_TESTS: "$(HOST: echo ${RUN_UA_TESTS})"
 
@@ -26,10 +26,10 @@ execute: |
   if [ -z "$SNAPCRAFT_UA_TOKEN" ]; then
     # This test has to run in the main repo's workflow and can be skipped in other environments.
     if [ -z "$RUN_UA_TESTS" ] || [ "$RUN_UA_TESTS" = "false" ]; then
-      echo "Skipping test because UA_TOKEN isn't set."
+      echo "Skipping test because UBUNTU_PRO_TOKEN isn't set."
       exit 0
     else
-      echo "Can't run test because UA_TOKEN isn't set."
+      echo "Can't run test because UBUNTU_PRO_TOKEN isn't set."
       exit 1
     fi
   fi


### PR DESCRIPTION
Updates the core22 Pro tests to use the Starcraft testing Pro token, rather than my personal token.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
